### PR TITLE
[Timeline] Update drag-over highlights promptly

### DIFF
--- a/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
+++ b/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
@@ -97,21 +97,37 @@ define(
 
             function link(scope, element, attrs) {
                 // Lookup swimlane by evaluating this attribute
-                function swimlane() {
+                function lookupSwimlane() {
                     return scope.$eval(attrs.mctSwimlaneDrop);
                 }
                 // Handle dragover
                 element.on('dragover', function (e) {
-                    dragOver(e, element, swimlane());
+                    var swimlane = lookupSwimlane(),
+                        highlight = swimlane.highlight(),
+                        highlightBottom = swimlane.highlightBottom();
+
+                    dragOver(e, element, swimlane);
+
+                    if ((highlightBottom !== swimlane.highlightBottom()) ||
+                            highlight !== swimlane.highlight()) {
+                        scope.$apply();
+                    }
                 });
                 // Handle drops
                 element.on('drop', function (e) {
-                    drop(e, element, swimlane());
+                    drop(e, element, lookupSwimlane());
+                    scope.$apply();
                 });
                 // Clear highlights when drag leaves this swimlane
                 element.on('dragleave', function () {
-                    swimlane().highlight(false);
-                    swimlane().highlightBottom(false);
+                    var swimlane = lookupSwimlane(),
+                        wasHighlighted = swimlane.highlight() ||
+                                swimlane.highlightBottom();
+                    swimlane.highlight(false);
+                    swimlane.highlightBottom(false);
+                    if (wasHighlighted) {
+                        scope.$apply();
+                    }
                 });
             }
 

--- a/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
+++ b/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
@@ -108,7 +108,7 @@ define(
 
                     dragOver(e, element, swimlane);
 
-                    if ((highlightBottom !== swimlane.highlightBottom()) ||
+                    if (highlightBottom !== swimlane.highlightBottom() ||
                             highlight !== swimlane.highlight()) {
                         scope.$apply();
                     }

--- a/platform/features/timeline/test/directives/MCTSwimlaneDropSpec.js
+++ b/platform/features/timeline/test/directives/MCTSwimlaneDropSpec.js
@@ -55,7 +55,7 @@ define(
                     'dndService',
                     ['setData', 'getData', 'removeData']
                 );
-                mockScope = jasmine.createSpyObj('$scope', ['$eval']);
+                mockScope = jasmine.createSpyObj('$scope', ['$eval', '$apply']);
                 mockElement = jasmine.createSpyObj('element', ['on']);
                 testAttrs = { mctSwimlaneDrop: "mockSwimlane" };
                 mockSwimlane = jasmine.createSpyObj(
@@ -118,6 +118,7 @@ define(
 
                 expect(mockSwimlane.highlight).toHaveBeenCalledWith(true);
                 expect(mockSwimlane.highlightBottom).toHaveBeenCalledWith(false);
+                expect(mockScope.$apply).toHaveBeenCalled();
             });
 
             it("updates bottom highlights on drag over", function () {
@@ -128,6 +129,7 @@ define(
 
                 expect(mockSwimlane.highlight).toHaveBeenCalledWith(false);
                 expect(mockSwimlane.highlightBottom).toHaveBeenCalledWith(true);
+                expect(mockScope.$apply).toHaveBeenCalled();
             });
 
             it("respects swimlane's allowDropIn response", function () {
@@ -157,12 +159,15 @@ define(
             it("notifies swimlane on drop", function () {
                 handlers.drop(testEvent);
                 expect(mockSwimlane.drop).toHaveBeenCalledWith('abc', 'someDomainObject');
+                expect(mockScope.$apply).toHaveBeenCalled();
             });
 
             it("clears highlights when drag leaves", function () {
+                mockSwimlane.highlight.andReturn(true);
                 handlers.dragleave();
                 expect(mockSwimlane.highlight).toHaveBeenCalledWith(false);
                 expect(mockSwimlane.highlightBottom).toHaveBeenCalledWith(false);
+                expect(mockScope.$apply).toHaveBeenCalled();
             });
         });
     }


### PR DESCRIPTION
Invoke `$apply` from `mct-swimlane-drop` and add some checks to ensure this is necessary, to avoid
triggering a ton of digest cycles while dragging.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y