### PR TITLE
R&I open970: hide nav-to-parent arrow when in Edit mode

### DIFF
--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -288,8 +288,9 @@ body.desktop .pane .mini-tab-icon.toggle-pane {
 
     .left {
         padding-right: $interiorMarginLg;
-        .l-back:not(.s-status-editing) {
+        .l-back {
             margin-right: $interiorMarginLg;
+            &.s-status-editing { display: none; }
         }
     }
 }


### PR DESCRIPTION
fixes #970 
Regression. 

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y

