### PR TITLE
[Edit Mode] #794 Modified policy to show remove action in context for non-editable domain object types

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -207,7 +207,7 @@ define([
                 {
                     "category": "action",
                     "implementation": EditContextualActionPolicy,
-                    "depends": ["navigationService"]
+                    "depends": ["navigationService", "editModeBlacklist", "nonEditContextBlacklist"]
                 },
                 {
                     "category": "action",
@@ -273,6 +273,16 @@ define([
                 },
                 {
                     "implementation": EditToolbarRepresenter
+                }
+            ],
+            "constants": [
+                {
+                    "key":"editModeBlacklist",
+                    "value": ["copy", "follow", "window", "link", "locate"]
+                },
+                {
+                    "key": "nonEditContextBlacklist",
+                    "value": ["copy", "follow", "properties", "move", "link", "remove", "locate"]
                 }
             ]
         }


### PR DESCRIPTION
### Changes
* Modified EditContextualActionPolicy to check whether parent of selected object is editable
* Made blacklists bundle constants to support overriding by plugins
* Added a new test for this case

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y