### PR TITLE
add shortcut for see the app quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ installed and then run the following commands:
 
 Documentation will be generated in `target/docs`.
 
+### Run the app
+
+Please see [tutorial](https://github.com/nasa/openmct/blob/master/docs/src/tutorials/index.md)
+
 # Glossary
 
 Certain terms are used throughout Open MCT with consistent meanings


### PR DESCRIPTION
It's good to bring people to see OpenMCT up and run on their local machine quickly and they don't need to search deep down in repository at the first time like I do. If developers can run this app after found this repository faster without searching down the repository's folder, they more tend to use it. 