### PR TITLE
[Table] Remove length check when updating visible rows

### DIFF
--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -165,17 +165,8 @@ define(
 
             //No need to scroll
             if (this.$scope.displayRows.length < this.maxDisplayRows) {
-                //Check whether need to resynchronize visible with display
-                // rows (if data added)
-                if (this.$scope.visibleRows.length !==
-                    this.$scope.displayRows.length){
-                    start = 0;
-                    end = this.$scope.displayRows.length;
-                } else {
-                    //Data is in sync, and no need to calculate scroll,
-                    // so do nothing.
-                    return;
-                }
+                start = 0;
+                end = this.$scope.displayRows.length;
             } else {
                 //rows has exceeded display maximum, so may be necessary to
                 // scroll

--- a/platform/features/table/test/controllers/MCTTableControllerSpec.js
+++ b/platform/features/table/test/controllers/MCTTableControllerSpec.js
@@ -61,13 +61,18 @@ define(
                 ]);
                 mockElement.find.andReturn(mockElement);
                 mockElement.prop.andReturn(0);
+                mockElement[0] = {
+                    scrollTop: 0,
+                    scrollHeight: 500,
+                    offsetHeight: 1000
+                };
 
                 mockScope.displayHeaders = true;
                 mockTimeout = jasmine.createSpy('$timeout');
                 mockTimeout.andReturn(promise(undefined));
 
                 controller = new MCTTableController(mockScope, mockTimeout, mockElement);
-                spyOn(controller, 'setVisibleRows');
+                spyOn(controller, 'setVisibleRows').andCallThrough();
             });
 
             it('Reacts to changes to filters, headers, and rows', function() {
@@ -176,6 +181,16 @@ define(
                         expect(sortedRows[0].col2.text).toEqual('ghi');
                         expect(sortedRows[1].col2.text).toEqual('def');
                         expect(sortedRows[2].col2.text).toEqual('abc');
+                    });
+
+                    // https://github.com/nasa/openmct/issues/910
+                    it('updates visible rows in scope', function () {
+                        var oldRows;
+                        mockScope.rows = testRows;
+                        controller.setRows(testRows);
+                        oldRows = mockScope.visibleRows;
+                        mockScope.toggleSort('col2');
+                        expect(mockScope.visibleRows).not.toEqual(oldRows);
                     });
 
                     it('correctly sorts rows of differing types', function () {


### PR DESCRIPTION
While the number of visible rows may not have changed, their contents may have; returning early here results in #910.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y