### PR TITLE
[Tables] Addressed issue with tables not appearing on reload

### DIFF
--- a/platform/features/table/src/TableConfiguration.js
+++ b/platform/features/table/src/TableConfiguration.js
@@ -145,25 +145,23 @@ define(
                 {}).columns || {};
         };
 
-        function equal(obj1, obj2) {
+        function configEqual(obj1, obj2) {
             var obj1Keys = Object.keys(obj1),
                 obj2Keys = Object.keys(obj2);
             return (obj1Keys.length === obj2Keys.length) &&
-                    obj1Keys.every(function(key){
-                        //To do a deep equals, could recurse here if typeof
-                        // obj1 === Object
+                    obj1Keys.every(function (key) {
                        return obj1[key] === obj2[key];
                     });
         }
 
         /**
-         * Set the established configuration on the domain object
+         * Set the established configuration on the domain object. Will noop
+         * if configuration is unchanged
          * @private
          */
         TableConfiguration.prototype.saveColumnConfiguration = function (columnConfig) {
             var self = this;
-            //Don't bother mutating if column configuration is unchanged
-            if (!equal(this.columnConfiguration, columnConfig)) {
+            if (!configEqual(this.columnConfiguration, columnConfig)) {
                 this.domainObject.useCapability('mutation', function (model) {
                     model.configuration = model.configuration || {};
                     model.configuration.table = model.configuration.table || {};

--- a/platform/features/table/src/TableConfiguration.js
+++ b/platform/features/table/src/TableConfiguration.js
@@ -39,6 +39,7 @@ define(
         function TableConfiguration(domainObject, telemetryFormatter) {
             this.domainObject = domainObject;
             this.columns = [];
+            this.columnConfiguration = {};
             this.telemetryFormatter = telemetryFormatter;
         }
 
@@ -144,16 +145,32 @@ define(
                 {}).columns || {};
         };
 
+        function equal(obj1, obj2) {
+            var obj1Keys = Object.keys(obj1),
+                obj2Keys = Object.keys(obj2);
+            return (obj1Keys.length === obj2Keys.length) &&
+                    obj1Keys.every(function(key){
+                        //To do a deep equals, could recurse here if typeof
+                        // obj1 === Object
+                       return obj1[key] === obj2[key];
+                    });
+        }
+
         /**
          * Set the established configuration on the domain object
          * @private
          */
         TableConfiguration.prototype.saveColumnConfiguration = function (columnConfig) {
-            this.domainObject.useCapability('mutation', function (model) {
-                model.configuration = model.configuration || {};
-                model.configuration.table = model.configuration.table || {};
-                model.configuration.table.columns = columnConfig;
-            });
+            var self = this;
+            //Don't bother mutating if column configuration is unchanged
+            if (!equal(this.columnConfiguration, columnConfig)) {
+                this.domainObject.useCapability('mutation', function (model) {
+                    model.configuration = model.configuration || {};
+                    model.configuration.table = model.configuration.table || {};
+                    model.configuration.table.columns = columnConfig;
+                    self.columnConfiguration = columnConfig;
+                });
+            }
         };
 
         /**

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -67,8 +67,8 @@ define(
             $scope.$watchCollection('filters', function () {
                 self.updateRows($scope.rows);
             });
-            $scope.$watch('headers', this.updateHeaders.bind(this));
             $scope.$watch('rows', this.updateRows.bind(this));
+            $scope.$watch('headers', this.updateHeaders.bind(this));
 
             /*
              * Listen for rows added individually (eg. for real-time tables)
@@ -101,13 +101,19 @@ define(
          */
         MCTTableController.prototype.newRow = function (event, rowIndex) {
             var row = this.$scope.rows[rowIndex];
-            //Add row to the filtered, sorted list of all rows
-            if (this.filterRows([row]).length > 0) {
-                this.insertSorted(this.$scope.displayRows, row);
-            }
+            //If rows.length === 1 we need to calculate column widths etc.
+            // so do the updateRows logic, rather than the 'add row' logic
+            if (this.$scope.rows.length === 1){
+                this.updateRows(this.$scope.rows);
+            } else {
+                //Add row to the filtered, sorted list of all rows
+                if (this.filterRows([row]).length > 0) {
+                    this.insertSorted(this.$scope.displayRows, row);
+                }
 
-            this.$timeout(this.setElementSizes.bind(this))
-                .then(this.scrollToBottom.bind(this));
+                this.$timeout(this.setElementSizes.bind(this))
+                    .then(this.scrollToBottom.bind(this));
+            }
         };
 
         /**

--- a/platform/features/table/src/controllers/RTTelemetryTableController.js
+++ b/platform/features/table/src/controllers/RTTelemetryTableController.js
@@ -87,20 +87,15 @@ define(
                     datum = self.handle.getDatum(telemetryObject);
                     if (datum) {
                         row = self.table.getRowValues(telemetryObject, datum);
-                        if (!self.$scope.rows) {
-                            self.$scope.rows = [row];
-                            self.$scope.$digest();
-                        } else {
-                            self.$scope.rows.push(row);
+                        self.$scope.rows.push(row);
 
-                            if (self.$scope.rows.length > self.maxRows) {
-                                self.$scope.$broadcast('remove:row', 0);
-                                self.$scope.rows.shift();
-                            }
-
-                            self.$scope.$broadcast('add:row',
-                                self.$scope.rows.length - 1);
+                        if (self.$scope.rows.length > self.maxRows) {
+                            self.$scope.$broadcast('remove:row', 0);
+                            self.$scope.rows.shift();
                         }
+
+                        self.$scope.$broadcast('add:row',
+                            self.$scope.rows.length - 1);
                     }
                 });
             }

--- a/platform/features/table/src/controllers/RTTelemetryTableController.js
+++ b/platform/features/table/src/controllers/RTTelemetryTableController.js
@@ -82,27 +82,28 @@ define(
             var datum,
                 row,
                 self = this;
+            if (this.handle) {
+                this.handle.getTelemetryObjects().forEach(function (telemetryObject) {
+                    datum = self.handle.getDatum(telemetryObject);
+                    if (datum) {
+                        row = self.table.getRowValues(telemetryObject, datum);
+                        if (!self.$scope.rows) {
+                            self.$scope.rows = [row];
+                            self.$scope.$digest();
+                        } else {
+                            self.$scope.rows.push(row);
 
-            this.handle.getTelemetryObjects().forEach(function (telemetryObject){
-                datum = self.handle.getDatum(telemetryObject);
-                if (datum) {
-                    row = self.table.getRowValues(telemetryObject, datum);
-                    if (!self.$scope.rows){
-                        self.$scope.rows = [row];
-                        self.$scope.$digest();
-                    } else {
-                        self.$scope.rows.push(row);
+                            if (self.$scope.rows.length > self.maxRows) {
+                                self.$scope.$broadcast('remove:row', 0);
+                                self.$scope.rows.shift();
+                            }
 
-                        if (self.$scope.rows.length > self.maxRows) {
-                            self.$scope.$broadcast('remove:row', 0);
-                            self.$scope.rows.shift();
+                            self.$scope.$broadcast('add:row',
+                                self.$scope.rows.length - 1);
                         }
-
-                        self.$scope.$broadcast('add:row',
-                            self.$scope.rows.length - 1);
                     }
-                }
-            });
+                });
+            }
         };
 
         return RTTelemetryTableController;

--- a/platform/features/table/src/controllers/RTTelemetryTableController.js
+++ b/platform/features/table/src/controllers/RTTelemetryTableController.js
@@ -69,53 +69,40 @@ define(
         RTTelemetryTableController.prototype = Object.create(TableController.prototype);
 
         /**
-         Override the subscribe function defined on the parent controller in
-         order to handle realtime telemetry instead of historical.
+         *
          */
-        RTTelemetryTableController.prototype.subscribe = function () {
-            var self = this;
-            self.$scope.rows = undefined;
-            (this.subscriptions || []).forEach(function (unsubscribe){
-                unsubscribe();
-            });
+        RTTelemetryTableController.prototype.addHistoricalData = function () {
+            //Noop for realtime table
+        };
 
-            if (this.handle) {
-                this.handle.unsubscribe();
-            }
+        /**
+         * Handling for real-time data
+         */
+        RTTelemetryTableController.prototype.updateRealtime = function () {
+            var datum,
+                row,
+                self = this;
 
-            function updateData(){
-                var datum,
-                    row;
-                self.handle.getTelemetryObjects().forEach(function (telemetryObject){
-                    datum = self.handle.getDatum(telemetryObject);
-                    if (datum) {
-                        row = self.table.getRowValues(telemetryObject, datum);
-                        if (!self.$scope.rows){
-                            self.$scope.rows = [row];
-                            self.$scope.$digest();
-                        } else {
-                            self.$scope.rows.push(row);
+            this.handle.getTelemetryObjects().forEach(function (telemetryObject){
+                datum = self.handle.getDatum(telemetryObject);
+                if (datum) {
+                    row = self.table.getRowValues(telemetryObject, datum);
+                    if (!self.$scope.rows){
+                        self.$scope.rows = [row];
+                        self.$scope.$digest();
+                    } else {
+                        self.$scope.rows.push(row);
 
-                            if (self.$scope.rows.length > self.maxRows) {
-                                self.$scope.$broadcast('remove:row', 0);
-                                self.$scope.rows.shift();
-                            }
-
-                            self.$scope.$broadcast('add:row',
-                                self.$scope.rows.length - 1);
+                        if (self.$scope.rows.length > self.maxRows) {
+                            self.$scope.$broadcast('remove:row', 0);
+                            self.$scope.rows.shift();
                         }
+
+                        self.$scope.$broadcast('add:row',
+                            self.$scope.rows.length - 1);
                     }
-                });
-
-            }
-
-            this.handle = this.$scope.domainObject && this.telemetryHandler.handle(
-                    this.$scope.domainObject,
-                    updateData,
-                    true // Lossless
-                );
-
-            this.setup();
+                }
+            });
         };
 
         return RTTelemetryTableController;

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -203,24 +203,22 @@ define(
                 }
             }
 
-            //if (handle) {
-                //Add telemetry metadata (if any) for parent object
-                addMetadata(domainObject);
+            //Add telemetry metadata (if any) for parent object
+            addMetadata(domainObject);
 
-                //If object is composed of multiple objects, also add
-                // telemetry metadata from children
-                if (domainObject.hasCapability('composition')) {
-                    domainObject.useCapability('composition').then(function (composition) {
-                        composition.forEach(addMetadata);
-                    }).then(function () {
-                        //Build columns based on available metadata
-                        buildAndFilterColumns();
-                    });
-                } else {
-                    //Build columns based on collected metadata
+            //If object is composed of multiple objects, also add
+            // telemetry metadata from children
+            if (domainObject.hasCapability('composition')) {
+                domainObject.useCapability('composition').then(function (composition) {
+                    composition.forEach(addMetadata);
+                }).then(function () {
+                    //Build columns based on available metadata
                     buildAndFilterColumns();
-                }
-           // }
+                });
+            } else {
+                //Build columns based on collected metadata
+                buildAndFilterColumns();
+            }
         };
 
         /**
@@ -228,11 +226,9 @@ define(
          * accordingly.
          * @private
          */
-        TelemetryTableController.prototype.filterColumns = function (columnConfig) {
-            if (!columnConfig){
-                columnConfig = this.table.getColumnConfiguration();
-                this.table.saveColumnConfiguration(columnConfig);
-            }
+        TelemetryTableController.prototype.filterColumns = function () {
+            var columnConfig = this.table.getColumnConfiguration();
+            this.table.saveColumnConfiguration(columnConfig);
             //Populate headers with visible columns (determined by configuration)
             this.$scope.headers = Object.keys(columnConfig).filter(function (column) {
                 return columnConfig[column];

--- a/platform/features/table/test/controllers/RTTelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/RTTelemetryTableControllerSpec.js
@@ -103,6 +103,7 @@ define(
                 mockScope.domainObject = mockDomainObject;
 
                 mockTelemetryHandle = jasmine.createSpyObj('telemetryHandle', [
+                    'request',
                     'getMetadata',
                     'unsubscribe',
                     'getDatum',
@@ -113,6 +114,7 @@ define(
                 // used by mocks
                 mockTelemetryHandle.getTelemetryObjects.andReturn([{}]);
                 mockTelemetryHandle.promiseTelemetryObjects.andReturn(promise(undefined));
+                mockTelemetryHandle.request.andReturn(promise(undefined));
                 mockTelemetryHandle.getDatum.andReturn({});
 
                 mockTelemetryHandler = jasmine.createSpyObj('telemetryHandler', [

--- a/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
@@ -33,7 +33,13 @@ define(
                 mockTelemetryHandler,
                 mockTelemetryHandle,
                 mockTelemetryFormatter,
+                mockTelemetryCapability,
                 mockDomainObject,
+                mockChild,
+                mockMutationCapability,
+                mockCompositionCapability,
+                childMutationCapability,
+                capabilities = {},
                 mockTable,
                 mockConfiguration,
                 watches,
@@ -64,6 +70,17 @@ define(
                 mockScope.$watchCollection.andCallFake(function (expression, callback){
                     watches[expression] = callback;
                 });
+                mockTelemetryCapability = jasmine.createSpyObj('telemetryCapability',
+                    ['getMetadata']
+                );
+                mockTelemetryCapability.getMetadata.andReturn({});
+                capabilities.telemetry = mockTelemetryCapability;
+
+                mockCompositionCapability = jasmine.createSpyObj('compositionCapability',
+                    ['invoke']
+                );
+                mockCompositionCapability.invoke.andReturn(promise([]));
+                capabilities.composition = mockCompositionCapability;
 
                 mockConfiguration = {
                     'range1': true,
@@ -81,13 +98,36 @@ define(
                 );
                 mockTable.columns = [];
                 mockTable.getColumnConfiguration.andReturn(mockConfiguration);
+                mockMutationCapability = jasmine.createSpyObj('mutationCapability', [
+                    "listen"
+                ]);
+                capabilities.mutation = mockMutationCapability;
 
-                mockDomainObject= jasmine.createSpyObj('domainObject', [
+                mockDomainObject = jasmine.createSpyObj('domainObject', [
                     'getCapability',
+                    'hasCapability',
                     'useCapability',
                     'getModel'
                 ]);
+                mockChild = jasmine.createSpyObj('domainObject', [
+                    'getCapability'
+                ]);
+                childMutationCapability = jasmine.createSpyObj('childMutationCapability', [
+                    "listen"
+                ]);
+                mockChild.getCapability.andReturn(childMutationCapability);
+
+
                 mockDomainObject.getModel.andReturn({});
+                mockDomainObject.hasCapability.andCallFake(function (name){
+                    return typeof capabilities[name] !== 'undefined';
+                });
+                mockDomainObject.useCapability.andCallFake(function (capability){
+                    return capabilities[capability] && capabilities[capability].invoke && capabilities[capability].invoke();
+                });
+                mockDomainObject.getCapability.andCallFake(function (name){
+                    return capabilities[name];
+                });
 
                 mockScope.domainObject = mockDomainObject;
 
@@ -103,6 +143,7 @@ define(
                 mockTelemetryHandle.promiseTelemetryObjects.andReturn(promise(undefined));
                 mockTelemetryHandle.request.andReturn(promise(undefined));
                 mockTelemetryHandle.getTelemetryObjects.andReturn([]);
+                mockTelemetryHandle.getMetadata.andReturn(["a", "b", "c"]);
 
                 mockTelemetryHandler = jasmine.createSpyObj('telemetryHandler', [
                     'handle'
@@ -127,7 +168,6 @@ define(
             });
 
             describe('the controller makes use of the table', function () {
-
                 it('to create column definitions from telemetry' +
                     ' metadata', function () {
                     controller.setup();
@@ -199,14 +239,6 @@ define(
                     expect(controller.subscribe).toHaveBeenCalled();
                 });
 
-                it('triggers telemetry subscription update when domain' +
-                    ' object composition changes', function () {
-                    controller.registerChangeListeners();
-                    expect(watches['domainObject.getModel().composition']).toBeDefined();
-                    watches['domainObject.getModel().composition'](["one"], ["two"]);
-                    expect(controller.subscribe).toHaveBeenCalled();
-                });
-
                 it('triggers telemetry subscription update when time' +
                     ' conductor bounds change', function () {
                     controller.registerChangeListeners();
@@ -214,12 +246,21 @@ define(
                     watches['telemetry:display:bounds']();
                     expect(controller.subscribe).toHaveBeenCalled();
                 });
+                it('Listens for changes to object model', function () {
+                    controller.registerChangeListeners();
+                    expect(mockMutationCapability.listen).toHaveBeenCalled();
+                });
 
-                it('triggers refiltering of the columns when configuration' +
-                    ' changes', function () {
-                    controller.setup();
-                    expect(watches['domainObject.getModel().configuration.table.columns']).toBeDefined();
-                    watches['domainObject.getModel().configuration.table.columns']();
+                it('Listens for changes to child model', function () {
+                    mockCompositionCapability.invoke.andReturn(promise([mockChild]));
+                    controller.registerChangeListeners();
+                    expect(childMutationCapability.listen).toHaveBeenCalled();
+                });
+
+                it('Recalculates columns when model changes occur', function () {
+                    controller.registerChangeListeners();
+                    expect(mockMutationCapability.listen).toHaveBeenCalled();
+                    mockMutationCapability.listen.mostRecentCall.args[0]();
                     expect(controller.filterColumns).toHaveBeenCalled();
                 });
 

--- a/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
@@ -203,7 +203,7 @@ define(
                     ' object composition changes', function () {
                     controller.registerChangeListeners();
                     expect(watches['domainObject.getModel().composition']).toBeDefined();
-                    watches['domainObject.getModel().composition']();
+                    watches['domainObject.getModel().composition'](["one"], ["two"]);
                     expect(controller.subscribe).toHaveBeenCalled();
                 });
 


### PR DESCRIPTION
Issue is occurring because no telemetry metadata is being returned from the telemetry handle. Root cause is difficult to ascertain as it's localized to WARP, and does not occur in open or VISTA.

### Summary of changes:
1. Changed point in execution where telemetry metadata is retrieved to be consistent with plots which are not exhibiting the reported behavior
2. Addressed race condition whereby two subscriptions that occur in rapid succession could potentially cause reset of telemetry metadata

### Author checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y