### PR TITLE
[Table] Fix headers in firefox

### DIFF
--- a/platform/features/table/res/sass/table.scss
+++ b/platform/features/table/res/sass/table.scss
@@ -34,17 +34,28 @@
 }
 .mct-table {
     table-layout: fixed;
-    th {
-        box-sizing: border-box;
+    thead {
+        display: block;
+        tr {
+            display: block;
+            white-space: nowrap;
+            th {
+                display: inline-block;
+                box-sizing: border-box;
+            }
+        }
     }
     tbody {
         tr {
             position: absolute;
+            white-space: nowrap;
+            display: block;
         }
         td {
             white-space: nowrap;
             overflow: hidden;
             box-sizing: border-box;
+            display: inline-block;
         }
     }
 }


### PR DESCRIPTION
Don't use table-cell displays for cells, resolves issues with zero-sized
tbody causing thead to be 100% of table size.

Fixes https://github.com/nasa/openmct/issues/809

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N (Style only change)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

Assigning to @akhenry for review and integrate.