### PR TITLE
[Timelines] #677 Removed temporary markup

### DIFF
--- a/platform/commonUI/browse/res/templates/browse-object.html
+++ b/platform/commonUI/browse/res/templates/browse-object.html
@@ -44,22 +44,7 @@
         </div>
     </div>
     <div class="holder l-flex-col flex-elem grows l-object-wrapper">
-        <div ng-if="isEditable" class="holder l-flex-col flex-elem grows l-object-wrapper-inner">
-            <!-- Toolbar and Save/Cancel buttons -->
-            <div class="l-edit-controls flex-elem l-flex-row flex-align-end">
-                <mct-representation key="'edit-action-buttons'"
-                                    mct-object="domainObject"
-                                    class='flex-elem conclude-editing'>
-                </mct-representation>
-
-            </div>
-            <mct-representation key="representation.selected.key"
-                                mct-object="representation.selected.key && domainObject"
-                                class="abs flex-elem grows object-holder-main scroll"
-                                toolbar="toolbar">
-            </mct-representation>
-        </div>
-        <div ng-if="!isEditable" class="holder l-flex-col flex-elem grows l-object-wrapper-inner">
+        <div class="holder l-flex-col flex-elem grows l-object-wrapper-inner">
             <!-- Toolbar and Save/Cancel buttons -->
             <div class="l-edit-controls flex-elem l-flex-row flex-align-end">
                 <mct-representation key="'edit-action-buttons'"

--- a/platform/commonUI/edit/src/representers/EditRepresenter.js
+++ b/platform/commonUI/edit/src/representers/EditRepresenter.js
@@ -118,8 +118,6 @@ define(
             // Track the represented object
             this.domainObject = representedObject;
 
-            this.scope.isEditable = representedObject.getCapability('status').get('editing');
-
             // Ensure existing watches are released
             this.destroy();
 


### PR DESCRIPTION
### Changes
1. Removed temporary markup and code from `browse-object.html` and `EditRepresenter.js` that was added to address #677 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y