### PR TITLE
[API] Propose new Registration API

### DIFF
--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -1,4 +1,5 @@
-* `Provider<X,S>` is responsible for providing objects of type `S` based
+* `Provider<S>` is an interface describing dependencies generally.
+* `Provider<X, S>` is responsible for providing objects of type `S` based
   on zero or more instances of objects of type `X` which have been registered.
   In practice, a `Provider` instance is an extension point within the
   architecture.
@@ -15,7 +16,6 @@
   * `decorate(decorator : (function (S) : S), [options] : RegistrationOptions)`
     augments behavior of provided objects, in priority order.
 
-
 `Registry<T>` extends `Provider<T, T[]>`. It provides simple registries, where
 a full list of all registered extensions of a certain category may be readily
 accessed.
@@ -25,5 +25,46 @@ services, and allows service instances of the same type to be registered.
 The default composition strategy is to provide the highest-priority service
 which has been registered.
 
+# Turtles All the Way Down
 
+`Application` extends `Provider<Provider<?, Initializer>, Initializer>`.
 
+As such, the following _could_ be valid initialization code
+(but wait, there's more):
+
+```js
+var app = new mct.Application();
+
+app.register(new mct.Core());
+
+app.run(window);
+```
+
+`MCT` extends `Application` by self-registering common plugins.
+
+Other variants may similarly extend `MCT` and self-register additional
+plugins. As such, bootstrapping an `MCT`-derived application should
+be as simple as:
+
+```
+define(['Variant'], function (Variant) {
+  new Variant().run();
+});
+```
+
+Where `Variant` may simply look like:
+
+```
+define(['mct', './plugins'], function (mct, plugins) {
+  function Variant() {
+    mct.MCT.call(this);
+
+    this.register(new plugins.SomePlugin());
+    this.register(new plugins.SomeOtherPlugin());
+  }
+
+  Variant.prototype = Object.create(mct.MCT.prototype);
+
+  return Variant;
+});
+```

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -212,6 +212,11 @@ of registered extensions.
 * `Registry<T>` extends `CompositeProvider<T, T[]>` and provides analogous support for
   _extension categories_, also
   used ubiquitously through Open MCT.
+* `RegistrationOptions` provides a location for additional
+  registration-related metadata to be provided.
+  * `priority` is used to control the ordering and/or preference of
+    factories, compositors, and/or decorators,
+    [as in the existing Framework Layer.](http://nasa.github.io/openmctweb/guide/#priority)
 
 # Examples
 

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -1,9 +1,10 @@
-* `Provider<S>` is an interface describing dependencies generally.
-* `Provider<X, S>` is responsible for providing objects of type `S` based
+* `Dependency<S>` is an interface describing dependencies generally.
+  * `get() : S` provides an instance of the architectural component.
+* `Provider<X, S>` extends `Dependency<S>`. It is responsible for providing
+  objects of type `S` based
   on zero or more instances of objects of type `X` which have been registered.
   In practice, a `Provider` instance is an extension point within the
   architecture.
-  * `get() : S` provides an instance of the architectural component.
   * `register(factory : (function () : X), [options] : RegistrationOptions)`
     registers an object (as returned by the provided `factory` function)
     with this provider. Evaluation of the provided `factory` will be
@@ -27,7 +28,15 @@ which has been registered.
 
 # Turtles All the Way Down
 
-`Application` extends `Provider<Provider<?, Initializer>, Initializer>`.
+An `Initializer` provides an interface of communicating application life
+cycle events to application components (such as plugins.)
+* `install()`: Install any extensions associate with the component.
+* `start()`: Perform any application start-up behavior associated with
+  this component.
+
+`Application` extends `Provider<Dependency<Initializer>, Initializer>`.
+* `run()`: Run the `install` phases of all registered components, then
+  runs the `start` phases of all registered components.
 
 As such, the following _could_ be valid initialization code
 (but wait, there's more):
@@ -56,14 +65,16 @@ Where `Variant` may simply look like:
 
 ```
 define(['mct', './plugins'], function (mct, plugins) {
+  var MCT = mct.MCT;
+
   function Variant() {
-    mct.MCT.call(this);
+    MCT.call(this);
 
     this.register(new plugins.SomePlugin());
     this.register(new plugins.SomeOtherPlugin());
   }
 
-  Variant.prototype = Object.create(mct.MCT.prototype);
+  Variant.prototype = Object.create(MCT.prototype);
 
   return Variant;
 });

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -68,8 +68,6 @@ be implemented in these plugins.
 ## Applications and Plugins
 
 ```nomnoml
-#direction: down
-
 [Application |
     install(plugin : Plugin)
     uninstall(plugin : Plugin)

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -1,0 +1,29 @@
+* `Provider<X,S>` is responsible for providing objects of type `S` based
+  on zero or more instances of objects of type `X` which have been registered.
+  In practice, a `Provider` instance is an extension point within the
+  architecture.
+  * `get() : S` provides an instance of the architectural component.
+  * `register(factory : (function () : X), [options] : RegistrationOptions)`
+    registers an object (as returned by the provided `factory` function)
+    with this provider. Evaluation of the provided `factory` will be
+    deferred until the first `get()` call to the `Provider`.
+  * `composite(compositor : (function (X[]) : S), [options] : RegistrationOptions)`
+    introduces a new strategy for converting an array of registered objects
+    of type `X` into a single instance of an object of type `S`. The
+    highest-priority `compositor` that has been registered in this fashion
+    will be used to assemble the provided object (before decoration)
+  * `decorate(decorator : (function (S) : S), [options] : RegistrationOptions)`
+    augments behavior of provided objects, in priority order.
+
+
+`Registry<T>` extends `Provider<T, T[]>`. It provides simple registries, where
+a full list of all registered extensions of a certain category may be readily
+accessed.
+
+`ServiceProvider<T>` extends `Provider<T, T>`. It provides single instances of
+services, and allows service instances of the same type to be registered.
+The default composition strategy is to provide the highest-priority service
+which has been registered.
+
+
+

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -384,6 +384,49 @@ define(['mct', './SomeAction'], function (mct, SomeAction) {
 });
 ```
 
+## Extending Extensions
+
+Augmenting the behavior of individual extensions is difficult in the
+existing bundle mechanism; for instance, to decorate a specific
+Action one has to decorate the ActionService, recognize the specific
+Action, and then decorate _that_.
+
+By introducing `Provider`s as a more general pattern for extensibility,
+cases like this may be simplified, provided that an appropriate `Plugin`
+exposes individual extensions in a suitable way.
+
+As an example, a plugin implementing a "navigate" action might look like:
+
+```
+function NavigationPlugin(core) {
+    var navigateActionProvider = new Provider(function () {
+        return new NavigateAction();
+    });
+
+    // Expose to permit extension
+    this.navigateActionProvider = navigateActionProvider;
+
+    Plugin.call(this, function () {
+        core.actionRegistry.register(function () {
+            return navigateActionProvider.get();
+        });
+    });
+}
+```
+
+And other plugins could then extend the "navigate" action directly:
+
+```
+function EditPlugin(navigationPlugin) {
+    Plugin.call(this, function () {
+        navigationPlugin.navigateActionProvider
+            .decorate(function (navigateAction) {
+                return new DecoratedNavigationAction(navigateAction);
+            });
+    });
+}
+```
+
 # Legacy Support
 
 The proposed API does not achieve parity with the existing Framework

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -130,7 +130,7 @@ Summary of interfaces:
   * `start()` initiates any behavior associated with this plugin that
     needs to run immediately after the application has started. (Useful
     for a "bootstrap" plugin.)
-* `MCT` is an instance of an `Application` that self-installs various
+* `MCT` extends `Application` and self-installs various
   plugins during its constructor call. It also exposes these same
   plugins as public fields such that other applications may access
   them (to `uninstall` them, for instance, or to pass them into other
@@ -200,10 +200,12 @@ of registered extensions.
     will be used to assemble the provided object (before decoration)
   * `decorate(decorator : (function (S) : S), [options] : RegistrationOptions)`
     augments behavior of objects provided by `get`, in priority order.
-* `ServiceProvider<S>` provides analogous support for the _composite services_
+* `ServiceProvider<S>` extends `Provider<S, S>` and provides analogous support
+  for the _composite services_
   pattern used throughout Open MCT (which, in turn, is a superset of the
   functionality needed for plain services.)
-* `Registry<T>` provides analogous support for _extension categories_, also
+* `Registry<T>` extends `Provider<T, T[]>` and provides analogous support for
+  _extension categories_, also
   used ubiquitously through Open MCT.
 
 # Examples

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -65,7 +65,21 @@ be implemented in these plugins.
 
 # Interfaces
 
-## Applications and Plugins
+In keeping with the scope of the Registration API, the interfaces
+described here are sufficient to:
+
+* Describe the set of plugins in use for a particular instance of
+  Open MCT, and initiate their behavior.
+* Support common patterns by which plugins can utilize and expose
+  defined extension points.
+
+Notably, there is no interdependency between these two sets of
+behavior; one could use the base classes for extension points
+independently of the plugin mechanism, and vice versa. This both
+ensures loose coupling within the Registration API, and also
+allows for greater flexibility for developers implementing plugins.
+
+## Application-level Interfaces
 
 ```nomnoml
 [Application |
@@ -137,7 +151,6 @@ which extend `MCT` and add/remove plugins during the constructor
 call. (This is a recommended pattern of use only; other, more
 imperative usage of this API is equally viable.)
 
-
 ## Extension Points
 
 ```nomnoml
@@ -154,27 +167,39 @@ imperative usage of this API is equally viable.)
 [Provider<S,S>]<:-[ServiceProvider<S>]
 ```
 
+Omitted from this diagram (for clarity) are `options` arguments to
+`register`, `decorate`, and `compose`. This argument should allow,
+at minimum, a `priority` to be specified, in order to control ordering
+of registered extensions.
 
-# Interfaces
-
-* `Dependency<S>` is an interface describing dependencies generally.
-  * `get() : S` provides an instance of the architectural component.
-* `Provider<X, S>` extends `Dependency<S>`. It is responsible for providing
-  objects of type `S` based
+* `Provider<X, S>` is responsible for providing objects of type `S` based
   on zero or more instances of objects of type `X` which have been registered.
   In practice, a `Provider` instance is an extension point within the
   architecture.
+  * `get() : S` provides an instance of the architectural component, as
+    constructed using the registered objects, along with the highest-priority
+    compositor and and decorators.
   * `register(factory : (function () : X), [options] : RegistrationOptions)`
     registers an object (as returned by the provided `factory` function)
     with this provider. Evaluation of the provided `factory` will be
     deferred until the first `get()` call to the `Provider`.
-  * `composite(compositor : (function (X[]) : S), [options] : RegistrationOptions)`
+  * `compose(compositor : (function (X[]) : S), [options] : RegistrationOptions)`
     introduces a new strategy for converting an array of registered objects
     of type `X` into a single instance of an object of type `S`. The
     highest-priority `compositor` that has been registered in this fashion
     will be used to assemble the provided object (before decoration)
   * `decorate(decorator : (function (S) : S), [options] : RegistrationOptions)`
-    augments behavior of provided objects, in priority order.
+    augments behavior of objects provided by `get`, in priority order.
+* `ServiceProvider<S>` provides analogous support for the _composite services_
+  pattern used throughout Open MCT (which, in turn, is a superset of the
+  functionality needed for plain services.)
+* `Registry<T>` provides analogous support for _extension categories_, also
+  used ubiquitously through Open MCT.
+
+# Interfaces
+
+
+
 
 `Registry<T>` extends `Provider<T, T[]>`. It provides simple registries, where
 a full list of all registered extensions of a certain category may be readily

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -1,3 +1,70 @@
+# Developer Use Cases
+
+1. Extending and maintaining Open MCT itself.
+2. Adapting and customizing Open MCT for use in specific missions.
+3. Developing features for use with Open MCT across multiple different
+   missions.
+
+# Scope
+
+As demonstrated by the existing APIs, writing plugins is sufficient to
+satisfy the three use cases above in the majority of cases. The only feature
+which is known to be unsatisfiable by plugins is plugin support itself.
+
+As such, prefer to keep "plugin-external" components small as simple, to
+keep the majority of development in plugins (or plugin-like components.)
+
+The "registration API" described in this document is limited to that scope:
+It describes classes and patterns that can allow plugins to interact,
+while making minimal assumptions about what specific functionality is to
+be implemented in these plugins.
+
+# Problems to Address
+
+1. Dependencies between plugins are implicit; a plugin may fail if its
+   required dependencies are not included, without any clear indication
+   of why this failure has occurred. Significant familiarity with
+   Open MCT is typically required to debug in these circumstances.
+2. Extension points are often implicit; no specific plugin is
+   identifiably responsible for defining any specific extension category
+   or composite service. These are instead paired by string matching.
+   This makes it difficult to follow how the application is initialized
+   and how objects are passed around at run-time, and creates an
+   additional documentation burden, as these named extension points do not
+   fit into more standard API documentation.
+3. Reuse of components between plugins is limited. Exposing base classes
+   from one plugin and reusing them from another is overly-difficult.
+
+# Principles
+
+1. The Registration API is exposed as a set of classes in one or more
+   namespaces. This supports reuse and extension using standard,
+   well-known object-oriented patterns. A composition-oriented style
+   is still supported and encouraged, but not enforced.
+2. Extension points should be expressed as objects with known interfaces.
+   (More specifically, they should be _expressible_ in this fashion;
+   it is out of scope for the Registration API to expose any specific
+   extension points.)
+3. Dependencies that are intended for injection should be expressed as
+   arguments to a constructor. The Registration API does not need to
+   stipulate this, but should at least be compatible with this. This
+   is both to allow for compatibility with existing code, and to allow
+   for clear documentation of the dependencies of specific components
+   ("to construct one of these, you need one of those.")
+4. The Registration API should accept minimal responsibility in order
+   to impose minimal constraints. For instance, it should not be
+   responsible for performing script-loading. Its sole responsibility
+   is to facilitate communication between components.
+5. The Registration API should continue to support ubiquitous use of
+   patterns that have proven useful for plugin-based extensibility
+   (the Registry, Composite, and Decorator patterns, specifically.)
+   However, it should be designed such that knowledge of these patterns
+   is only required when it is appropriate to the specific task or
+   activity at hand. (For instance, you should not need to be familiar
+   with decorators in order to simply register something.)
+
+# Interfaces
+
 * `Dependency<S>` is an interface describing dependencies generally.
   * `get() : S` provides an instance of the architectural component.
 * `Provider<X, S>` extends `Dependency<S>`. It is responsible for providing

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -376,6 +376,27 @@ define(['mct', './SomeAction'], function (mct, SomeAction) {
 });
 ```
 
+# Legacy Support
+
+The proposed API does not achieve parity with the existing Framework
+Layer. In particular:
+
+1. There is no Angular integration.
+2. Transitional support for legacy bundles is not specified.
+3. Script loading is not handled.
+
+Propose to resolve these by:
+
+1. Adding an Angular integration plugin that uses registries for
+   controllers/directives/etc. and maps these to appropriate configuration
+   of an Angular application.
+2. Adding a legacy support plugin that maps (and transforms, as necessary)
+   extensions exposed by legacy bundles to appropriate registries and/or
+   service providers using the new Registration API.
+3. Not handling script loading; the Registration API expects objects,
+   so how the scripts necessary to instantiate those objects (and how they
+   are instantiated) is left to the application developer.
+
 # Evaluation
 
 [Identified problems](#problems-to-address) are addressed by this solution:

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -1,3 +1,9 @@
+# Introduction
+
+This document proposes a Registration API which allows for components
+of Open MCT to communicate with one another using reusable, internally
+standardized patterns.
+
 # Developer Use Cases
 
 1. Extending and maintaining Open MCT itself.

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -370,3 +370,20 @@ define(['mct', './SomeAction'], function (mct, SomeAction) {
   return MyPlugin;
 
 });
+
+# Evaluation
+
+There are some problems with this approach:
+
+* Highly sensitive to ordering; does not address the problem of
+  [separating configuration from use](http://www.martinfowler.com/articles/injection.html#SeparatingConfigurationFromUse),
+  but instead leaves this as a problem to solve with code style
+  (requiring familiarity with the system.) This is particularly
+  true with `Provider#get` (don't want to invoke before configuration
+  is finished), but also true for `Application` and `Plugin`.
+  * One approach to mitigate this would be to throw `Error`s when
+    calls are made out-of-order (e.g. configuration after use.)
+* Some redundancy among interfaces (`Plugin` and `Application` both
+  look a lot like a `Provider`, but of what?)
+  * But, don't want to over-exercise commonalities and end up with
+    unclear interfaces.

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -19,6 +19,10 @@ It describes classes and patterns that can allow plugins to interact,
 while making minimal assumptions about what specific functionality is to
 be implemented in these plugins.
 
+By analogy to current API, this set of functionality will effectively
+replace the [Framework Layer](http://nasa.github.io/openmctweb/guide/#framework)
+of Open MCT.
+
 # Problems to Address
 
 1. Dependencies between plugins are implicit; a plugin may fail if its
@@ -407,6 +411,12 @@ This solution offers further benefits:
   `bundles.json`, no usage of global state at the language level or
   effectively-global state at the RequireJS level, etc.) and implies
   greater flexibility of the application's components.
+* Provides a reduction in code associated with a particular capability;
+  the Framework Layer consists of 18 classes (and has broader
+  responsibilities, including script-loading) whereas this approach
+  consists of 6 classes. (Although some additional work for Angular
+  integration and legacy support will also be needed before achieving
+  parity with the Framework Layer.)
 
 There are some problems with this approach:
 

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -11,7 +11,7 @@ As demonstrated by the existing APIs, writing plugins is sufficient to
 satisfy the three use cases above in the majority of cases. The only feature
 which is known to be unsatisfiable by plugins is plugin support itself.
 
-As such, prefer to keep "plugin-external" components small as simple, to
+As such, prefer to keep "plugin-external" components small and simple, to
 keep the majority of development in plugins (or plugin-like components.)
 
 The "registration API" described in this document is limited to that scope:
@@ -370,12 +370,30 @@ define(['mct', './SomeAction'], function (mct, SomeAction) {
   return MyPlugin;
 
 });
+```
 
 # Evaluation
 
+[Identified problems](#problems-to-address) are addressed by this solution:
+
+1. Dependencies between plugins can be made explicit; a `Plugin` may
+   impose dependencies on other specific `Plugin` subclasses as constructor
+   arguments, disambiguated with JSDoc. The software does not take part
+   in dependency management among plugins; rather, this responsibility is
+   plainly communicated to developers.
+2. Extension points are made explicit; `Provider` instances must be
+   reachable for plugins to configure, and may be made available as
+   public fields of `Plugin`s. Their types can be clearly documented,
+   usages and interactions can be followed with standard developer tools
+   (e.g. breakpoints), and so on.
+3. Reuse of classes between plugins is neither facilitated nor impeded
+   by the registration API. If, however, plugins are written following the
+   "expose classes in namespaces" approach, then it is trivially to
+   expose additional classes in these same namespaces.
+
 There are some problems with this approach:
 
-* Highly sensitive to ordering; does not address the problem of
+* It is highly sensitive to ordering; does not address the problem of
   [separating configuration from use](http://www.martinfowler.com/articles/injection.html#SeparatingConfigurationFromUse),
   but instead leaves this as a problem to solve with code style
   (requiring familiarity with the system.) This is particularly

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -196,56 +196,17 @@ of registered extensions.
 * `Registry<T>` provides analogous support for _extension categories_, also
   used ubiquitously through Open MCT.
 
-# Interfaces
+# Examples
 
+The following examples are provided to illustrate the intended usage of
+the Registration API. Particular attention is given to obeying and
+utilizing the "dependency injection as code style"
+[decision from the API Redesign](APIRedesign.md#decisions).
 
+## Building Applications on Open MCT
 
-
-`Registry<T>` extends `Provider<T, T[]>`. It provides simple registries, where
-a full list of all registered extensions of a certain category may be readily
-accessed.
-
-`ServiceProvider<T>` extends `Provider<T, T>`. It provides single instances of
-services, and allows service instances of the same type to be registered.
-The default composition strategy is to provide the highest-priority service
-which has been registered.
-
-# Turtles All the Way Down
-
-An `Initializer` provides an interface of communicating application life
-cycle events to application components (such as plugins.)
-* `install()`: Install any extensions associate with the component.
-* `start()`: Perform any application start-up behavior associated with
-  this component.
-
-`Application` extends `Provider<Dependency<Initializer>, Initializer>`.
-* `run()`: Run the `install` phases of all registered components, then
-  runs the `start` phases of all registered components.
-
-As such, the following _could_ be valid initialization code
-(but wait, there's more):
-
-```js
-var app = new mct.Application();
-
-app.register(new mct.Core());
-
-app.run(window);
-```
-
-`MCT` extends `Application` by self-registering common plugins.
-
-Other variants may similarly extend `MCT` and self-register additional
-plugins. As such, bootstrapping an `MCT`-derived application should
-be as simple as:
-
-```
-define(['Variant'], function (Variant) {
-  new Variant().run();
-});
-```
-
-Where `Variant` may simply look like:
+Applications built using Open MCT are expected to extend the `MCT` base
+class and
 
 ```
 define(['mct', './plugins'], function (mct, plugins) {

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -391,6 +391,23 @@ define(['mct', './SomeAction'], function (mct, SomeAction) {
    "expose classes in namespaces" approach, then it is trivially to
    expose additional classes in these same namespaces.
 
+This solution offers further benefits:
+
+* The `Provider` API is robust enough to support the various existing
+  extensions of Open MCT, but its usage is opt-in; plugins are free
+  to expose other (potentially wildly different) means of extension.
+  Usage of `Provider`s is _encouraged_ to promote ubiquitous
+  extensibility, but no limitation is exposed.
+* By moving everything into classes which accept dependencies, a
+  degree of inflexibility is removed from the architecture. In principle,
+  it should be possible to run multiple instances of `MCT` (with
+  their own service instances, etc.) within the same environment. While
+  this is not specifically desirable, it reflects a generally looser
+  coupling between the software and it environment (no expectation of a
+  `bundles.json`, no usage of global state at the language level or
+  effectively-global state at the RequireJS level, etc.) and implies
+  greater flexibility of the application's components.
+
 There are some problems with this approach:
 
 * It is highly sensitive to ordering; does not address the problem of

--- a/docs/src/design/proposals/Registration.md
+++ b/docs/src/design/proposals/Registration.md
@@ -484,6 +484,8 @@ This solution offers further benefits:
   to expose other (potentially wildly different) means of extension.
   Usage of `Provider`s is _encouraged_ to promote ubiquitous
   extensibility, but no limitation is exposed.
+* Plugins (and even whole applications, e.g. `MCT`) can be unit tested,
+  in the same style as individual extensions.
 * By moving everything into classes which accept dependencies, a
   degree of inflexibility is removed from the architecture. In principle,
   it should be possible to run multiple instances of `MCT` (with


### PR DESCRIPTION
Proposal for a new Registration API, #462.

Omitting checklists since changes are non-code. Our success criteria is peer review; I'd like to do this as:

- [ ] Team consensus (@larkin and @akhenry)
- [ ] Third-party review

I'm reasonably comfortable with this being good enough. My lingering concerns are mainly about ordering - I don't really like single-use objects that expect you to call their methods in one specific order. The way I'd normally be inclined to solve this is to return objects that handle the order-specific aspect of the behavior (e.g. remove `start` from `Plugin` and instead return a `start` function from `initialize`) but I feel this makes these interfaces more confusing, and also don't see how to apply that in the case of a `Provider`.


---

Pending tasks from review feedback:

- [ ] Define registration API down to specific extension points
- [ ] Remove `uninstall` from `MCT`
- [ ] Remove `Application`
- [ ] Define (or defer?) an internal non-Plugin architecture with clear dependencies