### PR TITLE
[Data Formats] Format numeric values with full precision

### DIFF
--- a/platform/features/plot/src/elements/PlotTelemetryFormatter.js
+++ b/platform/features/plot/src/elements/PlotTelemetryFormatter.js
@@ -26,6 +26,8 @@ define(
     function () {
         'use strict';
 
+        var DIGITS = 3;
+
         /**
          * Wraps a `TelemetryFormatter` to provide formats for domain and
          * range values; provides a single place to track domain/range
@@ -63,6 +65,10 @@ define(
         };
 
         PlotTelemetryFormatter.prototype.formatRangeValue = function (value) {
+            if (typeof value === 'number') {
+                return value.toFixed(DIGITS);
+            }
+
             return this.telemetryFormatter
                 .formatRangeValue(value, this.rangeFormat);
         };

--- a/platform/features/plot/test/elements/PlotTelemetryFormatterSpec.js
+++ b/platform/features/plot/test/elements/PlotTelemetryFormatterSpec.js
@@ -55,14 +55,17 @@ define(
                         .toHaveBeenCalledWith(12321, domainFormat);
                 });
 
-                it("includes format in formatRangeValue calls", function () {
+                it("includes format in formatRangeValue calls for strings", function () {
                     mockFormatter.formatRangeValue.andReturn("formatted!");
-                    expect(formatter.formatRangeValue(12321))
+                    expect(formatter.formatRangeValue('foo'))
                         .toEqual("formatted!");
                     expect(mockFormatter.formatRangeValue)
-                        .toHaveBeenCalledWith(12321, rangeFormat);
+                        .toHaveBeenCalledWith('foo', rangeFormat);
                 });
 
+                it("formats numeric values with three fixed digits", function () {
+                    expect(formatter.formatRangeValue(10)).toEqual("10.000");
+                });
             });
 
         });

--- a/platform/telemetry/src/TelemetryFormatter.js
+++ b/platform/telemetry/src/TelemetryFormatter.js
@@ -26,10 +26,6 @@ define(
     function () {
         "use strict";
 
-        // Date format to use for domain values; in particular,
-        // use day-of-year instead of month/day
-        var VALUE_FORMAT_DIGITS = 3;
-
         /**
          * The TelemetryFormatter is responsible for formatting (as text
          * for display) values along either the domain (usually time) or
@@ -73,7 +69,7 @@ define(
          *        value, suitable for display.
          */
         TelemetryFormatter.prototype.formatRangeValue = function (v, key) {
-            return isNaN(v) ? String(v) : v.toFixed(VALUE_FORMAT_DIGITS);
+            return String(v);
         };
 
         return TelemetryFormatter;

--- a/platform/telemetry/test/TelemetryFormatterSpec.js
+++ b/platform/telemetry/test/TelemetryFormatterSpec.js
@@ -59,7 +59,10 @@ define(
             });
 
             it("formats ranges as values", function () {
-                expect(formatter.formatRangeValue(10)).toEqual("10.000");
+                var value = 3.14159265352979323846264338, // not pi
+                    formatted = formatter.formatRangeValue(value);
+                // Make sure we don't lose information by formatting
+                expect(parseFloat(formatted)).toEqual(value);
             });
         });
     }


### PR DESCRIPTION
Addresses #778 

Summary of changes:

* In TelemetryFormatter, don't apply `toFixed` - this truncates useful information in most views
* In PlotTelemetryFormatter, do apply `toFixed` - in plots, it is impractical to read Y axis labels without rounding in this manner

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
