### PR TITLE
[New Edit Mode] #636 Removed edit concerns from DropGesture

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -26,7 +26,7 @@ define([
     "./src/controllers/ElementsController",
     "./src/controllers/EditObjectController",
     "./src/directives/MCTBeforeUnload",
-    "./src/actions/LinkAction",
+    "./src/actions/EditAndComposeAction",
     "./src/actions/EditAction",
     "./src/actions/PropertiesAction",
     "./src/actions/RemoveAction",
@@ -55,7 +55,7 @@ define([
     ElementsController,
     EditObjectController,
     MCTBeforeUnload,
-    LinkAction,
+    EditAndComposeAction,
     EditAction,
     PropertiesAction,
     RemoveAction,
@@ -126,7 +126,7 @@ define([
             "actions": [
                 {
                     "key": "compose",
-                    "implementation": LinkAction
+                    "implementation": EditAndComposeAction
                 },
                 {
                     "key": "edit",

--- a/platform/commonUI/edit/src/actions/EditAndComposeAction.js
+++ b/platform/commonUI/edit/src/actions/EditAndComposeAction.js
@@ -31,12 +31,12 @@ define(
          * @memberof platform/commonUI/edit
          * @implements {Action}
          */
-        function LinkAction(context) {
+        function EditAndComposeAction(context) {
             this.domainObject = (context || {}).domainObject;
             this.selectedObject = (context || {}).selectedObject;
         }
 
-        LinkAction.prototype.perform = function () {
+        EditAndComposeAction.prototype.perform = function () {
             var self = this;
 
             // Persist changes to the domain object
@@ -54,9 +54,13 @@ define(
                         .then(doPersist);
             }
 
+            if (this.domainObject.getCapability('type').getKey() !== 'folder') {
+                this.domainObject.getCapability('action').perform('edit');
+            }
+
             return this.selectedObject && doLink();
         };
 
-        return LinkAction;
+        return EditAndComposeAction;
     }
 );

--- a/platform/commonUI/edit/src/actions/EditAndComposeAction.js
+++ b/platform/commonUI/edit/src/actions/EditAndComposeAction.js
@@ -37,7 +37,8 @@ define(
         }
 
         EditAndComposeAction.prototype.perform = function () {
-            var self = this;
+            var self = this,
+                editAction = this.domainObject.getCapability('action').getActions("edit")[0];
 
             // Persist changes to the domain object
             function doPersist() {
@@ -54,8 +55,8 @@ define(
                         .then(doPersist);
             }
 
-            if (this.domainObject.getCapability('type').getKey() !== 'folder') {
-                this.domainObject.getCapability('action').perform('edit');
+            if (editAction) {
+                editAction.perform();
             }
 
             return this.selectedObject && doLink();

--- a/platform/commonUI/edit/src/policies/EditActionPolicy.js
+++ b/platform/commonUI/edit/src/policies/EditActionPolicy.js
@@ -81,17 +81,14 @@ define(
             var key = action.getMetadata().key,
                 category = (context || {}).category;
 
-            // Only worry about actions in the view-control category
-            if (category === 'view-control') {
-                // Restrict 'edit' to cases where there are editable
-                // views (similarly, restrict 'properties' to when
-                // the converse is true), and where the domain object is not
-                // already being edited.
-                if (key === 'edit') {
-                    return this.countEditableViews(context) > 0 && !isEditing(context);
-                } else if (key === 'properties') {
-                    return this.countEditableViews(context) < 1 && !isEditing(context);
-                }
+            // Restrict 'edit' to cases where there are editable
+            // views (similarly, restrict 'properties' to when
+            // the converse is true), and where the domain object is not
+            // already being edited.
+            if (key === 'edit') {
+                return this.countEditableViews(context) > 0 && !isEditing(context);
+            } else if (key === 'properties' && category === 'view-control') {
+                return this.countEditableViews(context) < 1 && !isEditing(context);
             }
 
             // Like all policies, allow by default.

--- a/platform/commonUI/edit/test/actions/EditAndComposeActionSpec.js
+++ b/platform/commonUI/edit/test/actions/EditAndComposeActionSpec.js
@@ -32,6 +32,7 @@ define(
                 mockComposition,
                 mockPersistence,
                 mockActionCapability,
+                mockEditAction,
                 mockType,
                 actionContext,
                 model,
@@ -69,7 +70,8 @@ define(
                 mockComposition = jasmine.createSpyObj("composition", [ "invoke", "add" ]);
                 mockPersistence = jasmine.createSpyObj("persistence", [ "persist" ]);
                 mockType = jasmine.createSpyObj("type", [ "hasFeature", "getKey" ]);
-                mockActionCapability = jasmine.createSpyObj("actionCapability", [ "perform"]);
+                mockActionCapability = jasmine.createSpyObj("actionCapability", [ "getActions"]);
+                mockEditAction = jasmine.createSpyObj("editAction", ["perform"]);
 
                 mockDomainObject.getId.andReturn("test");
                 mockDomainObject.getCapability.andReturn(mockContext);
@@ -78,6 +80,7 @@ define(
                 mockType.getKey.andReturn("layout");
                 mockComposition.invoke.andReturn(mockPromise(true));
                 mockComposition.add.andReturn(mockPromise(true));
+                mockActionCapability.getActions.andReturn([]);
 
                 capabilities = {
                     composition: mockComposition,
@@ -109,9 +112,19 @@ define(
                 expect(mockPersistence.persist).toHaveBeenCalled();
             });
 
-            it("enables edit mode", function () {
+            it("enables edit mode for objects that have an edit action", function () {
+                mockActionCapability.getActions.andReturn([mockEditAction]);
                 action.perform();
-                expect(mockActionCapability.perform).toHaveBeenCalledWith("edit");
+                expect(mockEditAction.perform).toHaveBeenCalled();
+            });
+
+            it("Does not enable edit mode for objects that do not have an" +
+                " edit action", function () {
+                mockActionCapability.getActions.andReturn([]);
+                action.perform();
+                expect(mockEditAction.perform).not.toHaveBeenCalled();
+                expect(mockComposition.add)
+                    .toHaveBeenCalledWith(mockDomainObject);
             });
 
         });

--- a/platform/commonUI/edit/test/actions/EditAndComposeActionSpec.js
+++ b/platform/commonUI/edit/test/actions/EditAndComposeActionSpec.js
@@ -21,8 +21,8 @@
  *****************************************************************************/
 
 define(
-    ["../../src/actions/LinkAction"],
-    function (LinkAction) {
+    ["../../src/actions/EditAndComposeAction"],
+    function (EditAndComposeAction) {
 
         describe("The Link action", function () {
             var mockQ,
@@ -31,6 +31,7 @@ define(
                 mockContext,
                 mockComposition,
                 mockPersistence,
+                mockActionCapability,
                 mockType,
                 actionContext,
                 model,
@@ -67,18 +68,21 @@ define(
                 mockContext = jasmine.createSpyObj("context", [ "getParent" ]);
                 mockComposition = jasmine.createSpyObj("composition", [ "invoke", "add" ]);
                 mockPersistence = jasmine.createSpyObj("persistence", [ "persist" ]);
-                mockType = jasmine.createSpyObj("type", [ "hasFeature" ]);
+                mockType = jasmine.createSpyObj("type", [ "hasFeature", "getKey" ]);
+                mockActionCapability = jasmine.createSpyObj("actionCapability", [ "perform"]);
 
                 mockDomainObject.getId.andReturn("test");
                 mockDomainObject.getCapability.andReturn(mockContext);
                 mockContext.getParent.andReturn(mockParent);
                 mockType.hasFeature.andReturn(true);
+                mockType.getKey.andReturn("layout");
                 mockComposition.invoke.andReturn(mockPromise(true));
                 mockComposition.add.andReturn(mockPromise(true));
 
                 capabilities = {
                     composition: mockComposition,
                     persistence: mockPersistence,
+                    action: mockActionCapability,
                     type: mockType
                 };
                 model = {
@@ -90,7 +94,7 @@ define(
                     selectedObject: mockDomainObject
                 };
 
-                action = new LinkAction(actionContext);
+                action = new EditAndComposeAction(actionContext);
             });
 
 
@@ -103,6 +107,11 @@ define(
             it("persists changes afterward", function () {
                 action.perform();
                 expect(mockPersistence.persist).toHaveBeenCalled();
+            });
+
+            it("enables edit mode", function () {
+                action.perform();
+                expect(mockActionCapability.perform).toHaveBeenCalledWith("edit");
             });
 
         });

--- a/platform/commonUI/regions/src/InspectorController.js
+++ b/platform/commonUI/regions/src/InspectorController.js
@@ -32,7 +32,8 @@ define(
          */
         function InspectorController($scope, policyService) {
             var domainObject = $scope.domainObject,
-                typeCapability = domainObject.getCapability('type');
+                typeCapability = domainObject.getCapability('type'),
+                statusListener;
 
             /**
              * Filters region parts to only those allowed by region policies
@@ -49,6 +50,11 @@ define(
             function setRegions() {
                 $scope.regions = filterRegions(typeCapability.getDefinition().inspector || new InspectorRegion());
             }
+
+            statusListener = domainObject.getCapability("status").listen(setRegions);
+            $scope.$on("$destroy", function () {
+                statusListener();
+            });
 
             setRegions();
         }

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -88,7 +88,6 @@ define(
                     toClear = [], // Properties to clear out of scope on change
                     counter = 0,
                     couldRepresent = false,
-                    couldEdit = false,
                     lastIdPath = [],
                     lastKey,
                     statusListener,
@@ -137,14 +136,13 @@ define(
                     });
                 }
 
-                function unchanged(canRepresent, canEdit, idPath, key) {
+                function unchanged(canRepresent, idPath, key) {
                     return (canRepresent === couldRepresent) &&
                         (key === lastKey) &&
                         (idPath.length === lastIdPath.length) &&
                         idPath.every(function (id, i) {
                             return id === lastIdPath[i];
-                        }) &&
-                        (canEdit === couldEdit);
+                        });
                 }
 
                 function getIdPath(domainObject) {
@@ -168,11 +166,10 @@ define(
                         representation = lookup($scope.key, domainObject),
                         uses = ((representation || {}).uses || []),
                         canRepresent = !!(representation && domainObject),
-                        canEdit = !!(domainObject && domainObject.hasCapability('editor') && domainObject.getCapability('editor').inEditContext()),
                         idPath = getIdPath(domainObject),
                         key = $scope.key;
 
-                    if (unchanged(canRepresent, canEdit, idPath, key)) {
+                    if (unchanged(canRepresent, idPath, key)) {
                         return;
                     }
 
@@ -201,7 +198,6 @@ define(
                     // To allow simplified change detection next time around
                     couldRepresent = canRepresent;
                     lastIdPath = idPath;
-                    couldEdit = canEdit;
                     lastKey = key;
 
                     // Populate scope with fields associated with the current
@@ -239,25 +235,6 @@ define(
                 // Also update when the represented domain object changes
                 // (to a different object)
                 $scope.$watch("domainObject", refresh);
-
-                function listenForStatusChange(object) {
-                    if (statusListener) {
-                        statusListener();
-                    }
-                    statusListener = object.getCapability("status").listen(refresh);
-                }
-
-                /**
-                 * Add a listener to the object for status changes.
-                 */
-                $scope.$watch("domainObject", function (domainObject, oldDomainObject) {
-                    if (domainObject !== oldDomainObject){
-                        listenForStatusChange(domainObject);
-                    }
-                });
-                if ($scope.domainObject) {
-                    listenForStatusChange($scope.domainObject);
-                }
 
                 // Finally, also update when there is a new version of that
                 // same domain object; these changes should be tracked in the

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -54,9 +54,6 @@ define(
                     // ...and broadcast the event. This allows specific
                     // views to have post-drop behavior which depends on
                     // drop position.
-                    // Also broadcast the editableDomainObject to
-                    // avoid race condition against non-editable
-                    // version in EditRepresenter
                     scope.$broadcast(
                         GestureConstants.MCT_DROP_EVENT,
                         id,
@@ -93,21 +90,13 @@ define(
 
             function drop(e) {
                 var event = (e || {}).originalEvent || e,
-                    id = event.dataTransfer.getData(GestureConstants.MCT_DRAG_TYPE),
-                    domainObjectType = domainObject.getModel().type;
+                    id = event.dataTransfer.getData(GestureConstants.MCT_DRAG_TYPE);
 
                 // Handle the drop; add the dropped identifier to the
                 // destination domain object's composition, and persist
                 // the change.
                 if (id) {
                     e.preventDefault();
-
-                    //Use scope.apply, drop event is outside digest cycle
-                    scope.$apply(function () {
-                        if (domainObjectType !== 'folder') {
-                            domainObject.getCapability('action').perform('edit');
-                        }
-                    });
                     $q.when(action && action.perform()).then(function () {
                         broadcastDrop(id, event);
                     });

--- a/platform/representation/test/MCTRepresentationSpec.js
+++ b/platform/representation/test/MCTRepresentationSpec.js
@@ -253,21 +253,6 @@ define(
                 expect(mockScope.testCapability).toBeUndefined();
             });
 
-            it("registers a status change listener", function () {
-                mockScope.$watch.calls[2].args[1](mockDomainObject);
-                expect(mockStatusCapability.listen).toHaveBeenCalled();
-            });
-
-            it("unlistens for status change on scope destruction", function () {
-                var mockUnlistener = jasmine.createSpy("unlisten");
-                mockStatusCapability.listen.andReturn(mockUnlistener);
-                mockScope.$watch.calls[2].args[1](mockDomainObject);
-                expect(mockStatusCapability.listen).toHaveBeenCalled();
-
-                mockScope.$on.calls[1].args[1]();
-                expect(mockUnlistener).toHaveBeenCalled();
-            });
-
             describe("when a domain object has been observed", function () {
                 var mockContext,
                     mockContext2,


### PR DESCRIPTION
New PR supersedes previous PR #932


### Changes:
* Removed edit code from DropGesture, and moved it to LinkAction
* Renamed LinkAction to EditAndComposeAction to avoid confusion with the LinkAction in entanglement, and to reflect its slightly modified role
* Moved 'folder' logic to EditAndComposeAction. At first I implemented as two separate actions and used `appliesTo` to filter out action if it was a folder type object, but was a lot of additional LOC.
* Updated tests
* __Modified EditActionPolicy to remove check for `view-control` category when determining applicability of action with key `edit`. This was so that objects that do not support edit mode do not make an edit action available.__

### Author Checklist

1. Changes address original issue? __Y__
2. Unit tests included and/or updated with changes? __Y__
3. Command line build passes? __Y__
4. Changes have been smoke-tested? __Y__