### PR TITLE
[Control] Color input shows selected color

### DIFF
--- a/platform/forms/res/templates/controls/color.html
+++ b/platform/forms/res/templates/controls/color.html
@@ -27,6 +27,14 @@
     <span class="l-click-area" ng-click="toggle.toggle()"></span>
 
     <span class="ui-symbol icon">{{structure.glyph}}</span>
+    <span ng-style="{
+             background: ngModel[field],
+             display: 'inline-block',
+             height: '11px',
+             width: '11px',
+         }"
+         ng-show="ngModel[field]">
+    </span>
     <span class="title-label" ng-if="structure.text">
         {{structure.text}}
     </span>


### PR DESCRIPTION
Small tweak to template for color control: Update color input to show selected color when picker is not visible:

before:
![screen shot 2016-04-04 at 1 32 43 pm](https://cloud.githubusercontent.com/assets/226503/14294594/c48d2336-fb26-11e5-9889-9d2f33226dc0.png)

after:
![screen shot 2016-04-05 at 12 05 43 pm](https://cloud.githubusercontent.com/assets/226503/14294646/ef00bba0-fb26-11e5-9fbc-354a9754ce35.png)

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N (html only change)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y