### PR TITLE
[Timeline] Persist resource graph toggles

### DIFF
--- a/platform/features/timeline/res/templates/tabular-swimlane-cols-tree.html
+++ b/platform/features/timeline/res/templates/tabular-swimlane-cols-tree.html
@@ -29,7 +29,7 @@
                }">
     <div class="l-cols">
         <span class="l-col l-col-icon l-plot-resource"
-              ng-click="ngModel.toggleGraph()"
+              ng-click="ngModel.toggleGraph(); parameters.commit()"
               title="Click to enable or disable inclusion in Resource Graphing">
             <span class="ui-symbol"
                   ng-show="ngModel.graph()"

--- a/platform/features/timeline/res/templates/timeline.html
+++ b/platform/features/timeline/res/templates/timeline.html
@@ -43,6 +43,7 @@
                     <div class="t-swimlanes-holder l-swimlanes-holder"
                          mct-scroll-y="scroll.y">
                         <mct-include key="'timeline-tabular-swimlane-cols-tree'"
+                                     parameters="{ commit: commit }"
                                      ng-repeat="swimlane in timelineController.swimlanes()"
                                      ng-model="swimlane">
                         </mct-include>

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -180,10 +180,6 @@ define(
                     // representation to store local variables into.
                     $scope.representation = {};
 
-                    // Change templates (passing in undefined to clear
-                    // if we don't have enough info to show a template.)
-                    changeTemplate(canRepresent ? representation : undefined);
-
                     // Any existing representers are no longer valid; release them.
                     destroyRepresenters();
 
@@ -230,6 +226,10 @@ define(
                         // next change object/key pair changes
                         toClear = uses.concat(['model']);
                     }
+
+                    // Change templates (passing in undefined to clear
+                    // if we don't have enough info to show a template.)
+                    changeTemplate(canRepresent ? representation : undefined);
                 }
 
                 // Update the representation when the key changes (e.g. if a

--- a/platform/representation/test/MCTRepresentationSpec.js
+++ b/platform/representation/test/MCTRepresentationSpec.js
@@ -194,6 +194,21 @@ define(
                     .toHaveBeenCalledWith(testViews[1]);
             });
 
+            it("exposes configuration before changing templates", function () {
+                var observedConfiguration;
+
+                mockChangeTemplate.andCallFake(function () {
+                    observedConfiguration = mockScope.configuration;
+                });
+
+                mockScope.key = "xyz";
+                mockScope.domainObject = mockDomainObject;
+                fireWatch('key', mockScope.key);
+                fireWatch('domainObject', mockDomainObject);
+
+                expect(observedConfiguration).toBeDefined();
+            });
+
             it("does not load templates until there is an object", function () {
                 mockScope.key = "xyz";
 


### PR DESCRIPTION
Summary of changes:

* Ensure a `configuration` object has been placed in scope before changing templates (otherwise, timeline falls back to using an empty configuration to store resource graph selection)
* Invoke `commit` when making changes from the Timeline itself (the `commit` occurs for free when making changes from the toolbar)

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y