### PR TITLE
Review and integrate 755

### DIFF
--- a/platform/commonUI/general/res/sass/_global.scss
+++ b/platform/commonUI/general/res/sass/_global.scss
@@ -53,7 +53,6 @@ body, html {
 	font-weight: 200;
 	height: 100%;
 	width: 100%;
-	overflow: hidden;
 }
 
 em {

--- a/platform/commonUI/general/res/sass/startup-base.scss
+++ b/platform/commonUI/general/res/sass/startup-base.scss
@@ -26,6 +26,10 @@
     top: $m; right: $m * 1.25; bottom: $m; left: $m * 1.25;
 }
 
+body, html {
+    overflow: hidden;
+}
+
 .l-splash-holder {
     // Main outer holder.
     @include transition-property(opacity);

--- a/platform/features/timeline/res/sass/_activities.scss
+++ b/platform/features/timeline/res/sass/_activities.scss
@@ -59,7 +59,7 @@
 	.handle {
 		cursor: col-resize;
 		&.mid {
-			cursor: ew-resize;
+			cursor: move;
 		}
 	}
 }

--- a/platform/features/timeline/res/sass/_timeline-thematic.scss
+++ b/platform/features/timeline/res/sass/_timeline-thematic.scss
@@ -140,17 +140,3 @@
         }
     }
 }
-
-.edit-mode .s-swimlane,
-.s-status-editing .s-swimlane {
-    cursor: pointer;
-    .t-object-label {
-        border-radius: $controlCr;
-        cursor: move;
-        padding: 2px 5px;
-        &:hover {
-            background: rgba($colorBodyFg, 0.3);
-            color: pullForward($colorBodyFg, 20%);
-        }
-    }
-}

--- a/platform/features/timeline/res/sass/_timelines.scss
+++ b/platform/features/timeline/res/sass/_timelines.scss
@@ -23,6 +23,11 @@
 .l-timeline-holder {
     @include absPosDefault();
 
+    .l-header {
+        @include user-select(none);
+        cursor: default;
+    }
+
     .l-timeline-pane {
         @include absPosDefault();
 
@@ -33,6 +38,9 @@
 	    .l-swimlanes-holder {
 		    @include absPosDefault();
 		    top: $timelineTopPaneHeaderH + 1;
+            .l-col.l-plot-resource {
+                cursor: pointer;
+            }
 	    }
 
 	    // Overall layout
@@ -250,21 +258,15 @@
 
 			&.l-plot-resource {
 				border-left: none !important;
-				cursor: pointer;
 				padding-left: 0;
 			}
 
 			&.l-title {
 				width: $timelineColTitleW;
-                .rep-object-label[draggable="true"] {
+                .rep-object-label {
                     border-radius: $basicCr;
-                    @include transition(background-color, 0.25s);
-                    cursor: pointer;
                     display: inline-block;
-                    padding: 0 $interiorMarginSm;
-                    &:hover {
-                        background-color: $colorItemTreeHoverBg;
-                    }
+                    padding: 0 $interiorMargin;
                 }
 			}
 
@@ -313,4 +315,12 @@
 	.l-subticks {
 		height: 5px
 	}
+}
+
+.s-status-editing .l-title .rep-object-label[draggable="true"] {
+    @include transition(background-color, 0.25s);
+    cursor: pointer;
+    &:hover {
+        background-color: $colorItemTreeHoverBg;
+    }
 }


### PR DESCRIPTION
Implements fixes for #748, #750 and #755.

* CSS fixed so that plot-resource icon doesn't display cursor: pointer in the header
* For #750, set l-header to use user-select: none
* Fixed timeline tabular labels to remove doubled hover effects, and to only display hover effects when in edit mode
* For #755, changed s-timeline-gantt.mid to use cursor: move instead of ew-resize. Need to verify on Linux.
* Fixed scrollbar flicker observed with #748 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N, N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y