### PR TITLE
Review and integrate open836: context arrows on Layout frames while editing

### DIFF
--- a/platform/commonUI/general/res/sass/user-environ/_frame.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_frame.scss
@@ -36,6 +36,8 @@
 		line-height: $ohH;
         .left {
             padding-right: $interiorMarginLg;
+
+            z-index: 5;
         }
 	}
 	>.object-holder.abs {


### PR DESCRIPTION
z-index added to .object-top-bar .left element to allow context arrow to display on hover in frames while editing. #836

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y