### PR TITLE
[Table] #798 Auto-size columns on new row

### DIFF
--- a/platform/features/table/bundle.js
+++ b/platform/features/table/bundle.js
@@ -161,6 +161,12 @@ define([
                     "key": "table-options-edit",
                     "templateUrl": "templates/table-options-edit.html"
                 }
+            ],
+            "stylesheets": [
+                {
+                    "stylesheetUrl": "css/table.css",
+                    "priority": "mandatory"
+                }
             ]
         }
     });

--- a/platform/features/table/res/sass/table.scss
+++ b/platform/features/table/res/sass/table.scss
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+.sizing-table {
+    min-width: 100%;
+    z-index: -1;
+    visibility: hidden;
+    position: absolute;
+
+    //Add some padding to allow for decorations such as limits indicator
+    td {
+        padding-right: 15px;
+        padding-left: 10px;
+        white-space: nowrap;
+    }
+}
+.mct-table {
+    table-layout: fixed;
+    th {
+        box-sizing: border-box;
+    }
+    tbody {
+        tr {
+            position: absolute;
+        }
+        td {
+            white-space: nowrap;
+            overflow: hidden;
+            box-sizing: border-box;
+        }
+    }
+}

--- a/platform/features/table/res/templates/mct-table.html
+++ b/platform/features/table/res/templates/mct-table.html
@@ -1,22 +1,25 @@
-<div class="l-view-section scrolling"
-     ng-style="overrideRowPositioning ?
-         {'overflow': 'auto'} :
-         {'overflow': 'scroll'}"
-     >
-    <table class="filterable"
-           ng-style="overrideRowPositioning && {
+<div class="l-view-section scrolling" style="overflow: auto;">
+    <table class="sizing-table">
+        <tbody>
+            <tr>
+                <td ng-repeat="header in displayHeaders">{{header}}</td>
+            </tr>
+            <tr><td ng-repeat="header in displayHeaders" >
+                {{sizingRow[header].text}}
+            </td></tr>
+        </tbody>
+    </table>
+    <table class="filterable mct-table"
+           ng-style="{
             height: totalHeight + 'px',
-            'table-layout': overrideRowPositioning ? 'fixed' : 'auto',
             'max-width': totalWidth
-        }">
+            }">
         <thead>
             <tr>
                 <th ng-repeat="header in displayHeaders"
-                    ng-style="overrideRowPositioning && {
+                    ng-style="{
                         width: columnWidths[$index] + 'px',
                         'max-width': columnWidths[$index] + 'px',
-                        overflow: 'none',
-                        'box-sizing': 'border-box'
                     }"
                     ng-class="[
                         enableSort ? 'sortable' : '',
@@ -29,11 +32,9 @@
             </tr>
             <tr ng-if="enableFilter" class="s-filters">
                 <th ng-repeat="header in displayHeaders"
-                    ng-style="overrideRowPositioning && {
+                    ng-style="{
                         width: columnWidths[$index] + 'px',
                         'max-width': columnWidths[$index] + 'px',
-                        overflow: 'none',
-                        'box-sizing': 'border-box'
                     }">
                     <input type="text"
                            ng-model="filters[header]"/>
@@ -41,21 +42,15 @@
             </tr>
         </thead>
 
-        <tbody ng-style="overrideRowPositioning ? '' : {
-            'opacity': '0.0'
-        }">
+        <tbody>
             <tr ng-repeat="visibleRow in visibleRows track by visibleRow.rowIndex"
-                ng-style="overrideRowPositioning && {
-                    position: 'absolute',
+                ng-style="{
                     top: visibleRow.offsetY + 'px',
                 }">
                 <td ng-repeat="header in displayHeaders"
-                    ng-style="overrideRowPositioning && {
+                    ng-style=" {
                         width: columnWidths[$index] + 'px',
-                        'white-space': 'nowrap',
                         'max-width': columnWidths[$index] + 'px',
-                        overflow: 'hidden',
-                        'box-sizing': 'border-box'
                     }"
                     class="{{visibleRow.contents[header].cssClass}}">
                     {{ visibleRow.contents[header].text }}

--- a/platform/features/table/test/controllers/MCTTableControllerSpec.js
+++ b/platform/features/table/test/controllers/MCTTableControllerSpec.js
@@ -58,15 +58,18 @@ define(
 
                 mockElement = jasmine.createSpyObj('element', [
                     'find',
+                    'prop',
                     'on'
                 ]);
                 mockElement.find.andReturn(mockElement);
+                mockElement.prop.andReturn(0);
 
                 mockScope.displayHeaders = true;
                 mockTimeout = jasmine.createSpy('$timeout');
                 mockTimeout.andReturn(promise(undefined));
 
                 controller = new MCTTableController(mockScope, mockTimeout, mockElement);
+                spyOn(controller, 'setVisibleRows');
             });
 
             it('Reacts to changes to filters, headers, and rows', function() {
@@ -138,8 +141,6 @@ define(
                     var removeRowFunc = mockScope.$on.calls[mockScope.$on.calls.length-1].args[1];
                     controller.updateRows(testRows);
                     expect(mockScope.displayRows.length).toBe(3);
-                    spyOn(controller, 'setVisibleRows');
-                    //controller.setVisibleRows.andReturn(undefined);
                     removeRowFunc(undefined, 2);
                     expect(mockScope.displayRows.length).toBe(2);
                     expect(controller.setVisibleRows).toHaveBeenCalled();
@@ -264,6 +265,25 @@ define(
                             mockScope.rows.push(row6);
                             controller.newRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[4].col2.text).toEqual('ggg');
+                        });
+
+                        it('Resizes columns if length of any columns in new' +
+                            ' row exceeds corresponding existing column', function() {
+                            var row7 = {
+                                'col1': {'text': 'row6 col1'},
+                                'col2': {'text': 'some longer string'},
+                                'col3': {'text': 'row6 col3'}
+                            };
+
+                            mockScope.sortColumn = undefined;
+                            mockScope.sortDirection = undefined;
+                            mockScope.filters = {};
+
+                            mockScope.displayRows = testRows.slice(0);
+
+                            mockScope.rows.push(row7);
+                            controller.newRow(undefined, mockScope.rows.length-1);
+                            expect(controller.$scope.sizingRow.col2).toEqual({text: 'some longer string'});
                         });
 
                     });


### PR DESCRIPTION
Tried to keep code delta to a minimum here for stability reasons, so does not address #806 or #801 which will be addressed separately.

### Summary of Changes
* Added a new off-screen sizing table which is used to determine column widths.
* On addition of a new row, contents are assessed to see if resizing is necessary. If so, resizing of the table is performed
* Simplified markup. This removed the need for some dynamic styles. These have been replaced with statically defined styles in an external stylesheet.
* Updated tests

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y