### PR TITLE
[Entanglement] Add policies for Move, Duplicate

### DIFF
--- a/platform/entanglement/bundle.js
+++ b/platform/entanglement/bundle.js
@@ -29,7 +29,9 @@ define([
     "./src/actions/SetPrimaryLocationAction",
     "./src/services/LocatingCreationDecorator",
     "./src/services/LocatingObjectDecorator",
+    "./src/policies/CopyPolicy",
     "./src/policies/CrossSpacePolicy",
+    "./src/policies/MovePolicy",
     "./src/capabilities/LocationCapability",
     "./src/services/MoveService",
     "./src/services/LinkService",
@@ -44,7 +46,9 @@ define([
     SetPrimaryLocationAction,
     LocatingCreationDecorator,
     LocatingObjectDecorator,
+    CopyPolicy,
     CrossSpacePolicy,
+    MovePolicy,
     LocationCapability,
     MoveService,
     LinkService,
@@ -140,6 +144,14 @@ define([
                 {
                     "category": "action",
                     "implementation": CrossSpacePolicy
+                },
+                {
+                    "category": "action",
+                    "implementation": CopyPolicy
+                },
+                {
+                    "category": "action",
+                    "implementation": MovePolicy
                 }
             ],
             "capabilities": [

--- a/platform/entanglement/src/policies/CopyPolicy.js
+++ b/platform/entanglement/src/policies/CopyPolicy.js
@@ -1,0 +1,57 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define */
+define([], function () {
+    'use strict';
+
+    /**
+     * Disallow duplication when the object to be duplicated is not
+     * creatable.
+     * @constructor
+     * @implements {Policy}
+     * @memberof platform/entanglement
+     */
+    function CopyPolicy() {
+    }
+
+    function allowCreation(domainObject) {
+        var type = domainObject && domainObject.getCapability('type');
+        return !!(type && type.hasFeature('creation'));
+    }
+
+    function selectedObject(context) {
+        return context.selectedObject || context.domainObject;
+    }
+
+    CopyPolicy.prototype.allow = function (action, context) {
+        var key = action.getMetadata().key;
+
+        if (key === 'copy') {
+            return allowCreation(selectedObject(context));
+        }
+
+        return true;
+    };
+
+    return CopyPolicy;
+});

--- a/platform/entanglement/src/policies/MovePolicy.js
+++ b/platform/entanglement/src/policies/MovePolicy.js
@@ -1,0 +1,63 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define */
+define([], function () {
+    'use strict';
+
+    /**
+     * Disallow moves when either the parent or the child are not
+     * modifiable by users.
+     * @constructor
+     * @implements {Policy}
+     * @memberof platform/entanglement
+     */
+    function MovePolicy() {
+    }
+
+    function parentOf(domainObject) {
+        var context = domainObject.getCapability('context');
+        return context && context.getParent();
+    }
+
+    function allowMutation(domainObject) {
+        var type = domainObject && domainObject.getCapability('type');
+        return !!(type && type.hasFeature('creation'));
+    }
+
+    function selectedObject(context) {
+        return context.selectedObject || context.domainObject;
+    }
+
+    MovePolicy.prototype.allow = function (action, context) {
+        var key = action.getMetadata().key;
+
+        if (key === 'move') {
+            return allowMutation(selectedObject(context)) &&
+                allowMutation(parentOf(selectedObject(context)));
+        }
+
+        return true;
+    };
+
+    return MovePolicy;
+});

--- a/platform/entanglement/test/policies/CopyPolicySpec.js
+++ b/platform/entanglement/test/policies/CopyPolicySpec.js
@@ -1,0 +1,94 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define,describe,beforeEach,it,jasmine,expect,spyOn */
+define([
+    '../../src/policies/CopyPolicy',
+    '../DomainObjectFactory'
+], function (CopyPolicy, domainObjectFactory) {
+    'use strict';
+
+    describe("CopyPolicy", function () {
+        var testMetadata,
+            testContext,
+            mockDomainObject,
+            mockType,
+            mockAction,
+            policy;
+
+        beforeEach(function () {
+            mockType =
+                jasmine.createSpyObj('type', ['hasFeature']);
+
+            testMetadata = {};
+
+            mockDomainObject = domainObjectFactory({
+                capabilities: { type: mockType }
+            });
+
+            mockType.hasFeature.andCallFake(function (feature) {
+                return feature === 'creation';
+            });
+
+            mockAction = jasmine.createSpyObj('action', ['getMetadata']);
+            mockAction.getMetadata.andReturn(testMetadata);
+
+            testContext = { domainObject: mockDomainObject };
+
+            policy = new CopyPolicy();
+        });
+
+        describe("for copy actions", function () {
+            beforeEach(function () {
+                testMetadata.key = 'copy';
+            });
+
+            describe("when an object is non-creatable", function () {
+                beforeEach(function () {
+                    mockType.hasFeature.andReturn(false);
+                });
+
+                it("disallows the action", function () {
+                    expect(policy.allow(mockAction, testContext)).toBe(false);
+                });
+            });
+
+            describe("when an object is creatable", function () {
+                it("allows the action", function () {
+                    expect(policy.allow(mockAction, testContext)).toBe(true);
+                });
+            });
+        });
+
+        describe("for other actions", function () {
+            beforeEach(function () {
+                testMetadata.key = 'foo';
+            });
+
+            it("simply allows the action", function () {
+                expect(policy.allow(mockAction, testContext)).toBe(true);
+                mockType.hasFeature.andReturn(false);
+                expect(policy.allow(mockAction, testContext)).toBe(true);
+            });
+        });
+    });
+});

--- a/platform/entanglement/test/policies/MovePolicySpec.js
+++ b/platform/entanglement/test/policies/MovePolicySpec.js
@@ -1,0 +1,127 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*global define,describe,beforeEach,it,jasmine,expect,spyOn */
+define([
+    '../../src/policies/MovePolicy',
+    '../DomainObjectFactory'
+], function (MovePolicy, domainObjectFactory) {
+    'use strict';
+
+    describe("MovePolicy", function () {
+        var testMetadata,
+            testContext,
+            mockDomainObject,
+            mockParent,
+            mockParentType,
+            mockType,
+            mockAction,
+            policy;
+
+        beforeEach(function () {
+            var mockContextCapability =
+                    jasmine.createSpyObj('context', ['getParent']);
+
+            mockType =
+                jasmine.createSpyObj('type', ['hasFeature']);
+            mockParentType =
+                jasmine.createSpyObj('parent-type', ['hasFeature']);
+
+
+            testMetadata = {};
+
+            mockDomainObject = domainObjectFactory({
+                capabilities: {
+                    context: mockContextCapability,
+                    type: mockType
+                }
+            });
+            mockParent = domainObjectFactory({
+                capabilities: {
+                    type: mockParentType
+                }
+            });
+
+            mockContextCapability.getParent.andReturn(mockParent);
+
+            mockType.hasFeature.andCallFake(function (feature) {
+                return feature === 'creation';
+            });
+            mockParentType.hasFeature.andCallFake(function (feature) {
+                return feature === 'creation';
+            });
+
+            mockAction = jasmine.createSpyObj('action', ['getMetadata']);
+            mockAction.getMetadata.andReturn(testMetadata);
+
+            testContext = { domainObject: mockDomainObject };
+
+            policy = new MovePolicy();
+        });
+
+        describe("for move actions", function () {
+            beforeEach(function () {
+                testMetadata.key = 'move';
+            });
+
+            describe("when an object is non-modifiable", function () {
+                beforeEach(function () {
+                    mockType.hasFeature.andReturn(false);
+                });
+
+                it("disallows the action", function () {
+                    expect(policy.allow(mockAction, testContext)).toBe(false);
+                });
+            });
+
+            describe("when a parent is non-modifiable", function () {
+                beforeEach(function () {
+                    mockParentType.hasFeature.andReturn(false);
+                });
+
+                it("disallows the action", function () {
+                    expect(policy.allow(mockAction, testContext)).toBe(false);
+                });
+            });
+
+            describe("when an object and its parent are modifiable", function () {
+                it("allows the action", function () {
+                    expect(policy.allow(mockAction, testContext)).toBe(true);
+                });
+            });
+        });
+
+        describe("for other actions", function () {
+            beforeEach(function () {
+                testMetadata.key = 'foo';
+            });
+
+            it("simply allows the action", function () {
+                expect(policy.allow(mockAction, testContext)).toBe(true);
+                mockType.hasFeature.andReturn(false);
+                expect(policy.allow(mockAction, testContext)).toBe(true);
+                mockParentType.hasFeature.andReturn(false);
+                expect(policy.allow(mockAction, testContext)).toBe(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Addresses #792 by adding policies which suppress Move and Duplicate actions when objects involved are non-modifiable or non-creatable, respectively.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y