### PR TITLE
[Website] Fixed failed circle.yml command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ deployment:
     commands:
         - npm install canvas nomnoml
         - ./build-docs.sh
-        - git fetch--unshallow
+        - git fetch --unshallow
         - git push git@heroku.com:openmctweb-demo.git $CIRCLE_SHA1:refs/heads/master
   openmct-demo:
     branch: live_demo


### PR DESCRIPTION
Corrects build error introduced by #939. Command in circle.yml was missing a space. 

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __N/A__ build changes only
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__