### PR TITLE
[Time Conductor] Restore missing time conductor

### DIFF
--- a/platform/features/timeline/src/controllers/TimelineController.js
+++ b/platform/features/timeline/src/controllers/TimelineController.js
@@ -97,6 +97,8 @@ define(
                 }
             }
 
+            $scope.$watch("configuration", swimlanePopulator.configure);
+
             // Recalculate swimlane state on changes
             $scope.$watch("domainObject", swimlanePopulator.populate);
 

--- a/platform/features/timeline/src/controllers/swimlane/TimelineSwimlanePopulator.js
+++ b/platform/features/timeline/src/controllers/swimlane/TimelineSwimlanePopulator.js
@@ -43,8 +43,7 @@ define(
             var swimlanes = [],
                 start = Number.POSITIVE_INFINITY,
                 end = Number.NEGATIVE_INFINITY,
-                colors = (configuration.colors || {}),
-                assigner = new TimelineColorAssigner(colors),
+                assigner,
                 lastDomainObject;
 
             // Track extremes of start/end times
@@ -152,8 +151,15 @@ define(
                 recalculateSwimlanes(lastDomainObject);
             }
 
+            function initialize() {
+                var colors = (configuration.colors || {});
+                assigner = new TimelineColorAssigner(colors);
+                configuration.colors = colors;
+                recalculateSwimlanes(lastDomainObject);
+            }
+
             // Ensure colors are exposed in configuration
-            configuration.colors = colors;
+            initialize();
 
             return {
                 /**
@@ -188,6 +194,15 @@ define(
                  */
                 end: function () {
                     return end;
+                },
+                /**
+                 * Pass a new configuration object (to retrieve and store
+                 * swimlane configuration)
+                 * @param newConfig
+                 */
+                configure: function (newConfig) {
+                    configuration = newConfig;
+                    initialize();
                 }
             };
         }

--- a/platform/features/timeline/test/controllers/TimelineControllerSpec.js
+++ b/platform/features/timeline/test/controllers/TimelineControllerSpec.js
@@ -68,6 +68,14 @@ define(
                 };
             }
 
+            function fireWatch(expr, value) {
+                mockScope.$watch.calls.forEach(function (call) {
+                    if (call.args[0] === expr) {
+                        call.args[1](value);
+                    }
+                });
+            }
+
 
             beforeEach(function () {
                 var mockA, mockB, mockUtilization, mockPromise, mockGraph, testCapabilities;
@@ -149,8 +157,7 @@ define(
             });
 
             it("repopulates when modifications are made", function () {
-                var fnWatchCall,
-                    strWatchCall;
+                var fnWatchCall;
 
                 // Find the $watch that was given a function
                 mockScope.$watch.calls.forEach(function (call) {
@@ -158,16 +165,11 @@ define(
                         // white-box: we know the first call is
                         // the one we're looking for
                         fnWatchCall = fnWatchCall || call;
-                    } else if (typeof call.args[0] === 'string') {
-                        strWatchCall = strWatchCall || call;
                     }
                 });
 
                 // Make sure string watch was for domainObject
-                expect(strWatchCall.args[0]).toEqual('domainObject');
-                // Initially populate
-                strWatchCall.args[1](mockDomainObject);
-
+                fireWatch('domainObject', mockDomainObject);
                 // There should be to swimlanes
                 expect(controller.swimlanes().length).toEqual(2);
 
@@ -189,23 +191,23 @@ define(
                 // order of $watch calls in TimelineController.
 
                 // Initially populate
-                mockScope.$watch.calls[0].args[1](mockDomainObject);
+                fireWatch('domainObject', mockDomainObject);
 
                 // Verify precondition - no graphs
                 expect(controller.graphs().length).toEqual(0);
 
                 // Execute the watch function for graph state
-                tmp = mockScope.$watch.calls[2].args[0]();
+                tmp = mockScope.$watch.calls[3].args[0]();
 
                 // Change graph state
                 testConfiguration.graph = { a: true, b: true };
 
                 // Verify that this would have triggered a watch
-                expect(mockScope.$watch.calls[2].args[0]())
+                expect(mockScope.$watch.calls[3].args[0]())
                     .not.toEqual(tmp);
 
                 // Run the function the watch would have triggered
-                mockScope.$watch.calls[2].args[1]();
+                mockScope.$watch.calls[3].args[1]();
 
                 // Should have some graphs now
                 expect(controller.graphs().length).toEqual(2);
@@ -218,7 +220,7 @@ define(
                 mockZoom.duration.andReturn(12345);
 
                 // Initially populate
-                mockScope.$watch.calls[0].args[1](mockDomainObject);
+                fireWatch('domainObject', mockDomainObject);
 
                 expect(controller.width(mockZoom)).toEqual(54321);
                 // Verify interactions; we took zoom's duration for our start/end,

--- a/platform/features/timeline/test/controllers/TimelineControllerSpec.js
+++ b/platform/features/timeline/test/controllers/TimelineControllerSpec.js
@@ -141,6 +141,13 @@ define(
                 expect(mockScope.scroll.y).toEqual(0);
             });
 
+            it("watches for a configuration object", function () {
+                expect(mockScope.$watch).toHaveBeenCalledWith(
+                    "configuration",
+                    jasmine.any(Function)
+                );
+            });
+
             it("repopulates when modifications are made", function () {
                 var fnWatchCall,
                     strWatchCall;

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -177,6 +177,10 @@ define(
                     // representation to store local variables into.
                     $scope.representation = {};
 
+                    // Change templates (passing in undefined to clear
+                    // if we don't have enough info to show a template.)
+                    changeTemplate(canRepresent ? representation : undefined);
+
                     // Any existing representers are no longer valid; release them.
                     destroyRepresenters();
 
@@ -222,10 +226,6 @@ define(
                         // next change object/key pair changes
                         toClear = uses.concat(['model']);
                     }
-
-                    // Change templates (passing in undefined to clear
-                    // if we don't have enough info to show a template.)
-                    changeTemplate(canRepresent ? representation : undefined);
                 }
 
                 // Update the representation when the key changes (e.g. if a

--- a/platform/representation/test/MCTRepresentationSpec.js
+++ b/platform/representation/test/MCTRepresentationSpec.js
@@ -194,21 +194,6 @@ define(
                     .toHaveBeenCalledWith(testViews[1]);
             });
 
-            it("exposes configuration before changing templates", function () {
-                var observedConfiguration;
-
-                mockChangeTemplate.andCallFake(function () {
-                    observedConfiguration = mockScope.configuration;
-                });
-
-                mockScope.key = "xyz";
-                mockScope.domainObject = mockDomainObject;
-                fireWatch('key', mockScope.key);
-                fireWatch('domainObject', mockDomainObject);
-
-                expect(observedConfiguration).toBeDefined();
-            });
-
             it("does not load templates until there is an object", function () {
                 mockScope.key = "xyz";
 


### PR DESCRIPTION
Addresses #957 by:

* Reverting changes to `mct-representation` ordering which triggered the issue originally
* Solving for #908 by instead watching for the `configuration` object when it is passed in

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? N &ast;
4. Changes have been smoke-tested? Y

&ast; Build has existing failures due to #952 and #956, but verification steps show no new build failures caused by these changes.
