### PR TITLE
R&I open929: Label context arrow always visible; frame dragging in label area

### DIFF
--- a/platform/commonUI/browse/res/templates/browse/object-header.html
+++ b/platform/commonUI/browse/res/templates/browse/object-header.html
@@ -26,5 +26,5 @@
     <mct-representation
         key="'menu-arrow'"
         mct-object='domainObject'
-        class="flex-elem"></mct-representation>
+        class="flex-elem context-available-w"></mct-representation>
 </span>

--- a/platform/commonUI/general/res/sass/controls/_controls.scss
+++ b/platform/commonUI/general/res/sass/controls/_controls.scss
@@ -279,21 +279,13 @@ input[type="search"] {
         padding-right: 0.35em; // For context arrow. Done with em's so pad is relative to the scale of the text.
     }
 
+    .context-available-w {
+        z-index: 5;
+    }
+
     .context-available {
         font-size: 0.7em;
-        @include webkitProp(flex, '0 0 1');
-    }
-}
-
-body.desktop .object-header {
-    .context-available {
-        @include trans-prop-nice(opacity, 0.25s);
-        opacity: 0;
-    }
-    &:hover {
-        .context-available {
-            opacity: 1;
-        }
+        @include flex(0 0 1);
     }
 }
 

--- a/platform/commonUI/general/res/sass/user-environ/_frame.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_frame.scss
@@ -36,8 +36,6 @@
 		line-height: $ohH;
         .left {
             padding-right: $interiorMarginLg;
-
-            z-index: 5;
         }
 	}
 	>.object-holder.abs {


### PR DESCRIPTION
open #929 
* Label context arrows now always visible;
* Also enabled frame dragging in title/label area when editing in Display Layout;
* CSS and markup changes;

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y