### PR TITLE
[Persistence] Don't evict models on persist

### DIFF
--- a/platform/core/bundle.js
+++ b/platform/core/bundle.js
@@ -355,7 +355,8 @@ define([
                     "implementation": InstantiationCapability,
                     "depends": [
                         "$injector",
-                        "identifierService"
+                        "identifierService",
+                        "now"
                     ]
                 }
             ],

--- a/platform/core/src/capabilities/InstantiationCapability.js
+++ b/platform/core/src/capabilities/InstantiationCapability.js
@@ -35,10 +35,16 @@ define(
          * @param $injector Angular's `$injector`
          * @implements {Capability}
          */
-        function InstantiationCapability($injector, identifierService, domainObject) {
+        function InstantiationCapability(
+            $injector,
+            identifierService,
+            now,
+            domainObject
+        ) {
             this.$injector = $injector;
             this.identifierService = identifierService;
             this.domainObject = domainObject;
+            this.now = now;
         }
 
         /**
@@ -56,6 +62,8 @@ define(
                     this.identifierService.parse(this.domainObject.getId()),
                 space = parsedId.getDefinedSpace(),
                 id = this.identifierService.generate(space);
+
+            model.modified = this.now();
 
             // Lazily initialize; instantiate depends on capabilityService,
             // which depends on all capabilities, including this one.

--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -149,9 +149,6 @@ define(
                 getKey(domainObject.getId()),
                 domainObject.getModel()
             ]).then(function(result){
-                if (result) {
-                    cacheService.remove(domainObject.getId());
-                }
                 return rejectIfFalsey(result, self.$q);
             }).catch(function(error){
                 return notifyOnError(error, domainObject, self.notificationService, self.$q);

--- a/platform/core/test/capabilities/InstantiationCapabilitySpec.js
+++ b/platform/core/test/capabilities/InstantiationCapabilitySpec.js
@@ -31,6 +31,7 @@ define(
                 mockIdentifierService,
                 mockInstantiate,
                 mockIdentifier,
+                mockNow,
                 mockDomainObject,
                 instantiation;
 
@@ -57,9 +58,13 @@ define(
                 mockIdentifierService.parse.andReturn(mockIdentifier);
                 mockIdentifierService.generate.andReturn("some-id");
 
+                mockNow = jasmine.createSpy();
+                mockNow.andReturn(1234321);
+
                 instantiation = new InstantiationCapability(
                     mockInjector,
                     mockIdentifierService,
+                    mockNow,
                     mockDomainObject
                 );
             });
@@ -81,7 +86,10 @@ define(
                 expect(instantiation.instantiate(testModel))
                     .toBe(mockDomainObject);
                 expect(mockInstantiate)
-                    .toHaveBeenCalledWith(testModel, jasmine.any(String));
+                    .toHaveBeenCalledWith({
+                        someKey: "some value",
+                        modified: mockNow()
+                    }, jasmine.any(String));
             });
 
         });

--- a/platform/core/test/capabilities/PersistenceCapabilitySpec.js
+++ b/platform/core/test/capabilities/PersistenceCapabilitySpec.js
@@ -176,12 +176,8 @@ define(
                     expect(mockQ.reject).not.toHaveBeenCalled();
                     expect(mockNofificationService.error).not.toHaveBeenCalled();
                 });
-
-                it("removes the model from the cache", function () {
-                    persistence.persist();
-                    expect(mockCacheService.remove).toHaveBeenCalledWith(id);
-                });
             });
+
             describe("unsuccessful persistence", function() {
                 var sadPromise = {
                         then: function(callback){


### PR DESCRIPTION
https://github.com/nasa/openmct/issues/745#issuecomment-204559209:

> Specifically, [removing from the cache on persistence](https://github.com/nasa/openmct/pull/773/files#diff-f6d9cdddbe14e455171941b3e3466e8aR152) causes this - it permits multiple instances of the same model to exist in the application. There are probably a lot of other subtle regressions lurking around this.

> Intent there was to maintain similarity with earlier implementation (for newly-created objects, get models from persistence instead of using the version created in memory.) This is poorly-reasoned (also clears the cache on _every_ persist) and unnecessary; there are not cases where an object will look different on read from persistence than it did before it was saved.
