### PR TITLE
[Tree] Don't assume context capability is present

### DIFF
--- a/platform/commonUI/general/src/ui/TreeNodeView.js
+++ b/platform/commonUI/general/src/ui/TreeNodeView.js
@@ -81,13 +81,13 @@ define([
     };
 
     function getIdPath(domainObject) {
+        var context = domainObject && domainObject.getCapability('context');
+
         function getId(domainObject) {
             return domainObject.getId();
         }
 
-        return domainObject ?
-            domainObject.getCapability('context').getPath().map(getId) :
-            [];
+        return context ? context.getPath().map(getId) : [];
     }
 
     TreeNodeView.prototype.value = function (domainObject) {

--- a/platform/commonUI/general/test/ui/TreeViewSpec.js
+++ b/platform/commonUI/general/test/ui/TreeViewSpec.js
@@ -200,6 +200,21 @@ define([
                 });
             });
 
+            describe("when a context-less object is selected", function () {
+                beforeEach(function () {
+                    var testCapabilities = makeGenericCapabilities(),
+                        mockDomainObject =
+                            makeMockDomainObject('xyz', {}, testCapabilities);
+                    delete testCapabilities.context;
+                    treeView.value(mockDomainObject);
+                });
+
+                it("clears all selection state", function () {
+                    var selected = $(treeView.elements()[0]).find('.selected');
+                    expect(selected.length).toEqual(0);
+                });
+            });
+
             describe("when children contain children", function () {
                 beforeEach(function () {
                     var newCapabilities = makeGenericCapabilities(),


### PR DESCRIPTION
Addresses #753 (newly-created objects may not have context, causing errors when these are encountered by TreeNodeView)

### Author Checklist

1. Changes address original issue? Y &ast;
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

&ast; Partially; other cases described in that issue are addressed in #756 