### PR TITLE
[Website] #901 Automate build process

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -22,13 +22,14 @@
 #* at runtime from the About dialog for additional information.
 #*****************************************************************************
 
-# Script to build and deploy docs to github pages.
+# Script to build and deploy docs.
 
 OUTPUT_DIRECTORY="target/docs"
+# Docs, once built, are pushed to the private website repo
 REPOSITORY_URL="git@github.com:nasa/openmct-website.git"
 WEBSITE_DIRECTORY="website"
 
-BUILD_SHA=`git rev-parse head`
+BUILD_SHA=`git rev-parse HEAD`
 
 # A remote will be created for the git repository we are pushing to.
 # Don't worry, as this entire directory will get trashed inbetween builds.
@@ -55,6 +56,7 @@ git config user.name "BuildBot"
 
 echo "git add ."
 git add .
-echo "git commit -m \"Docs updated from build build $BUILD_SHA\""
-git commit -m "Docs updated from build build $BUILD_SHA"
+echo "git commit -m \"Docs updated from build $BUILD_SHA\""
+git commit -m "Docs updated from build $BUILD_SHA"
+# Push to the website repo
 git push

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -57,3 +57,4 @@ echo "git add ."
 git add .
 echo "git commit -m \"Docs updated from build build $BUILD_SHA\""
 git commit -m "Docs updated from build build $BUILD_SHA"
+git push

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -25,14 +25,15 @@
 # Script to build and deploy docs to github pages.
 
 OUTPUT_DIRECTORY="target/docs"
-REPOSITORY_URL="git@github.com:nasa/openmctweb.git"
+REPOSITORY_URL="git@github.com:nasa/openmct-website.git"
+WEBSITE_DIRECTORY="website"
 
 BUILD_SHA=`git rev-parse head`
 
 # A remote will be created for the git repository we are pushing to.
 # Don't worry, as this entire directory will get trashed inbetween builds.
 REMOTE_NAME="documentation"
-WEBSITE_BRANCH="gh-pages"
+WEBSITE_BRANCH="master"
 
 # Clean output directory, JSDOC will recreate
 if [ -d $OUTPUT_DIRECTORY ]; then
@@ -40,23 +41,21 @@ if [ -d $OUTPUT_DIRECTORY ]; then
 fi
 
 npm run docs
-cd $OUTPUT_DIRECTORY || exit 1
 
-echo "git init"
-git init
+echo "git clone $REPOSITORY_URL website"
+git clone $REPOSITORY_URL website
+echo "cp -r $OUTPUT_DIRECTORY $WEBSITE_DIRECTORY/docs"
+cp -r $OUTPUT_DIRECTORY $WEBSITE_DIRECTORY/docs
+echo "cd $WEBSITE_DIRECTORY"
+cd $WEBSITE_DIRECTORY
 
 # Configure github for CircleCI user.
 git config user.email "buildbot@circleci.com"
 git config user.name "BuildBot"
 
-echo "git remote add $REMOTE_NAME $REPOSITORY_URL"
-git remote add $REMOTE_NAME $REPOSITORY_URL
 echo "git add ."
 git add .
-echo "git commit -m \"Generate docs from build $BUILD_SHA\""
-git commit -m "Generate docs from build $BUILD_SHA"
-
-echo "git push $REMOTE_NAME HEAD:$WEBSITE_BRANCH -f"
-git push $REMOTE_NAME HEAD:$WEBSITE_BRANCH -f
-
-echo "Documentation pushed to gh-pages branch."
+echo "git commit -m \"Docs updated from build build $BUILD_SHA\""
+git commit -m "Docs updated from build build $BUILD_SHA"
+echo "git push"
+git push

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -43,11 +43,11 @@ fi
 npm run docs
 
 echo "git clone $REPOSITORY_URL website"
-git clone $REPOSITORY_URL website
+git clone $REPOSITORY_URL website || exit 1
 echo "cp -r $OUTPUT_DIRECTORY $WEBSITE_DIRECTORY/docs"
 cp -r $OUTPUT_DIRECTORY $WEBSITE_DIRECTORY/docs
 echo "cd $WEBSITE_DIRECTORY"
-cd $WEBSITE_DIRECTORY
+cd $WEBSITE_DIRECTORY || exit 1
 
 # Configure github for CircleCI user.
 git config user.email "buildbot@circleci.com"
@@ -57,5 +57,3 @@ echo "git add ."
 git add .
 echo "git commit -m \"Docs updated from build build $BUILD_SHA\""
 git commit -m "Docs updated from build build $BUILD_SHA"
-echo "git push"
-git push

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,8 @@ deployment:
     commands:
         - npm install canvas nomnoml
         - ./build-docs.sh
-    heroku:
-      appname: openmctweb-demo
+        - git fetch--unshallow
+        - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master
   openmct-demo:
     branch: live_demo
     heroku:

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,11 @@
 deployment:
   production:
     branch: master
-    heroku:
-      appname: openmctweb-demo
-  website:
-    branch: openmct-website
     commands:
         - npm install canvas nomnoml
         - ./build-docs.sh
+    heroku:
+      appname: openmctweb-demo
   openmct-demo:
     branch: live_demo
     heroku:

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,12 @@ deployment:
     branch: master
     heroku:
       appname: openmctweb-demo
+  website:
+    branch: openmct-website
+    commands:
+        - git clone
+        - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master
+
   openmct-demo:
     branch: live_demo
     heroku:

--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,8 @@ deployment:
   website:
     branch: openmct-website
     commands:
-        - git clone
-        - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master
-
+        - npm install canvas nomnoml
+        - ./build-docs.sh
   openmct-demo:
     branch: live_demo
     heroku:


### PR DESCRIPTION
New process is to push built docs to the openmct-website repo. This will in turn trigger a full website build and redeployment to gh-pages.

### Changes
1. Do not push to gh-pages
2. Clone website repo from openmct-website
3. Build docs into openmct-website
4. Soft push openmct-website
 * Step 4 will trigger a rebuild of the openmct-website repo, which will deploy to openmct/gh-pages.

I also changed the circleci deployment configuration to go back to using commands for the heroku deployment, rather than the circleci heroku support. This is due to to circle.yml not supporting both heroku and 'command' specifiers simultaneously. I did make sure to address the shallow clone issue that necessitated using the native heroku support in the first place.

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __N/A__ - build changes
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__
