### PR TITLE
[Firefox] Invoke preventDefault on drop

### DIFF
--- a/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
+++ b/platform/features/timeline/src/directives/MCTSwimlaneDrop.js
@@ -91,6 +91,7 @@ define(
 
                 if (id) {
                     event.stopPropagation();
+                    e.preventDefault();
                     // Delegate the drop to the swimlane itself
                     swimlane.drop(id, droppedObject);
                 }

--- a/platform/features/timeline/test/directives/MCTSwimlaneDropSpec.js
+++ b/platform/features/timeline/test/directives/MCTSwimlaneDropSpec.js
@@ -162,6 +162,11 @@ define(
                 expect(mockScope.$apply).toHaveBeenCalled();
             });
 
+            it("invokes preventDefault on drop", function () {
+                handlers.drop(testEvent);
+                expect(testEvent.preventDefault).toHaveBeenCalled();
+            });
+
             it("clears highlights when drag leaves", function () {
                 mockSwimlane.highlight.andReturn(true);
                 handlers.dragleave();

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -123,6 +123,7 @@ define(
                 // destination domain object's composition, and persist
                 // the change.
                 if (id) {
+                    e.preventDefault();
                     $q.when(action && action.perform()).then(function (result) {
                         //Don't go into edit mode for folders
                         if (domainObjectType!=='folder') {

--- a/platform/representation/test/gestures/DropGestureSpec.js
+++ b/platform/representation/test/gestures/DropGestureSpec.js
@@ -194,6 +194,11 @@ define(
                 );
             });
 
+            it("invokes preventDefault on drop", function () {
+                callbacks.drop(mockEvent);
+                expect(mockEvent.preventDefault).toHaveBeenCalled();
+            });
+
         });
     }
 );


### PR DESCRIPTION
...such that Firefox does not try to treat drop as a new URL
to navigate to. Addresses #688 and #527 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y