### PR TITLE
[New Edit Mode] #634 Removed edit concerns from MctRepresentation

### DIFF
--- a/platform/commonUI/regions/src/InspectorController.js
+++ b/platform/commonUI/regions/src/InspectorController.js
@@ -32,7 +32,8 @@ define(
          */
         function InspectorController($scope, policyService) {
             var domainObject = $scope.domainObject,
-                typeCapability = domainObject.getCapability('type');
+                typeCapability = domainObject.getCapability('type'),
+                statusListener;
 
             /**
              * Filters region parts to only those allowed by region policies
@@ -49,6 +50,11 @@ define(
             function setRegions() {
                 $scope.regions = filterRegions(typeCapability.getDefinition().inspector || new InspectorRegion());
             }
+
+            statusListener = domainObject.getCapability("status").listen(setRegions);
+            $scope.$on("$destroy", function () {
+                statusListener();
+            });
 
             setRegions();
         }

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -88,7 +88,6 @@ define(
                     toClear = [], // Properties to clear out of scope on change
                     counter = 0,
                     couldRepresent = false,
-                    couldEdit = false,
                     lastIdPath = [],
                     lastKey,
                     statusListener,
@@ -137,14 +136,13 @@ define(
                     });
                 }
 
-                function unchanged(canRepresent, canEdit, idPath, key) {
+                function unchanged(canRepresent, idPath, key) {
                     return (canRepresent === couldRepresent) &&
                         (key === lastKey) &&
                         (idPath.length === lastIdPath.length) &&
                         idPath.every(function (id, i) {
                             return id === lastIdPath[i];
-                        }) &&
-                        (canEdit === couldEdit);
+                        });
                 }
 
                 function getIdPath(domainObject) {
@@ -168,11 +166,10 @@ define(
                         representation = lookup($scope.key, domainObject),
                         uses = ((representation || {}).uses || []),
                         canRepresent = !!(representation && domainObject),
-                        canEdit = !!(domainObject && domainObject.hasCapability('editor') && domainObject.getCapability('editor').inEditContext()),
                         idPath = getIdPath(domainObject),
                         key = $scope.key;
 
-                    if (unchanged(canRepresent, canEdit, idPath, key)) {
+                    if (unchanged(canRepresent, idPath, key)) {
                         return;
                     }
 
@@ -201,7 +198,6 @@ define(
                     // To allow simplified change detection next time around
                     couldRepresent = canRepresent;
                     lastIdPath = idPath;
-                    couldEdit = canEdit;
                     lastKey = key;
 
                     // Populate scope with fields associated with the current
@@ -239,25 +235,6 @@ define(
                 // Also update when the represented domain object changes
                 // (to a different object)
                 $scope.$watch("domainObject", refresh);
-
-                function listenForStatusChange(object) {
-                    if (statusListener) {
-                        statusListener();
-                    }
-                    statusListener = object.getCapability("status").listen(refresh);
-                }
-
-                /**
-                 * Add a listener to the object for status changes.
-                 */
-                $scope.$watch("domainObject", function (domainObject, oldDomainObject) {
-                    if (domainObject !== oldDomainObject){
-                        listenForStatusChange(domainObject);
-                    }
-                });
-                if ($scope.domainObject) {
-                    listenForStatusChange($scope.domainObject);
-                }
 
                 // Finally, also update when there is a new version of that
                 // same domain object; these changes should be tracked in the

--- a/platform/representation/test/MCTRepresentationSpec.js
+++ b/platform/representation/test/MCTRepresentationSpec.js
@@ -253,21 +253,6 @@ define(
                 expect(mockScope.testCapability).toBeUndefined();
             });
 
-            it("registers a status change listener", function () {
-                mockScope.$watch.calls[2].args[1](mockDomainObject);
-                expect(mockStatusCapability.listen).toHaveBeenCalled();
-            });
-
-            it("unlistens for status change on scope destruction", function () {
-                var mockUnlistener = jasmine.createSpy("unlisten");
-                mockStatusCapability.listen.andReturn(mockUnlistener);
-                mockScope.$watch.calls[2].args[1](mockDomainObject);
-                expect(mockStatusCapability.listen).toHaveBeenCalled();
-
-                mockScope.$on.calls[1].args[1]();
-                expect(mockUnlistener).toHaveBeenCalled();
-            });
-
             describe("when a domain object has been observed", function () {
                 var mockContext,
                     mockContext2,


### PR DESCRIPTION
Switching into edit mode will no longer refresh all representations of an object as it previously did. A refresh will still occur of the object view, because the template changes (to an editable version of it).

### Changes

* Removed canEdit and couldEdit checks from MctRepresentation
* Removed status change listener from MctRepresentation
* Added status change listener to RegionController
* New tests

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__