### PR TITLE
[Mobile] Remove usage of element.scope()

### DIFF
--- a/platform/commonUI/inspect/src/gestures/InfoButtonGesture.js
+++ b/platform/commonUI/inspect/src/gestures/InfoButtonGesture.js
@@ -38,7 +38,6 @@ define(
         function InfoGestureButton($document, agentService, infoService, element, domainObject) {
             var dismissBubble,
                 touchPosition,
-                scopeOff,
                 body = $document.find('body');
 
             function trackPosition(event) {
@@ -94,10 +93,6 @@ define(
                 element.on('click', showBubble);
             }
 
-            // Also make sure we dismiss bubble if representation is destroyed
-            // before the mouse actually leaves it
-            scopeOff = element.scope().$on('$destroy', hideBubble);
-
             return {
                 /**
                  * Detach any event handlers associated with this gesture.
@@ -109,7 +104,6 @@ define(
                     hideBubble();
                     // ...and detach listeners
                     element.off('click', showBubble);
-                    scopeOff();
                 }
             };
         }

--- a/platform/commonUI/inspect/test/gestures/InfoButtonGestureSpec.js
+++ b/platform/commonUI/inspect/test/gestures/InfoButtonGestureSpec.js
@@ -137,6 +137,11 @@ define(
                 );
             });
 
+            // https://github.com/nasa/openmct/issues/948
+            it("does not try to access scope", function () {
+                expect(mockElement.scope).not.toHaveBeenCalled();
+            });
+
         });
     }
 );


### PR DESCRIPTION
Usage is unnecessary and is sensitive to initialization ordering of
representations, resulting in #948.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y