### PR TITLE
Fix naming of 'Edit Display Layout Example'

### DIFF
--- a/demo/src/DemoInitializer.js
+++ b/demo/src/DemoInitializer.js
@@ -131,7 +131,7 @@ define(
                         },
                         {
                             title: "Select Object to Edit",
-                            content: "Expand the 'Examples' folder and click on the 'Layout Edit Example' object.",
+                            content: "Expand the 'Examples' folder and click on the 'Edit Display Layout Example' object.",
                             target: "mct-tree ul.tree",
                             placement: "right",
                             yOffset: "20px"


### PR DESCRIPTION
open #858
- Mismatch between named example layout and
reference in Hopscotch tour fixed.

@akhenry Sorry, had to fix a mismatched naming between my example layout and how it's referred to in the Hopscotch tour.

### Author Checklist

Changes address original issue? Y
Unit tests included and/or updated with changes? N
Command line build passes? Hope so
Changes have been smoke-tested? Y