### PR TITLE
[Package] Specify require minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "moment": "^2.11.1",
     "node-bourbon": "^4.2.3",
     "phantomjs-prebuilt": "^2.1.0",
-    "requirejs": "^2.1.17",
+    "requirejs": "2.1.x",
     "split": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Specify requirejs minor version of 2.1, as 2.2 is not compatible with karma-requirejs.

Fixes build problems that appeared after latest requirejs version bump.

# Author Checklist

1. Changes address original issue? Y (issue is described in this PR)
2. Unit tests included and/or updated with changes? N (config only change)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y