### PR TITLE
[Build] Fix build on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,8 @@ gulp.task('stylesheets', function () {
         .pipe(sourcemaps.init())
         .pipe(sass(options.sass).on('error', sass.logError))
         .pipe(rename(function (file) {
-            file.dirname = file.dirname.replace('/sass', '/css');
+            file.dirname =
+                file.dirname.replace(path.sep + 'sass', path.sep + 'css');
             return file;
         }))
         .pipe(sourcemaps.write('.'))

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdoc": "jsdoc -c jsdoc.json -r -d target/docs/api",
     "otherdoc": "node docs/gendocs.js --in docs/src --out target/docs --suppress-toc 'docs/src/index.md|docs/src/process/index.md'",
     "docs": "npm run jsdoc ; npm run otherdoc",
-    "prepublish": "./node_modules/bower/bin/bower install && ./node_modules/gulp/bin/gulp.js install"
+    "prepublish": "node ./node_modules/bower/bin/bower install && node ./node_modules/gulp/bin/gulp.js install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary of changes:

* In the prepublish step, run bower and gulp via node, instead of
  relying on shebang interpretation. (Forward-slash path separators
  appear to get normalized by node itself before executing the scripts.)
* In the gulp build, replace hard-coded *nix-style separators with
  path.sep; this allows stylesheets to be output to expected locations
  when building on Windows.

Addresses #827.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N &ast;
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

&ast; Changes are to build only, out of scope for unit testing