### PR TITLE
[Timeline] Fix reordering behavior in timelines

### DIFF
--- a/platform/features/timeline/src/controllers/swimlane/TimelineSwimlaneDropHandler.js
+++ b/platform/features/timeline/src/controllers/swimlane/TimelineSwimlaneDropHandler.js
@@ -100,6 +100,13 @@ define(
                 return swimlane.highlight() || expandedForDropInto();
             }
 
+            function isReorder(targetObject, droppedObject) {
+                var droppedContext = droppedObject.getCapability('context'),
+                    droppedParent =
+                        droppedContext && droppedContext.getParent(),
+                    droppedParentId = droppedParent && droppedParent.getId();
+                return targetObject.getId() === droppedParentId;
+            }
 
             // Choose an appropriate composition action for the drag-and-drop
             function chooseAction(targetObject, droppedObject) {
@@ -142,26 +149,21 @@ define(
             }
 
             function canDrop(targetObject, droppedObject) {
-                var droppedContext = droppedObject.getCapability('context'),
-                    droppedParent =
-                        droppedContext && droppedContext.getParent(),
-                    droppedParentId = droppedParent && droppedParent.getId();
 
-                return (targetObject.getId() === droppedParentId) ||
+                return isReorder(targetObject, droppedObject) ||
                         !!chooseAction(targetObject, droppedObject);
             }
 
             function drop(domainObject, targetObject, indexOffset) {
-                var action = chooseAction(targetObject, domainObject);
-
                 function changeIndex() {
                     var id = domainObject.getId();
                     return insert(id, targetObject, indexOffset);
                 }
 
-                return action ?
-                    action.perform().then(changeIndex) :
-                    changeIndex();
+                return isReorder(targetObject, domainObject) ?
+                    changeIndex() :
+                    chooseAction(targetObject, domainObject)
+                        .perform().then(changeIndex);
             }
 
             return {

--- a/platform/features/timeline/test/controllers/swimlane/TimelineSwimlaneDropHandlerSpec.js
+++ b/platform/features/timeline/test/controllers/swimlane/TimelineSwimlaneDropHandlerSpec.js
@@ -206,6 +206,7 @@ define(
 
             it("allows reordering within a parent", function () {
                 var testModel = { composition: [ 'x', 'b', 'y', 'd' ] };
+
                 mockSwimlane.highlightBottom.andReturn(true);
                 mockSwimlane.expanded = true;
                 mockSwimlane.children = [];
@@ -223,6 +224,16 @@ define(
                         .args[1](testModel);
                     expect(testModel.composition).toEqual([ 'x', 'b', 'd', 'y']);
                 });
+            });
+
+            it("does not invoke an action when reordering", function () {
+                mockSwimlane.highlightBottom.andReturn(true);
+                mockSwimlane.expanded = true;
+                mockSwimlane.children = [];
+                mockContext.getParent
+                    .andReturn(mockSwimlane.parent.domainObject);
+                handler.drop('d', mockOtherObject);
+                expect(mockAction.perform).not.toHaveBeenCalled();
             });
 
         });


### PR DESCRIPTION
Fix reordering behavior when dragging-and-dropping within timelines; addresses #789.

Don't rely on Move action being unavailable in the reorder case (and don't bother loading actions in this case, as well, since no such action is necessary)

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

