### PR TITLE
Review and integrate open871

### DIFF
--- a/platform/commonUI/general/res/sass/_global.scss
+++ b/platform/commonUI/general/res/sass/_global.scss
@@ -84,7 +84,11 @@ p {
 	margin-bottom: $interiorMarginLg;
 }
 
-ol, ul { padding-left: 0; }
+ol, ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
 
 mct-container {
 	display: block;


### PR DESCRIPTION
#871, #869

Cherry-picked from live_demo869. Removed bullets and set margin in ol, ul. Fixes bullets showing up and row margin problems in datetime picker, and anywhere else we will use the ul/li structure for non-textual content.

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N, N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y