### PR TITLE
[Tree] Refresh properly on mutation

### DIFF
--- a/platform/commonUI/general/src/ui/TreeView.js
+++ b/platform/commonUI/general/src/ui/TreeView.js
@@ -60,8 +60,9 @@ define([
         }
     };
 
-    TreeView.prototype.loadComposition = function (domainObject) {
-        var self = this;
+    TreeView.prototype.loadComposition = function () {
+        var self = this,
+            domainObject = this.activeObject;
 
         function addNode(domainObject, index) {
             self.nodeViews[index].model(domainObject);

--- a/platform/commonUI/general/test/ui/TreeViewSpec.js
+++ b/platform/commonUI/general/test/ui/TreeViewSpec.js
@@ -161,7 +161,7 @@ define([
                 beforeEach(function () {
                     mockComposition.pop();
                     testCapabilities.mutation.listen
-                        .mostRecentCall.args[0](mockDomainObject);
+                        .mostRecentCall.args[0](mockDomainObject.getModel());
                     waitForCompositionCallback();
                 });
 


### PR DESCRIPTION
...by removing the incorrect expectation that a domain object
(and not just its model) will be passed in when mutation occurs.
Addresses #745.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y