### PR TITLE
[Timelines] #715 Added a check to prevent mutation when modes are unchanged

### DIFF
--- a/platform/features/timeline/src/controllers/swimlane/TimelineSwimlaneDecorator.js
+++ b/platform/features/timeline/src/controllers/swimlane/TimelineSwimlaneDecorator.js
@@ -45,11 +45,13 @@ define(
             function modes(value) {
                 // Can be used as a setter...
                 if (arguments.length > 0 && Array.isArray(value)) {
-                    // Update the relationships
-                    mutator.mutate(function (model) {
-                        model.relationships = model.relationships || {};
-                        model.relationships[ACTIVITY_RELATIONSHIP] = value;
-                    }).then(persister.persist);
+                    if ((model.relationships || {})[ACTIVITY_RELATIONSHIP] !== value) {
+                        // Update the relationships
+                        mutator.mutate(function (model) {
+                            model.relationships = model.relationships || {};
+                            model.relationships[ACTIVITY_RELATIONSHIP] = value;
+                        }).then(persister.persist);
+                    }
                 }
                 // ...otherwise, use as a getter
                 return (model.relationships || {})[ACTIVITY_RELATIONSHIP] || [];

--- a/platform/features/timeline/test/controllers/swimlane/TimelineSwimlaneDecoratorSpec.js
+++ b/platform/features/timeline/test/controllers/swimlane/TimelineSwimlaneDecoratorSpec.js
@@ -32,12 +32,14 @@ define(
                 mockCapabilities,
                 testModel,
                 mockPromise,
+                testModes,
                 decorator;
 
             beforeEach(function () {
                 mockSwimlane = {};
                 mockCapabilities = {};
                 testModel = {};
+                testModes = ['a', 'b', 'c'];
 
                 mockSelection = jasmine.createSpyObj('selection', ['select', 'get']);
 
@@ -133,6 +135,22 @@ define(
                 expect(mockCapabilities.persistence.persist).not.toHaveBeenCalled();
                 mockPromise.then.mostRecentCall.args[0]();
                 expect(mockCapabilities.persistence.persist).toHaveBeenCalled();
+            });
+
+            it("does not mutate modes when unchanged", function () {
+                testModel.relationships = { modes: testModes };
+                decorator.modes(testModes);
+                expect(mockCapabilities.mutation.mutate).not.toHaveBeenCalled();
+                expect(testModel.relationships.modes).toEqual(testModes);
+            });
+
+            it("does mutate modes when changed", function () {
+                var testModes2 = ['d', 'e', 'f'];
+                testModel.relationships = { modes: testModes };
+                decorator.modes(testModes2);
+                expect(mockCapabilities.mutation.mutate).toHaveBeenCalled();
+                mockCapabilities.mutation.mutate.mostRecentCall.args[0](testModel);
+                expect(testModel.relationships.modes).toBe(testModes2);
             });
 
             it("does not provide a 'remove' method with no parent", function () {


### PR DESCRIPTION
Addressees #715. See [comment](https://github.com/nasa/openmct/issues/715#issuecomment-199553274) on that ticket for explanation of root cause.

### Summary of changes
* Added an additional check to prevent mutation of model with unchanged value, which was in turn causing all swim-lanes in timeline to be refreshed.
* Updated tests

### Author Checklist

1. Changes address original issue?
2. Unit tests included and/or updated with changes?
3. Command line build passes?
4. Changes have been smoke-tested?