### PR TITLE
[Tables] #806 Cleanup and refactoring of Tables

### DIFF
--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -6,12 +6,13 @@ Victor Woeltjen
 September 23, 2015  
 Document Version 1.1  
 
-Date                | Version   | Summary of Changes      | Author
-------------------- | --------- | ----------------------- | ---------------
-April 29, 2015      | 0         | Initial Draft           | Victor Woeltjen
-May 12, 2015        | 0.1       |                         | Victor Woeltjen
-June 4, 2015        | 1.0       | Name Changes            | Victor Woeltjen
-October 4, 2015     | 1.1       | Conversion to MarkDown  | Andrew Henry
+Date                | Version   | Summary of Changes        | Author
+------------------- | --------- | ------------------------- | ---------------
+April 29, 2015      | 0         | Initial Draft             | Victor Woeltjen
+May 12, 2015        | 0.1       |                           | Victor Woeltjen
+June 4, 2015        | 1.0       | Name Changes              | Victor Woeltjen
+October 4, 2015     | 1.1       | Conversion to MarkDown    | Andrew Henry
+April 5, 2016       | 1.2       | Added Mct-table directive | Andrew Henry
 
 # Introduction
 The purpose of this guide is to familiarize software developers with the Open
@@ -1599,6 +1600,61 @@ there are items .
             ... and other sections ... 
         ] 
     }
+
+## Table
+
+The `mct-table` directive provides a generic table component, with optional 
+sorting and filtering capabilities. The table can be pre-populated with data 
+by setting the `rows` parameter, and it can be updated in real-time using the
+`add:row` and `remove:row` broadcast events. The table will expand to occupy 
+100% of the size of its containing element. The table is highly optimized for 
+very large data sets.
+
+### Events
+
+The table supports two events for notifying that the rows have changed. For 
+performance reasons, the table does not monitor the content of `rows` 
+constantly. 
+
+* `add:row`: A `$broadcast` event that will notify the table that a new row 
+has been added to the table.
+
+eg. The code below adds a new row, and alerts the table using the `add:row` 
+event. Sorting and filtering will be applied automatically by the table component.
+
+```
+$scope.rows.push(newRow);
+$scope.$broadcast('add:row', $scope.rows.length-1);
+```
+
+* `remove:row`: A `$broadcast` event that will notify the table that a row 
+should be removed from the table.
+
+eg. The code below removes a row from the rows array, and then alerts the table 
+to its removal.
+    
+```
+$scope.rows.slice(5, 1);
+$scope.$broadcast('remove:row', 5);
+```
+
+### Parameters
+
+* `headers`: An array of string values which will constitute the column titles
+ that appear at the top of the table. Corresponding values are specified in 
+ the rows using the header title provided here.
+* `rows`: An array of objects containing row values. Each element in the 
+array must be an associative array, where the key corresponds to a column header. 
+* `enableFilter`: A boolean that if true, will enable searching and result 
+filtering. When enabled, each column will have a text input field that can be
+used to filter the table rows in real time.
+* `enableSort`: A boolean determining whether rows can be sorted. If true, 
+sorting will be enabled allowing sorting by clicking on column headers. Only 
+one column may be sorted at a time.
+* `autoScroll`: A boolean value that if true, will cause the table to automatically 
+scroll to the bottom as new data arrives. Auto-scroll can be disengaged manually 
+by scrolling away from the bottom of the table, and can also be enabled manually 
+by scrolling to the bottom of the table rows.
 
 # Services 
 

--- a/platform/features/table/bundle.js
+++ b/platform/features/table/bundle.js
@@ -23,16 +23,16 @@
 
 define([
     "./src/directives/MCTTable",
-    "./src/controllers/RTTelemetryTableController",
-    "./src/controllers/TelemetryTableController",
+    "./src/controllers/RealtimeTableController",
+    "./src/controllers/HistoricalTableController",
     "./src/controllers/TableOptionsController",
     '../../commonUI/regions/src/Region',
     '../../commonUI/browse/src/InspectorRegion',
     "legacyRegistry"
 ], function (
     MCTTable,
-    RTTelemetryTableController,
-    TelemetryTableController,
+    RealtimeTableController,
+    HistoricalTableController,
     TableOptionsController,
     Region,
     InspectorRegion,
@@ -108,13 +108,13 @@ define([
             ],
             "controllers": [
                 {
-                    "key": "TelemetryTableController",
-                    "implementation": TelemetryTableController,
+                    "key": "HistoricalTableController",
+                    "implementation": HistoricalTableController,
                     "depends": ["$scope", "telemetryHandler", "telemetryFormatter"]
                 },
                 {
-                    "key": "RTTelemetryTableController",
-                    "implementation": RTTelemetryTableController,
+                    "key": "RealtimeTableController",
+                    "implementation": RealtimeTableController,
                     "depends": ["$scope", "telemetryHandler", "telemetryFormatter"]
                 },
                 {
@@ -129,7 +129,7 @@ define([
                     "name": "Historical Table",
                     "key": "table",
                     "glyph": "\ue605",
-                    "templateUrl": "templates/table.html",
+                    "templateUrl": "templates/historical-table.html",
                     "needs": [
                         "telemetry"
                     ],

--- a/platform/features/table/bundle.js
+++ b/platform/features/table/bundle.js
@@ -160,6 +160,12 @@ define([
                     "key": "table-options-edit",
                     "templateUrl": "templates/table-options-edit.html"
                 }
+            ],
+            "stylesheets": [
+                {
+                    "stylesheetUrl": "css/table.css",
+                    "priority": "mandatory"
+                }
             ]
         }
     });

--- a/platform/features/table/res/sass/table.scss
+++ b/platform/features/table/res/sass/table.scss
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+.sizing-table {
+    min-width: 100%;
+    z-index: -1;
+    visibility: hidden;
+    position: absolute;
+
+    //Add some padding to allow for decorations such as limits indicator
+    td {
+        padding-right: 10px;
+        padding-left: 10px;
+        white-space: nowrap;
+    }
+}
+.mct-table {
+    table-layout: fixed;
+    th {
+        box-sizing: border-box;
+    }
+    tbody {
+        tr {
+            position: absolute;
+        }
+        td {
+            white-space: nowrap;
+            overflow: hidden;
+            box-sizing: border-box;
+        }
+    }
+}

--- a/platform/features/table/res/templates/historical-table.html
+++ b/platform/features/table/res/templates/historical-table.html
@@ -1,4 +1,4 @@
-<div ng-controller="TelemetryTableController">
+<div ng-controller="HistoricalTableController">
     <mct-table
         headers="headers"
         rows="rows"

--- a/platform/features/table/res/templates/mct-table.html
+++ b/platform/features/table/res/templates/mct-table.html
@@ -1,22 +1,25 @@
-<div class="l-view-section scrolling"
-     ng-style="overrideRowPositioning ?
-         {'overflow': 'auto'} :
-         {'overflow': 'scroll'}"
-     >
-    <table class="filterable"
-           ng-style="overrideRowPositioning && {
+<div class="l-view-section scrolling" style="overflow: auto;">
+    <table class="sizing-table">
+        <tbody>
+            <tr>
+                <td ng-repeat="header in displayHeaders">{{header}}</td>
+            </tr>
+            <tr><td ng-repeat="header in displayHeaders" >
+                {{sizingRow[header].text}}
+            </td></tr>
+        </tbody>
+    </table>
+    <table class="filterable mct-table"
+           ng-style="{
             height: totalHeight + 'px',
-            'table-layout': overrideRowPositioning ? 'fixed' : 'auto',
             'max-width': totalWidth
-        }">
+            }">
         <thead>
             <tr>
                 <th ng-repeat="header in displayHeaders"
-                    ng-style="overrideRowPositioning && {
+                    ng-style="{
                         width: columnWidths[$index] + 'px',
                         'max-width': columnWidths[$index] + 'px',
-                        overflow: 'none',
-                        'box-sizing': 'border-box'
                     }"
                     ng-class="[
                         enableSort ? 'sortable' : '',
@@ -29,11 +32,9 @@
             </tr>
             <tr ng-if="enableFilter" class="s-filters">
                 <th ng-repeat="header in displayHeaders"
-                    ng-style="overrideRowPositioning && {
+                    ng-style="{
                         width: columnWidths[$index] + 'px',
                         'max-width': columnWidths[$index] + 'px',
-                        overflow: 'none',
-                        'box-sizing': 'border-box'
                     }">
                     <input type="text"
                            ng-model="filters[header]"/>
