### PR TITLE
[Edit] Elements pool filtering displays more consistent results

### DIFF
--- a/platform/commonUI/edit/res/templates/elements.html
+++ b/platform/commonUI/edit/res/templates/elements.html
@@ -26,7 +26,7 @@
     </mct-include>
     <div class="flex-elem grows vscroll">
         <ul class="tree">
-            <li ng-repeat="containedObject in composition | filter:searchText">
+            <li ng-repeat="containedObject in composition | filter:searchElements">
                 <span class="tree-item">
                     <mct-representation
                             class="rep-object-label"

--- a/platform/commonUI/edit/src/controllers/ElementsController.js
+++ b/platform/commonUI/edit/src/controllers/ElementsController.js
@@ -19,12 +19,10 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/*global define,Promise*/
 
 define(
     [],
     function () {
-        "use strict";
 
         /**
          * The ElementsController prepares the elements view for display

--- a/platform/commonUI/edit/src/controllers/ElementsController.js
+++ b/platform/commonUI/edit/src/controllers/ElementsController.js
@@ -39,7 +39,18 @@ define(
                     $scope.searchText = text;
                 }
             }
+
+            function searchElements(value) {
+                if ($scope.searchText) {
+                    return value.getModel().name.toLowerCase().search(
+                            $scope.searchText.toLowerCase()) !== -1;
+                } else {
+                    return true;
+                }
+            }
+
             $scope.filterBy = filterBy;
+            $scope.searchElements = searchElements;
         }
 
         return ElementsController;

--- a/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
+++ b/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
@@ -1,0 +1,68 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,describe,it,expect,beforeEach,jasmine*/
+
+define(
+    ["../../src/controllers/ElementsController"],
+    function (ElementsController) {
+        "use strict";
+
+        describe("The Elements Pane controller", function () {
+            var mockScope,
+                controller;
+
+            beforeEach(function () {
+                mockScope = jasmine.createSpy("$scope");
+                controller = new ElementsController(mockScope);
+            });
+
+            it("filters objects in elements pool based on input text and" +
+                " object name", function () {
+                var objects = [
+                    {
+                        getModel: getModel({name: "first element"})
+                    },
+                    {
+                        getModel: getModel({name: "second element"})
+                    },
+                    {
+                        getModel: getModel({name: "third element"})
+                    },
+                    {
+                        getModel: getModel({name: "THIRD Element 1"})
+                    }
+
+                ];
+                function getModel (model) {
+                    return function() {
+                        return model;
+                    };
+                }
+                mockScope.filterBy("third element");
+                expect(objects.filter(mockScope.searchElements).length).toBe(2);
+                mockScope.filterBy("element");
+                expect(objects.filter(mockScope.searchElements).length).toBe(4);
+            });
+
+        });
+    }
+);

--- a/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
+++ b/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
@@ -19,12 +19,11 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/*global define,describe,it,expect,beforeEach,jasmine*/
+/*global describe,it,expect,beforeEach,jasmine*/
 
 define(
     ["../../src/controllers/ElementsController"],
     function (ElementsController) {
-        "use strict";
 
         describe("The Elements Pane controller", function () {
             var mockScope,
@@ -34,6 +33,12 @@ define(
                 mockScope = jasmine.createSpy("$scope");
                 controller = new ElementsController(mockScope);
             });
+
+            function getModel (model) {
+                return function() {
+                    return model;
+                };
+            }
 
             it("filters objects in elements pool based on input text and" +
                 " object name", function () {
@@ -50,13 +55,8 @@ define(
                     {
                         getModel: getModel({name: "THIRD Element 1"})
                     }
-
                 ];
-                function getModel (model) {
-                    return function() {
-                        return model;
-                    };
-                }
+
                 mockScope.filterBy("third element");
                 expect(objects.filter(mockScope.searchElements).length).toBe(2);
                 mockScope.filterBy("element");


### PR DESCRIPTION
Addresses #663 

### Changes:
* Have limited the search to object names. Was using Angular's default search filter - unless a property is specified this filter does a deep search on all property values, so it may have been matching on other object attributes, causing the strange results.

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y