### PR TITLE
[Build] Ignore gh-pages from circle-ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,8 @@ deployment:
 test:
   post:
     - gulp lint
+
+general:
+  branches:
+    ignore:
+      - gh-pages


### PR DESCRIPTION
Added a section to circle.yml to skip the build and test process for the gh-pages branch.