@@ -41,21 +42,15 @@
             </tr>
         </thead>
 
-        <tbody ng-style="overrideRowPositioning ? '' : {
-            'opacity': '0.0'
-        }">
+        <tbody>
             <tr ng-repeat="visibleRow in visibleRows track by visibleRow.rowIndex"
-                ng-style="overrideRowPositioning && {
-                    position: 'absolute',
+                ng-style="{
                     top: visibleRow.offsetY + 'px',
                 }">
                 <td ng-repeat="header in displayHeaders"
-                    ng-style="overrideRowPositioning && {
+                    ng-style=" {
                         width: columnWidths[$index] + 'px',
-                        'white-space': 'nowrap',
                         'max-width': columnWidths[$index] + 'px',
-                        overflow: 'hidden',
-                        'box-sizing': 'border-box'
                     }"
                     class="{{visibleRow.contents[header].cssClass}}">
                     {{ visibleRow.contents[header].text }}

--- a/platform/features/table/res/templates/rt-table.html
+++ b/platform/features/table/res/templates/rt-table.html
@@ -1,4 +1,4 @@
-<div ng-controller="RTTelemetryTableController">
+<div ng-controller="RealtimeTableController">
     <mct-table
         headers="headers"
         rows="rows"

--- a/platform/features/table/src/controllers/HistoricalTableController.js
+++ b/platform/features/table/src/controllers/HistoricalTableController.js
@@ -47,7 +47,7 @@ define(
          * Populates historical data on scope when it becomes available from
          * the telemetry API
          */
-        HistoricalTableController.prototype.addHistoricalData = function (domainObject) {
+        HistoricalTableController.prototype.addHistoricalData = function () {
             var rowData = [],
                 self = this;
 

--- a/platform/features/table/src/controllers/HistoricalTableController.js
+++ b/platform/features/table/src/controllers/HistoricalTableController.js
@@ -1,0 +1,70 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define*/
+
+define(
+    [
+        './TelemetryTableController'
+    ],
+    function (TableController) {
+        "use strict";
+
+        /**
+         * Extends TelemetryTableController and adds real-time streaming
+         * support.
+         * @memberof platform/features/table
+         * @param $scope
+         * @param telemetryHandler
+         * @param telemetryFormatter
+         * @constructor
+         */
+        function HistoricalTableController($scope, telemetryHandler, telemetryFormatter) {
+            TableController.call(this, $scope, telemetryHandler, telemetryFormatter);
+        }
+
+        HistoricalTableController.prototype = Object.create(TableController.prototype);
+
+        /**
+         * Populates historical data on scope when it becomes available from
+         * the telemetry API
+         */
+        HistoricalTableController.prototype.addHistoricalData = function (domainObject) {
+            var rowData = [],
+                self = this;
+
+            this.handle.getTelemetryObjects().forEach(function (telemetryObject){
+                var series = self.handle.getSeries(telemetryObject) || {},
+                    pointCount = series.getPointCount ? series.getPointCount() : 0,
+                    i = 0;
+
+                for (; i < pointCount; i++) {
+                    rowData.push(self.table.getRowValues(telemetryObject,
+                        self.handle.makeDatum(telemetryObject, series, i)));
+                }
+            });
+
+            this.$scope.rows = rowData;
+        };
+
+        return HistoricalTableController;
+    }
+);

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -85,7 +85,7 @@ define(
                 then: function (callback) {
                     return fastPromise(callback(returnValue));
                 }
-            }
+            };
         }
 
         /**

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -23,10 +23,13 @@ define(
             this.maxDisplayRows = 50;
 
             this.scrollable = element.find('div');
+            this.thead = element.find('thead');
+            this.tbody = element.find('tbody');
+            this.$scope.sizingRow = {};
+
             this.scrollable.on('scroll', this.onScroll.bind(this));
 
             $scope.visibleRows = [];
-            $scope.overrideRowPositioning = false;
 
             /**
              * Set default values for optional parameters on a given scope
@@ -100,14 +103,31 @@ define(
          * @private
          */
         MCTTableController.prototype.newRow = function (event, rowIndex) {
-            var row = this.$scope.rows[rowIndex];
-            //Add row to the filtered, sorted list of all rows
-            if (this.filterRows([row]).length > 0) {
-                this.insertSorted(this.$scope.displayRows, row);
+            var self = this,
+                row = this.$scope.rows[rowIndex],
+                largestRow;
+
+            function sizeAndScroll () {
+                self.setElementSizes();
+                self.scrollToBottom();
             }
 
-            this.$timeout(this.setElementSizes.bind(this))
-                .then(this.scrollToBottom.bind(this));
+            //Does the row pass the current filter?
+            if (this.filterRows([row]).length === 1) {
+                this.insertSorted(this.$scope.displayRows, row);
+
+                //Calculate largest row
+                largestRow = this.buildLargestRow([this.$scope.sizingRow, row]);
+
+                // Has it changed? If so, set the the 'sizing' row which
+                // determines column widths
+                if (JSON.stringify(largestRow) !== JSON.stringify(this.$scope.sizingRow)){
+                    this.$scope.sizingRow = largestRow;
+                    this.$timeout(sizeAndScroll);
+                } else {
+                    sizeAndScroll();
+                }
+            }
         };
 
         /**
@@ -249,13 +269,12 @@ define(
          * for individual rows.
          */
         MCTTableController.prototype.setElementSizes = function () {
-            var self = this,
-                thead = this.element.find('thead'),
-                tbody = this.element.find('tbody'),
+            var thead = this.thead,
+                tbody = this.tbody,
                 firstRow = tbody.find('tr'),
                 column = firstRow.find('td'),
                 headerHeight = thead.prop('offsetHeight'),
-                rowHeight = 20,
+                rowHeight = firstRow.prop('offsetHeight'),
                 columnWidth,
                 tableWidth = 0,
                 overallHeight = headerHeight + (rowHeight *
@@ -279,8 +298,6 @@ define(
             } else {
                 this.$scope.totalWidth = 'none';
             }
-
-            this.$scope.overrideRowPositioning = true;
         };
 
         /**
@@ -400,19 +417,19 @@ define(
          * pre-calculate optimal column sizes without having to render
          * every row.
          */
-        MCTTableController.prototype.findLargestRow = function (rows) {
+        MCTTableController.prototype.buildLargestRow = function (rows) {
             var largestRow = rows.reduce(function (largestRow, row) {
                 Object.keys(row).forEach(function (key) {
-                    var currentColumn = row[key].text,
+                    var currentColumn = (row[key] || {}).text,
                         currentColumnLength =
                             (currentColumn && currentColumn.length) ?
                                 currentColumn.length :
                                 currentColumn,
-                        largestColumn = largestRow[key].text,
+                        largestColumn = (largestRow[key] || {}).text,
                         largestColumnLength =
                             (largestColumn && largestColumn.length) ?
                                 largestColumn.length :
-                                largestColumn;
+                                0;
 
                     if (currentColumnLength > largestColumnLength) {
                         largestRow[key] = JSON.parse(JSON.stringify(row[key]));
@@ -420,23 +437,6 @@ define(
                 });
                 return largestRow;
             }, JSON.parse(JSON.stringify(rows[0] || {})));
-
-            largestRow = JSON.parse(JSON.stringify(largestRow));
-
-            // Pad with characters to accomodate variable-width fonts,
-            // and remove characters that would allow word-wrapping.
-            Object.keys(largestRow).forEach(function (key) {
-                var padCharacters,
-                    i;
-
-                largestRow[key].text = String(largestRow[key].text);
-                padCharacters = largestRow[key].text.length / 10;
-                for (i = 0; i < padCharacters; i++) {
-                    largestRow[key].text = largestRow[key].text + 'W';
-                }
-                largestRow[key].text = largestRow[key].text
-                    .replace(/[ \-_]/g, 'W');
-            });
             return largestRow;
         };
 
@@ -447,15 +447,9 @@ define(
          * @private
          */
         MCTTableController.prototype.resize = function (){
-            var largestRow = this.findLargestRow(this.$scope.displayRows),
-                self = this;
-            this.$scope.visibleRows = [
-                {
-                    rowIndex: 0,
-                    offsetY: undefined,
-                    contents: largestRow
-                }
-            ];
+            var self = this;
+
+            this.$scope.sizingRow = this.buildLargestRow(this.$scope.displayRows);
 
             //Wait a timeout to allow digest of previous change to visible
             // rows to happen.
@@ -488,8 +482,6 @@ define(
         MCTTableController.prototype.updateRows = function (newRows) {
             //Reset visible rows because new row data available.
             this.$scope.visibleRows = [];
-
-            this.$scope.overrideRowPositioning = false;
 
             //Nothing to show because no columns visible
             if (!this.$scope.displayHeaders) {

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -70,14 +70,22 @@ define(
             $scope.$watchCollection('filters', function () {
                 self.updateRows($scope.rows);
             });
-            $scope.$watch('headers', this.updateHeaders.bind(this));
-            $scope.$watch('rows', this.updateRows.bind(this));
+            $scope.$watch('rows', this.setRows.bind(this));
+            $scope.$watch('headers', this.setHeaders.bind(this));
 
             /*
              * Listen for rows added individually (eg. for real-time tables)
              */
-            $scope.$on('add:row', this.newRow.bind(this));
+            $scope.$on('add:row', this.addRow.bind(this));
             $scope.$on('remove:row', this.removeRow.bind(this));
+        }
+
+        function fastPromise(returnValue) {
+            return {
+                then: function (callback) {
+                    return fastPromise(callback(returnValue));
+                }
+            }
         }
 
         /**
@@ -99,40 +107,26 @@ define(
 
         /**
          * Handles a row add event. Rows can be added as needed using the
-         * `addRow` broadcast event.
+         * `add:row` broadcast event.
          * @private
          */
-        MCTTableController.prototype.newRow = function (event, rowIndex) {
-            var self = this,
-                row = this.$scope.rows[rowIndex],
-                largestRow;
-
-            function sizeAndScroll () {
-                self.setElementSizes();
-                self.scrollToBottom();
-            }
+        MCTTableController.prototype.addRow = function (event, rowIndex) {
+            var row = this.$scope.rows[rowIndex];
 
             //Does the row pass the current filter?
             if (this.filterRows([row]).length === 1) {
+                //Insert the row into the correct position in the array
                 this.insertSorted(this.$scope.displayRows, row);
-
-                //Calculate largest row
-                largestRow = this.buildLargestRow([this.$scope.sizingRow, row]);
-
-                // Has it changed? If so, set the the 'sizing' row which
-                // determines column widths
-                if (JSON.stringify(largestRow) !== JSON.stringify(this.$scope.sizingRow)){
-                    this.$scope.sizingRow = largestRow;
-                    this.$timeout(sizeAndScroll);
-                } else {
-                    sizeAndScroll();
-                }
+                //Resize the columns (if necessary), then update the rows
+                // visible in the table
+                this.resize([this.$scope.sizingRow, row])
+                    .then(this.setVisibleRows.bind(this));
             }
         };
 
         /**
-         * Handles a row add event. Rows can be added as needed using the
-         * `addRow` broadcast event.
+         * Handles a row remove event. Rows can be removed as needed using the
+         * `remove:row` broadcast event.
          * @private
          */
         MCTTableController.prototype.removeRow = function (event, rowIndex) {
@@ -182,8 +176,7 @@ define(
             if (this.$scope.displayRows.length < this.maxDisplayRows) {
                 //Check whether need to resynchronize visible with display
                 // rows (if data added)
-                if (this.$scope.visibleRows.length !=
-                    this.$scope.displayRows.length){
+                if (this.$scope.visibleRows.length != this.$scope.displayRows.length){
                     start = 0;
                     end = this.$scope.displayRows.length;
                 } else {
@@ -245,7 +238,7 @@ define(
          * enabled, reset filters.  If sorting is enabled, reset
          * sorting.
          */
-        MCTTableController.prototype.updateHeaders = function (newHeaders) {
+        MCTTableController.prototype.setHeaders = function (newHeaders) {
             if (!newHeaders){
                 return;
             }
@@ -261,7 +254,7 @@ define(
                     this.$scope.sortColumn = undefined;
                     this.$scope.sortDirection = undefined;
             }
-            this.updateRows(this.$scope.rows);
+            this.setRows(this.$scope.rows);
         };
 
         /**
@@ -291,7 +284,6 @@ define(
             this.$scope.headerHeight = headerHeight;
             this.$scope.rowHeight = rowHeight;
             this.$scope.totalHeight = overallHeight;
-            this.setVisibleRows();
 
             if (tableWidth > 0) {
                 this.$scope.totalWidth = tableWidth + 'px';
@@ -441,27 +433,30 @@ define(
         };
 
         /**
-         * Calculates the widest row in the table, pads that row, and adds
-         * it to the table. Allows the table to size itself, then uses this
-         * as basis for column dimensions.
+         * Calculates the widest row in the table, and if necessary, resizes
+         * the table accordingly
+         *
+         * @param rows the rows on which to resize
+         * @returns {Promise} a promise that will resolve when resizing has
+         * occurred.
          * @private
          */
-        MCTTableController.prototype.resize = function (){
-            var self = this;
+        MCTTableController.prototype.resize = function (rows){
+            //Calculate largest row
+            var largestRow = this.buildLargestRow(rows);
 
-            this.$scope.sizingRow = this.buildLargestRow(this.$scope.displayRows);
-
-            //Wait a timeout to allow digest of previous change to visible
-            // rows to happen.
-            this.$timeout(function () {
-                //Remove temporary padding row used for setting column widths
-                self.$scope.visibleRows = [];
-                self.setElementSizes();
-            });
+            // Has it changed? If so, set the the 'sizing' row which
+            // determines column widths
+            if (JSON.stringify(largestRow) !== JSON.stringify(this.$scope.sizingRow)){
+                this.$scope.sizingRow = largestRow;
+                return this.$timeout(this.setElementSizes.bind(this));
+            } else {
+                return fastPromise(undefined);
+            }
         };
 
         /**
-         * @priate
+         * @private
          */
         MCTTableController.prototype.filterAndSort = function (rows) {
             var displayRows = rows;
@@ -479,17 +474,14 @@ define(
          * Update rows with new data.  If filtering is enabled, rows
          * will be sorted before display.
          */
-        MCTTableController.prototype.updateRows = function (newRows) {
-            //Reset visible rows because new row data available.
-            this.$scope.visibleRows = [];
-
+        MCTTableController.prototype.setRows = function (newRows) {
             //Nothing to show because no columns visible
-            if (!this.$scope.displayHeaders) {
+            if (!this.$scope.displayHeaders || !newRows) {
                 return;
             }
 
             this.filterAndSort(newRows || []);
-            this.resize();
+            this.resize(newRows).then(this.setVisibleRows.bind(this));
         };
 
         /**

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -120,7 +120,8 @@ define(
                 //Resize the columns (if necessary), then update the rows
                 // visible in the table
                 this.resize([this.$scope.sizingRow, row])
-                    .then(this.setVisibleRows.bind(this));
+                    .then(this.setVisibleRows.bind(this))
+                    .then(this.scrollToBottom.bind(this));
             }
         };
 

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -61,14 +61,14 @@ define(
                     $scope.sortColumn = undefined;
                     $scope.sortDirection = undefined;
                 }
-                self.updateRows($scope.rows);
+                self.setRows($scope.rows);
             };
 
             /*
              * Define watches to listen for changes to headers and rows.
              */
             $scope.$watchCollection('filters', function () {
-                self.updateRows($scope.rows);
+                self.setRows($scope.rows);
             });
             $scope.$watch('rows', this.setRows.bind(this));
             $scope.$watch('headers', this.setHeaders.bind(this));

--- a/platform/features/table/src/controllers/RealtimeTableController.js
+++ b/platform/features/table/src/controllers/RealtimeTableController.js
@@ -37,7 +37,7 @@ define(
          * @param telemetryFormatter
          * @constructor
          */
-        function RTTelemetryTableController($scope, telemetryHandler, telemetryFormatter) {
+        function RealtimeTableController($scope, telemetryHandler, telemetryFormatter) {
             TableController.call(this, $scope, telemetryHandler, telemetryFormatter);
 
             $scope.autoScroll = false;
@@ -66,58 +66,31 @@ define(
             });
         }
 
-        RTTelemetryTableController.prototype = Object.create(TableController.prototype);
+        RealtimeTableController.prototype = Object.create(TableController.prototype);
 
-        /**
-         Override the subscribe function defined on the parent controller in
-         order to handle realtime telemetry instead of historical.
-         */
-        RTTelemetryTableController.prototype.subscribe = function () {
-            var self = this;
-            self.$scope.rows = undefined;
-            (this.subscriptions || []).forEach(function (unsubscribe){
-                unsubscribe();
-            });
+        RealtimeTableController.prototype.addRealtimeData = function() {
+            var self = this,
+                datum,
+                row;
+            this.handle.getTelemetryObjects().forEach(function (telemetryObject){
+                datum = self.handle.getDatum(telemetryObject);
+                if (datum) {
+                    //Populate row values from telemetry datum
+                    row = self.table.getRowValues(telemetryObject, datum);
+                    self.$scope.rows.push(row);
 
-            if (this.handle) {
-                this.handle.unsubscribe();
-            }
-
-            function updateData(){
-                var datum,
-                    row;
-                self.handle.getTelemetryObjects().forEach(function (telemetryObject){
-                    datum = self.handle.getDatum(telemetryObject);
-                    if (datum) {
-                        row = self.table.getRowValues(telemetryObject, datum);
-                        if (!self.$scope.rows){
-                            self.$scope.rows = [row];
-                            self.$scope.$digest();
-                        } else {
-                            self.$scope.rows.push(row);
-
-                            if (self.$scope.rows.length > self.maxRows) {
-                                self.$scope.$broadcast('remove:row', 0);
-                                self.$scope.rows.shift();
-                            }
-
-                            self.$scope.$broadcast('add:row',
-                                self.$scope.rows.length - 1);
-                        }
+                    //Inform table that a new row has been added
+                    if (self.$scope.rows.length > self.maxRows) {
+                        self.$scope.$broadcast('remove:row', 0);
+                        self.$scope.rows.shift();
                     }
-                });
 
-            }
+                    self.$scope.$broadcast('add:row',
+                        self.$scope.rows.length - 1);
+                }
+            });
+        }
 
-            this.handle = this.$scope.domainObject && this.telemetryHandler.handle(
-                    this.$scope.domainObject,
-                    updateData,
-                    true // Lossless
-                );
-
-            this.setup();
-        };
-
-        return RTTelemetryTableController;
+        return RealtimeTableController;
     }
 );

--- a/platform/features/table/src/controllers/RealtimeTableController.js
+++ b/platform/features/table/src/controllers/RealtimeTableController.js
@@ -68,6 +68,10 @@ define(
 
         RealtimeTableController.prototype = Object.create(TableController.prototype);
 
+        /**
+         * Overrides method on TelemetryTableController providing handling
+         * for realtime data.
+         */
         RealtimeTableController.prototype.addRealtimeData = function() {
             var self = this,
                 datum,
@@ -89,7 +93,7 @@ define(
                         self.$scope.rows.length - 1);
                 }
             });
-        }
+        };
 
         return RealtimeTableController;
     }

--- a/platform/features/table/src/controllers/TableOptionsController.js
+++ b/platform/features/table/src/controllers/TableOptionsController.js
@@ -55,8 +55,15 @@ define(
 
             $scope.columnsForm = {};
 
+            function unlisten() {
+                self.listeners.forEach(function (listener) {
+                    listener();
+                });
+            }
+
             $scope.$watch('domainObject', function(domainObject) {
-               self.populateForm(domainObject.getModel());
+                unlisten();
+                self.populateForm(domainObject.getModel());
 
                 self.listeners.push(self.domainObject.getCapability('mutation').listen(function (model) {
                     self.populateForm(model);
@@ -79,11 +86,7 @@ define(
             /**
              * Destroy all mutation listeners
              */
-            $scope.$on('$destroy', function () {
-                self.listeners.forEach(function (listener) {
-                   listener();
-                });
-            })
+            $scope.$on('$destroy', unlisten);
 
         }
 

--- a/platform/features/table/src/controllers/TableOptionsController.js
+++ b/platform/features/table/src/controllers/TableOptionsController.js
@@ -104,7 +104,7 @@ define(
                     'key': key
                 });
             });
-            this.$scope.configuration = JSON.parse(JSON.stringify(model.configuration));
+            this.$scope.configuration = JSON.parse(JSON.stringify(model.configuration || {}));
         };
 
         return TableOptionsController;

--- a/platform/features/table/src/controllers/TableOptionsController.js
+++ b/platform/features/table/src/controllers/TableOptionsController.js
@@ -51,13 +51,22 @@ define(
 
             this.$scope = $scope;
             this.domainObject = $scope.domainObject;
+            this.listeners = [];
 
             $scope.columnsForm = {};
 
-            this.domainObject.getCapability('mutation').listen(function (model) {
-               self.populateForm(model);
+            $scope.$watch('domainObject', function(domainObject) {
+               self.populateForm(domainObject.getModel());
+
+                self.listeners.push(self.domainObject.getCapability('mutation').listen(function (model) {
+                    self.populateForm(model);
+                }));
             });
 
+            /**
+             * Maintain a configuration object on scope that stores column
+             * configuration. On change, synchronize with object model.
+             */
             $scope.$watchCollection('configuration.table.columns', function (columns){
                 if (columns){
                     self.domainObject.useCapability('mutation', function (model) {
@@ -66,6 +75,15 @@ define(
                     self.domainObject.getCapability('persistence').persist();
                 }
             });
+
+            /**
+             * Destroy all mutation listeners
+             */
+            $scope.$on('$destroy', function () {
+                self.listeners.forEach(function (listener) {
+                   listener();
+                });
+            })
 
         }
 

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -77,7 +77,7 @@ define(
                 return listener && listener();
             });
             this.changeListeners = [];
-        }
+        };
 
         /**
          * Defer registration of change listeners until domain object is
@@ -156,7 +156,7 @@ define(
 
             if (handle) {
                 handle.promiseTelemetryObjects().then(function () {
-                    self.$scope.headers = []
+                    self.$scope.headers = [];
                     self.$scope.rows = [];
                     table.populateColumns(handle.getMetadata());
 

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -52,19 +52,15 @@ define(
             this.$scope = $scope;
             this.columns = {}; //Range and Domain columns
             this.handle = undefined;
-            //this.pending = false;
             this.telemetryHandler = telemetryHandler;
             this.table = new TableConfiguration($scope.domainObject,
                 telemetryFormatter);
             this.changeListeners = [];
 
-            $scope.rows = undefined;
+            $scope.rows = [];
 
             // Subscribe to telemetry when a domain object becomes available
-            this.$scope.$watch('domainObject', function(domainObject){
-                if (!domainObject)
-                    return;
-
+            this.$scope.$watch('domainObject', function(){
                 self.subscribe();
                 self.registerChangeListeners();
             });
@@ -74,15 +70,23 @@ define(
         }
 
         /**
+         * @private
+         */
+        TelemetryTableController.prototype.unregisterChangeListeners = function () {
+            this.changeListeners.forEach(function (listener) {
+                return listener && listener();
+            });
+            this.changeListeners = [];
+        }
+
+        /**
          * Defer registration of change listeners until domain object is
          * available in order to avoid race conditions
          * @private
          */
         TelemetryTableController.prototype.registerChangeListeners = function () {
-            this.changeListeners.forEach(function (listener) {
-                return listener && listener();
-            });
-            this.changeListeners = [];
+            this.unregisterChangeListeners();
+
             // When composition changes, re-subscribe to the various
             // telemetry subscriptions
             this.changeListeners.push(this.$scope.$watchCollection(
@@ -104,52 +108,42 @@ define(
         };
 
         /**
+         * Function for handling realtime data when it is available. This
+         * will be called by the telemetry framework when new data is
+         * available.
+         *
+         * Method should be overridden by specializing class.
+         */
+        TelemetryTableController.prototype.addRealtimeData = function () {
+        };
+
+        /**
+         * Function for handling historical data. Will be called by
+         * telemetry framework when requested historical data is available.
+         * Should be overridden by specializing class.
+         */
+        TelemetryTableController.prototype.addHistoricalData = function () {
+        };
+
+        /**
          Create a new subscription. This can be overridden by children to
          change default behaviour (which is to retrieve historical telemetry
          only).
          */
         TelemetryTableController.prototype.subscribe = function () {
-            var self = this;
-
             if (this.handle) {
                 this.handle.unsubscribe();
             }
 
-            //Noop because not supporting realtime data right now
-            function noop(){
-            }
-
             this.handle = this.$scope.domainObject && this.telemetryHandler.handle(
                     this.$scope.domainObject,
-                    noop,
+                    this.addRealtimeData.bind(this),
                     true // Lossless
                 );
 
             this.handle.request({}).then(this.addHistoricalData.bind(this));
 
             this.setup();
-        };
-
-        /**
-         * Populates historical data on scope when it becomes available
-         * @private
-         */
-        TelemetryTableController.prototype.addHistoricalData = function () {
-            var rowData = [],
-                self = this;
-
-            this.handle.getTelemetryObjects().forEach(function (telemetryObject){
-                var series = self.handle.getSeries(telemetryObject) || {},
-                    pointCount = series.getPointCount ? series.getPointCount() : 0,
-                    i = 0;
-
-                for (; i < pointCount; i++) {
-                    rowData.push(self.table.getRowValues(telemetryObject,
-                        self.handle.makeDatum(telemetryObject, series, i)));
-                }
-            });
-
-            this.$scope.rows = rowData;
         };
 
         /**
@@ -162,7 +156,9 @@ define(
 
             if (handle) {
                 handle.promiseTelemetryObjects().then(function () {
-                    table.buildColumns(handle.getMetadata());
+                    self.$scope.headers = []
+                    self.$scope.rows = [];
+                    table.populateColumns(handle.getMetadata());
 
                     self.filterColumns();
 
@@ -177,25 +173,13 @@ define(
         };
 
         /**
-         * @private
-         * @param object The object for which data is available (table may
-         * be composed of multiple objects)
-         * @param datum The data received from the telemetry source
-         */
-        TelemetryTableController.prototype.updateRows = function (object, datum) {
-            this.$scope.rows.push(this.table.getRowValues(object, datum));
-        };
-
-        /**
          * When column configuration changes, update the visible headers
          * accordingly.
          * @private
          */
-        TelemetryTableController.prototype.filterColumns = function (columnConfig) {
-            if (!columnConfig){
-                columnConfig = this.table.getColumnConfiguration();
-                this.table.saveColumnConfiguration(columnConfig);
-            }
+        TelemetryTableController.prototype.filterColumns = function () {
+            var columnConfig = this.table.buildColumnConfiguration();
+
             //Populate headers with visible columns (determined by configuration)
             this.$scope.headers = Object.keys(columnConfig).filter(function (column) {
                 return columnConfig[column];

--- a/platform/features/table/src/directives/MCTTable.js
+++ b/platform/features/table/src/directives/MCTTable.js
@@ -12,6 +12,51 @@ define(
          * Defines a generic 'Table' component. The table can be populated
          * en-masse by setting the rows attribute, or rows can be added as
          * needed via a broadcast 'addRow' event.
+         *
+         * This directive accepts parameters specifying header and row
+         * content, as well as some additional options.
+         *
+         * Two broadcast events for notifying the table that the rows have
+         * changed. For performance reasons, the table does not monitor the
+         * content of `rows` constantly.
+         * - 'add:row': A $broadcast event that will notify the table that
+         * a new row has been added to the table.
+         * eg.
+         * <pre><code>
+         * $scope.rows.push(newRow);
+         * $scope.$broadcast('add:row', $scope.rows.length-1);
+         * </code></pre>
+         * The code above adds a new row, and alerts the table using the
+         * add:row event. Sorting and filtering will be applied
+         * automatically by the table component.
+         *
+         * - 'remove:row': A $broadcast event that will notify the table that a
+         * row should be removed from the table.
+         * eg.
+         * <pre><code>
+         * $scope.rows.slice(5, 1);
+         * $scope.$broadcast('remove:row', 5);
+         * </code></pre>
+         * The code above removes a row from the rows array, and then alerts
+         * the table to its removal.
+         *
+         * @memberof platform/features/table
+         * @param {string[]} headers The column titles to appear at the top
+         * of the table. Corresponding values are specified in the rows
+         * using the header title provided here.
+         * @param {Object[]} rows The row content. Each row is an object
+         * with key-value pairs where the key corresponds to a header
+         * specified in the headers parameter.
+         * @param {boolean} enableFilter If true, values will be searchable
+         * and results filtered
+         * @param {boolean} enableSort If true, sorting will be enabled
+         * allowing sorting by clicking on column headers
+         * @param {boolean} autoScroll If true, table will automatically
+         * scroll to the bottom as new data arrives. Auto-scroll can be
+         * disengaged manually by scrolling away from the bottom of the
+         * table, and can also be enabled manually by scrolling to the bottom of
+         * the table rows.
+         *
          * @constructor
          */
         function MCTTable($timeout) {

--- a/platform/features/table/test/TableConfigurationSpec.js
+++ b/platform/features/table/test/TableConfigurationSpec.js
@@ -116,10 +116,10 @@ define(
                 }];
 
                 beforeEach(function() {
-                    table.buildColumns(metadata);
+                    table.populateColumns(metadata);
                 });
 
-                it("populates the columns attribute", function() {
+                it("populates columns", function() {
                     expect(table.columns.length).toBe(5);
                 });
 
@@ -141,7 +141,7 @@ define(
 
                 it("Provides a default configuration with all columns" +
                     " visible", function() {
-                    var configuration = table.getColumnConfiguration();
+                    var configuration = table.buildColumnConfiguration();
 
                     expect(configuration).toBeDefined();
                     expect(Object.keys(configuration).every(function(key){
@@ -160,7 +160,7 @@ define(
                     };
                     mockModel.configuration = modelConfig;
 
-                    tableConfig = table.getColumnConfiguration();
+                    tableConfig = table.buildColumnConfiguration();
 
                     expect(tableConfig).toBeDefined();
                     expect(tableConfig['Range 1']).toBe(false);
@@ -191,6 +191,9 @@ define(
                         expect(mockTelemetryFormatter.formatRangeValue).toHaveBeenCalled();
                     });
                 });
+                /**
+                 * TODO: Add test for saving column config
+                 */
             });
         });
     }

--- a/platform/features/table/test/controllers/HistoricalTableControllerSpec.js
+++ b/platform/features/table/test/controllers/HistoricalTableControllerSpec.js
@@ -23,7 +23,7 @@
 
 define(
     [
-        "../../src/controllers/TelemetryTableController"
+        "../../src/controllers/HistoricalTableController"
     ],
     function (TableController) {
         "use strict";
@@ -73,14 +73,14 @@ define(
 
                 mockTable = jasmine.createSpyObj('table',
                     [
-                        'buildColumns',
-                        'getColumnConfiguration',
+                        'populateColumns',
+                        'buildColumnConfiguration',
                         'getRowValues',
                         'saveColumnConfiguration'
                     ]
                 );
                 mockTable.columns = [];
-                mockTable.getColumnConfiguration.andReturn(mockConfiguration);
+                mockTable.buildColumnConfiguration.andReturn(mockConfiguration);
 
                 mockDomainObject= jasmine.createSpyObj('domainObject', [
                     'getCapability',
@@ -126,21 +126,18 @@ define(
                 expect(mockTelemetryHandle.unsubscribe).toHaveBeenCalled();
             });
 
-            describe('the controller makes use of the table', function () {
+            describe('makes use of the table', function () {
 
                 it('to create column definitions from telemetry' +
                     ' metadata', function () {
                     controller.setup();
-                    expect(mockTable.buildColumns).toHaveBeenCalled();
+                    expect(mockTable.populateColumns).toHaveBeenCalled();
                 });
 
                 it('to create column configuration, which is written to the' +
                     ' object model', function () {
-                    var mockModel = {};
-
                     controller.setup();
-                    expect(mockTable.getColumnConfiguration).toHaveBeenCalled();
-                    expect(mockTable.saveColumnConfiguration).toHaveBeenCalled();
+                    expect(mockTable.buildColumnConfiguration).toHaveBeenCalled();
                 });
             });
 

--- a/platform/features/table/test/controllers/MCTTableControllerSpec.js
+++ b/platform/features/table/test/controllers/MCTTableControllerSpec.js
@@ -58,15 +58,18 @@ define(
 
                 mockElement = jasmine.createSpyObj('element', [
                     'find',
+                    'prop',
                     'on'
                 ]);
                 mockElement.find.andReturn(mockElement);
+                mockElement.prop.andReturn(0);
 
                 mockScope.displayHeaders = true;
                 mockTimeout = jasmine.createSpy('$timeout');
                 mockTimeout.andReturn(promise(undefined));
 
                 controller = new MCTTableController(mockScope, mockTimeout, mockElement);
+                spyOn(controller, 'setVisibleRows');
             });
 
             it('Reacts to changes to filters, headers, and rows', function() {
@@ -138,8 +141,6 @@ define(
                     var removeRowFunc = mockScope.$on.calls[mockScope.$on.calls.length-1].args[1];
                     controller.updateRows(testRows);
                     expect(mockScope.displayRows.length).toBe(3);
-                    spyOn(controller, 'setVisibleRows');
-                    //controller.setVisibleRows.andReturn(undefined);
                     removeRowFunc(undefined, 2);
                     expect(mockScope.displayRows.length).toBe(2);
                     expect(controller.setVisibleRows).toHaveBeenCalled();
@@ -264,6 +265,25 @@ define(
                             mockScope.rows.push(row6);
                             controller.newRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[4].col2.text).toEqual('ggg');
+                        });
+
+                        it('Resizes columns if length of any columns in new' +
+                            ' row exceeds corresponding existing column', function() {
+                            var row7 = {
+                                'col1': {'text': 'row6 col1'},
+                                'col2': {'text': 'some longer string'},
+                                'col3': {'text': 'row6 col3'}
+                            };
+
+                            mockScope.sortColumn = undefined;
+                            mockScope.sortDirection = undefined;
+                            mockScope.filters = {};
+
+                            mockScope.displayRows = testRows.slice(0);
+
+                            mockScope.rows.push(row7);
+                            controller.newRow(undefined, mockScope.rows.length-1);
+                            expect(controller.$scope.sizingRow.col2).toEqual({text: 'some longer string'});
                         });
 
                     });

--- a/platform/features/table/test/controllers/MCTTableControllerSpec.js
+++ b/platform/features/table/test/controllers/MCTTableControllerSpec.js
@@ -118,7 +118,7 @@ define(
                 });
 
                 it('Sets rows on scope when rows change', function() {
-                    controller.updateRows(testRows);
+                    controller.setRows(testRows);
                     expect(mockScope.displayRows.length).toBe(3);
                     expect(mockScope.displayRows).toEqual(testRows);
                 });
@@ -130,7 +130,7 @@ define(
                             'col2': {'text': 'ghi'},
                             'col3': {'text': 'row3 col3'}
                         };
-                    controller.updateRows(testRows);
+                    controller.setRows(testRows);
                     expect(mockScope.displayRows.length).toBe(3);
                     testRows.push(row4);
                     addRowFunc(undefined, 3);
@@ -139,7 +139,7 @@ define(
 
                 it('Supports removing rows individually', function() {
                     var removeRowFunc = mockScope.$on.calls[mockScope.$on.calls.length-1].args[1];
-                    controller.updateRows(testRows);
+                    controller.setRows(testRows);
                     expect(mockScope.displayRows.length).toBe(3);
                     removeRowFunc(undefined, 2);
                     expect(mockScope.displayRows.length).toBe(2);
@@ -211,20 +211,20 @@ define(
                             mockScope.displayRows = controller.sortRows(testRows.slice(0));
 
                             mockScope.rows.push(row4);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[0].col2.text).toEqual('xyz');
 
                             mockScope.rows.push(row5);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[4].col2.text).toEqual('aaa');
 
                             mockScope.rows.push(row6);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[2].col2.text).toEqual('ggg');
 
                             //Add a duplicate row
                             mockScope.rows.push(row6);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[2].col2.text).toEqual('ggg');
                             expect(mockScope.displayRows[3].col2.text).toEqual('ggg');
                         });
@@ -240,12 +240,12 @@ define(
                             mockScope.displayRows = controller.filterRows(testRows);
 
                             mockScope.rows.push(row5);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows.length).toBe(2);
                             expect(mockScope.displayRows[1].col2.text).toEqual('aaa');
 
                             mockScope.rows.push(row6);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows.length).toBe(2);
                             //Row was not added because does not match filter
                         });
@@ -259,11 +259,11 @@ define(
                             mockScope.displayRows = testRows.slice(0);
 
                             mockScope.rows.push(row5);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[3].col2.text).toEqual('aaa');
 
                             mockScope.rows.push(row6);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(mockScope.displayRows[4].col2.text).toEqual('ggg');
                         });
 
@@ -282,7 +282,7 @@ define(
                             mockScope.displayRows = testRows.slice(0);
 
                             mockScope.rows.push(row7);
-                            controller.newRow(undefined, mockScope.rows.length-1);
+                            controller.addRow(undefined, mockScope.rows.length-1);
                             expect(controller.$scope.sizingRow.col2).toEqual({text: 'some longer string'});
                         });
 

--- a/platform/features/table/test/controllers/RealtimeTableControllerSpec.js
+++ b/platform/features/table/test/controllers/RealtimeTableControllerSpec.js
@@ -23,7 +23,7 @@
 
 define(
     [
-        "../../src/controllers/RTTelemetryTableController"
+        "../../src/controllers/RealtimeTableController"
     ],
     function (TableController) {
         "use strict";
@@ -77,14 +77,14 @@ define(
 
                 mockTable = jasmine.createSpyObj('table',
                     [
-                        'buildColumns',
-                        'getColumnConfiguration',
+                        'populateColumns',
+                        'buildColumnConfiguration',
                         'getRowValues',
                         'saveColumnConfiguration'
                     ]
                 );
                 mockTable.columns = [];
-                mockTable.getColumnConfiguration.andReturn(mockConfiguration);
+                mockTable.buildColumnConfiguration.andReturn(mockConfiguration);
                 mockTable.getRowValues.andReturn(mockTableRow);
 
                 mockDomainObject= jasmine.createSpyObj('domainObject', [
@@ -107,13 +107,16 @@ define(
                     'unsubscribe',
                     'getDatum',
                     'promiseTelemetryObjects',
-                    'getTelemetryObjects'
+                    'getTelemetryObjects',
+                    'request'
                 ]);
+
                 // Arbitrary array with non-zero length, contents are not
                 // used by mocks
                 mockTelemetryHandle.getTelemetryObjects.andReturn([{}]);
                 mockTelemetryHandle.promiseTelemetryObjects.andReturn(promise(undefined));
                 mockTelemetryHandle.getDatum.andReturn({});
+                mockTelemetryHandle.request.andReturn(promise(undefined));
 
                 mockTelemetryHandler = jasmine.createSpyObj('telemetryHandler', [
                     'handle'

--- a/platform/features/table/test/controllers/TableOptionsControllerSpec.js
+++ b/platform/features/table/test/controllers/TableOptionsControllerSpec.js
@@ -63,6 +63,18 @@ define(
                 controller = new TableOptionsController(mockScope);
             });
 
+            it('Listens for changing domain object', function() {
+                expect(mockScope.$watch).toHaveBeenCalledWith('domainObject', jasmine.any(Function));
+            });
+
+            it('On destruction of controller, destroys listeners', function() {
+                var unlistenFunc = jasmine.createSpy("unlisten");
+                controller.listeners.push(unlistenFunc);
+                expect(mockScope.$on).toHaveBeenCalledWith('$destroy', jasmine.any(Function));
+                mockScope.$on.mostRecentCall.args[1]();
+                expect(unlistenFunc).toHaveBeenCalled();
+            });
+
             it('Registers a listener for mutation events on the object', function() {
                 mockScope.$watch.mostRecentCall.args[1](mockDomainObject);
                 expect(mockCapability.listen).toHaveBeenCalled();

--- a/platform/features/table/test/controllers/TableOptionsControllerSpec.js
+++ b/platform/features/table/test/controllers/TableOptionsControllerSpec.js
@@ -47,11 +47,16 @@ define(
                     'listen'
                 ]);
                 mockDomainObject = jasmine.createSpyObj('domainObject', [
-                   'getCapability'
+                   'getCapability',
+                   'getModel'
                 ]);
                 mockDomainObject.getCapability.andReturn(mockCapability);
+                mockDomainObject.getModel.andReturn({});
+
                 mockScope = jasmine.createSpyObj('scope', [
-                    '$watchCollection'
+                    '$watchCollection',
+                    '$watch',
+                    '$on'
                 ]);
                 mockScope.domainObject = mockDomainObject;
 
@@ -59,6 +64,7 @@ define(
             });
 
             it('Registers a listener for mutation events on the object', function() {
+                mockScope.$watch.mostRecentCall.args[1](mockDomainObject);
                 expect(mockCapability.listen).toHaveBeenCalled();
             });
 


### PR DESCRIPTION
Branch based on #798 so includes resizing code from there.

### Changes
* Renamed some functions to make their purpose clearer. Also refactored where functions were mixing responsibilities (eg setElemetSizes was also setting rows)
* Addressed code review issues from #796
* Addressed need to 'set' rows before 'adding' rows. Realtime tables no longer set rows, instead using the 'add' path only.
* Reorganized Historical and Real-time controllers
* Documented MctTable directive as per #803