### PR TITLE
[Build] Use Circle's heroku integration for deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,8 @@
 deployment:
   production:
     branch: master
-    commands:
-      - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master
+    heroku:
+      appname: openmctweb-demo
   openmct-demo:
     branch: live_demo
     heroku:


### PR DESCRIPTION
Use circle's heroku integration to deploy to ensure that we deploy
a full clone of the repo and not a shallow clone, prevents build
failure in master branch.

Resolves the build failures we are currently seeing in master.

# Author Checklist

1. Changes address original issue? Y (this ticket)
2. Unit tests included and/or updated with changes?  N/A, build only change
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

