### PR TITLE
Integrate open638b into open638

### DIFF
--- a/platform/commonUI/general/res/sass/_inspector.scss
+++ b/platform/commonUI/general/res/sass/_inspector.scss
@@ -62,8 +62,10 @@
     .l-inspector-part {
         @include box-sizing(border-box);
         padding-right: $interiorMargin;
-        .form {
+        .tree .form {
             margin-left: $treeVCW + $interiorMarginLg;
+        }
+        .form {
             margin-bottom: $interiorMarginLg;
             .form-section {
                 margin-bottom: 0;

--- a/platform/commonUI/themes/espresso/res/css/theme-espresso.css
+++ b/platform/commonUI/themes/espresso/res/css/theme-espresso.css
@@ -1492,30 +1492,32 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     box-sizing: border-box;
     padding-right: 5px; }
     /* line 65, ../../../../general/res/sass/_inspector.scss */
+    .l-inspect .l-inspector-part .tree .form {
+      margin-left: 20px; }
+    /* line 68, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .l-inspector-part .form {
-      margin-left: 20px;
       margin-bottom: 10px; }
-      /* line 68, ../../../../general/res/sass/_inspector.scss */
+      /* line 70, ../../../../general/res/sass/_inspector.scss */
       .l-inspect .l-inspector-part .form .form-section {
         margin-bottom: 0; }
-        /* line 70, ../../../../general/res/sass/_inspector.scss */
+        /* line 72, ../../../../general/res/sass/_inspector.scss */
         .l-inspect .l-inspector-part .form .form-section:not(.first) {
           border-top: 1px solid rgba(255, 255, 255, 0.1); }
-        /* line 73, ../../../../general/res/sass/_inspector.scss */
+        /* line 75, ../../../../general/res/sass/_inspector.scss */
         .l-inspect .l-inspector-part .form .form-section .form-row {
           -webkit-align-items: center;
           align-items: center;
           border: none;
           padding: 0; }
-  /* line 82, ../../../../general/res/sass/_inspector.scss */
+  /* line 84, ../../../../general/res/sass/_inspector.scss */
   .l-inspect ul li,
   .l-inspect em.t-inspector-part-header {
     display: block;
     position: relative; }
-  /* line 88, ../../../../general/res/sass/_inspector.scss */
+  /* line 90, ../../../../general/res/sass/_inspector.scss */
   .l-inspect ul li {
     margin-bottom: 10px; }
-  /* line 92, ../../../../general/res/sass/_inspector.scss */
+  /* line 94, ../../../../general/res/sass/_inspector.scss */
   .l-inspect em.t-inspector-part-header {
     -moz-border-radius: 3px;
     -webkit-border-radius: 3px;
@@ -1525,21 +1527,21 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     margin-bottom: 5px;
     padding: 5px 5px;
     text-transform: uppercase; }
-  /* line 101, ../../../../general/res/sass/_inspector.scss */
+  /* line 103, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-properties {
     padding: 3px 0; }
-    /* line 102, ../../../../general/res/sass/_inspector.scss */
+    /* line 104, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-properties:not(.first) {
       border-top: 1px solid rgba(255, 255, 255, 0.1); }
-    /* line 106, ../../../../general/res/sass/_inspector.scss */
+    /* line 108, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-properties .label {
       color: #737373;
       text-transform: uppercase; }
-    /* line 110, ../../../../general/res/sass/_inspector.scss */
+    /* line 112, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-properties .value {
       color: #bfbfbf;
       word-break: break-all; }
-  /* line 117, ../../../../general/res/sass/_inspector.scss */
+  /* line 119, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location .location-item {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -1549,18 +1551,18 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     line-height: 1.2em;
     position: relative;
     padding: 2px 4px; }
-    /* line 126, ../../../../general/res/sass/_inspector.scss */
+    /* line 128, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-location .location-item .t-object-label .t-item-icon {
       height: 1.2em;
       width: 0.7rem; }
-    /* line 131, ../../../../general/res/sass/_inspector.scss */
+    /* line 133, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-location .location-item:hover {
       background: rgba(153, 153, 153, 0.1);
       color: #cccccc; }
-      /* line 134, ../../../../general/res/sass/_inspector.scss */
+      /* line 136, ../../../../general/res/sass/_inspector.scss */
       .l-inspect .inspector-location .location-item:hover .icon, .l-inspect .inspector-location .location-item:hover .t-item-icon {
         color: #33ccff; }
-  /* line 139, ../../../../general/res/sass/_inspector.scss */
+  /* line 141, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location:not(.last) .t-object-label .t-title-label:after {
     color: #737373;
     content: '\3e';
@@ -1571,15 +1573,15 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     line-height: inherit;
     margin-left: 3px;
     width: 4px; }
-  /* line 152, ../../../../general/res/sass/_inspector.scss */
+  /* line 154, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .holder-elements .current-elements {
     position: relative; }
-    /* line 155, ../../../../general/res/sass/_inspector.scss */
+    /* line 157, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .holder-elements .current-elements .tree-item .t-object-label {
       font-size: 0.75rem;
       left: 0; }
 
-/* line 166, ../../../../general/res/sass/_inspector.scss */
+/* line 168, ../../../../general/res/sass/_inspector.scss */
 .l-inspect .splitter-inspect-panel,
 .l-inspect .split-pane-component.pane.bottom {
   -moz-transition-property: opacity;
@@ -1601,14 +1603,14 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   opacity: 0;
   pointer-events: none; }
 
-/* line 175, ../../../../general/res/sass/_inspector.scss */
+/* line 177, ../../../../general/res/sass/_inspector.scss */
 mct-representation:not(.s-status-editing) .l-inspect .split-pane-component.pane.top {
   bottom: 0 !important; }
 
-/* line 181, ../../../../general/res/sass/_inspector.scss */
+/* line 183, ../../../../general/res/sass/_inspector.scss */
 .s-status-editing .l-inspect .location-item {
   pointer-events: none; }
-/* line 184, ../../../../general/res/sass/_inspector.scss */
+/* line 186, ../../../../general/res/sass/_inspector.scss */
 .s-status-editing .l-inspect .splitter-inspect-panel,
 .s-status-editing .l-inspect .split-pane-component.pane.bottom {
   opacity: 1;

--- a/platform/commonUI/themes/snow/res/css/theme-snow.css
+++ b/platform/commonUI/themes/snow/res/css/theme-snow.css
@@ -1473,30 +1473,32 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     box-sizing: border-box;
     padding-right: 5px; }
     /* line 65, ../../../../general/res/sass/_inspector.scss */
+    .l-inspect .l-inspector-part .tree .form {
+      margin-left: 20px; }
+    /* line 68, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .l-inspector-part .form {
-      margin-left: 20px;
       margin-bottom: 10px; }
-      /* line 68, ../../../../general/res/sass/_inspector.scss */
+      /* line 70, ../../../../general/res/sass/_inspector.scss */
       .l-inspect .l-inspector-part .form .form-section {
         margin-bottom: 0; }
-        /* line 70, ../../../../general/res/sass/_inspector.scss */
+        /* line 72, ../../../../general/res/sass/_inspector.scss */
         .l-inspect .l-inspector-part .form .form-section:not(.first) {
           border-top: 1px solid rgba(0, 0, 0, 0.1); }
-        /* line 73, ../../../../general/res/sass/_inspector.scss */
+        /* line 75, ../../../../general/res/sass/_inspector.scss */
         .l-inspect .l-inspector-part .form .form-section .form-row {
           -webkit-align-items: center;
           align-items: center;
           border: none;
           padding: 0; }
-  /* line 82, ../../../../general/res/sass/_inspector.scss */
+  /* line 84, ../../../../general/res/sass/_inspector.scss */
   .l-inspect ul li,
   .l-inspect em.t-inspector-part-header {
     display: block;
     position: relative; }
-  /* line 88, ../../../../general/res/sass/_inspector.scss */
+  /* line 90, ../../../../general/res/sass/_inspector.scss */
   .l-inspect ul li {
     margin-bottom: 10px; }
-  /* line 92, ../../../../general/res/sass/_inspector.scss */
+  /* line 94, ../../../../general/res/sass/_inspector.scss */
   .l-inspect em.t-inspector-part-header {
     -moz-border-radius: 4px;
     -webkit-border-radius: 4px;
@@ -1506,21 +1508,21 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     margin-bottom: 5px;
     padding: 5px 5px;
     text-transform: uppercase; }
-  /* line 101, ../../../../general/res/sass/_inspector.scss */
+  /* line 103, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-properties {
     padding: 3px 0; }
-    /* line 102, ../../../../general/res/sass/_inspector.scss */
+    /* line 104, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-properties:not(.first) {
       border-top: 1px solid #e3e3e3; }
-    /* line 106, ../../../../general/res/sass/_inspector.scss */
+    /* line 108, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-properties .label {
       color: #999999;
       text-transform: uppercase; }
-    /* line 110, ../../../../general/res/sass/_inspector.scss */
+    /* line 112, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-properties .value {
       color: #404040;
       word-break: break-all; }
-  /* line 117, ../../../../general/res/sass/_inspector.scss */
+  /* line 119, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location .location-item {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -1530,18 +1532,18 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     line-height: 1.2em;
     position: relative;
     padding: 2px 4px; }
-    /* line 126, ../../../../general/res/sass/_inspector.scss */
+    /* line 128, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-location .location-item .t-object-label .t-item-icon {
       height: 1.2em;
       width: 0.7rem; }
-    /* line 131, ../../../../general/res/sass/_inspector.scss */
+    /* line 133, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .inspector-location .location-item:hover {
       background: rgba(102, 102, 102, 0.1);
       color: #333333; }
-      /* line 134, ../../../../general/res/sass/_inspector.scss */
+      /* line 136, ../../../../general/res/sass/_inspector.scss */
       .l-inspect .inspector-location .location-item:hover .icon, .l-inspect .inspector-location .location-item:hover .t-item-icon {
         color: #0099cc; }
-  /* line 139, ../../../../general/res/sass/_inspector.scss */
+  /* line 141, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .inspector-location:not(.last) .t-object-label .t-title-label:after {
     color: #8c8c8c;
     content: '\3e';
@@ -1552,15 +1554,15 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
     line-height: inherit;
     margin-left: 3px;
     width: 4px; }
-  /* line 152, ../../../../general/res/sass/_inspector.scss */
+  /* line 154, ../../../../general/res/sass/_inspector.scss */
   .l-inspect .holder-elements .current-elements {
     position: relative; }
-    /* line 155, ../../../../general/res/sass/_inspector.scss */
+    /* line 157, ../../../../general/res/sass/_inspector.scss */
     .l-inspect .holder-elements .current-elements .tree-item .t-object-label {
       font-size: 0.75rem;
       left: 0; }
 
-/* line 166, ../../../../general/res/sass/_inspector.scss */
+/* line 168, ../../../../general/res/sass/_inspector.scss */
 .l-inspect .splitter-inspect-panel,
 .l-inspect .split-pane-component.pane.bottom {
   -moz-transition-property: opacity;
@@ -1582,14 +1584,14 @@ tr[class*="s-limit"].s-limit-lwr td:first-child:before {
   opacity: 0;
   pointer-events: none; }
 
-/* line 175, ../../../../general/res/sass/_inspector.scss */
+/* line 177, ../../../../general/res/sass/_inspector.scss */
 mct-representation:not(.s-status-editing) .l-inspect .split-pane-component.pane.top {
   bottom: 0 !important; }
 
-/* line 181, ../../../../general/res/sass/_inspector.scss */
+/* line 183, ../../../../general/res/sass/_inspector.scss */
 .s-status-editing .l-inspect .location-item {
   pointer-events: none; }
-/* line 184, ../../../../general/res/sass/_inspector.scss */
+/* line 186, ../../../../general/res/sass/_inspector.scss */
 .s-status-editing .l-inspect .splitter-inspect-panel,
 .s-status-editing .l-inspect .split-pane-component.pane.bottom {
   opacity: 1;


### PR DESCRIPTION
open #638 

### Changes
* Wired in custom radio button control and modified PlotOptionsController / plotOptionsStructure accordingly. Note that radios now group and click properly, but checking a "Marker" checkbox for one plot line element will check that box for all other plot line elements when you have multiples in, for example, a Panel.
* Form row elements now converted to flex layout; spacing, borders, etc. on form elements are all as finally intended.
* Fixed bottom property of split-pane-component.pane.top to extend all the way to the bottom when not in edit mode.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N, N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

I've included some screenshots of how things should look.

![screen shot 2016-02-02 at 4 41 18 pm](https://cloud.githubusercontent.com/assets/1056412/12769533/91c35838-c9cd-11e5-9d1e-6395341596a5.png)
![screen shot 2016-02-02 at 4 41 04 pm](https://cloud.githubusercontent.com/assets/1056412/12769532/91c1f4de-c9cd-11e5-9fcd-2e8a559bfa99.png)
