### PR TITLE
Review and integrate open909: fix for Timeline Resource Graph labels

### DIFF
--- a/platform/features/timeline/res/sass/_timelines.scss
+++ b/platform/features/timeline/res/sass/_timelines.scss
@@ -158,9 +158,13 @@
 		            top: 20px; bottom: 5px;
 		            .l-labels-holder {
 			            @include absPosDefault();
+                        @include justify-content(space-between);
 			            left: $m;
-			            .tick-label.tick-label-y {
-				            text-align: left;
+			            .t-resource-graph-tick-label {
+                            font-size: 0.9em;
+                            &.tick-label-y {
+                                text-align: left;
+                            }
 			            }
 		            }
 	            }

--- a/platform/features/timeline/res/templates/resource-graph-labels.html
+++ b/platform/features/timeline/res/templates/resource-graph-labels.html
@@ -23,14 +23,14 @@
     {{parameters.title}}
 </div>
 <div class="l-graph-area">
-	<div class="l-labels-holder">
-		<div class="tick-label tick-label-y tick-label-1" style="top: 0;">
+	<div class="l-labels-holder l-flex-col">
+		<div class="t-resource-graph-tick-label tick-label-y flex-elem">
             {{parameters.high}}
         </div>
-		<div class="tick-label tick-label-y" style="top: 50%; margin-top: -0.5em; height: 1em;">
+		<div class="t-resource-graph-tick-label tick-label-y flex-elem">
             {{parameters.middle}}
         </div>
-		<div class="tick-label tick-label-y" style="top: auto; bottom: 4px; height: 1em;">
+		<div class="t-resource-graph-tick-label tick-label-y flex-elem">
             {{parameters.low}}
         </div>
 	</div>


### PR DESCRIPTION
[Frontend] Modified .tick-labels in Timelines
open #909
- Changed markup to not use plot's .tick-label class
- Changed CSS accordingly
- Fixed alignment (clipped bottom value) by refactoring to use flex-box layout for tick labels

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y