### PR TITLE
[Tables] #972 When processing large data sets periodically yield thread

### DIFF
--- a/platform/features/table/bundle.js
+++ b/platform/features/table/bundle.js
@@ -109,7 +109,7 @@ define([
                 {
                     "key": "HistoricalTableController",
                     "implementation": HistoricalTableController,
-                    "depends": ["$scope", "telemetryHandler", "telemetryFormatter"]
+                    "depends": ["$scope", "telemetryHandler", "telemetryFormatter", "$timeout", "$q"]
                 },
                 {
                     "key": "RealtimeTableController",

--- a/platform/features/table/bundle.js
+++ b/platform/features/table/bundle.js
@@ -109,7 +109,7 @@ define([
                 {
                     "key": "HistoricalTableController",
                     "implementation": HistoricalTableController,
-                    "depends": ["$scope", "telemetryHandler", "telemetryFormatter", "$timeout", "$q"]
+                    "depends": ["$scope", "telemetryHandler", "telemetryFormatter", "$timeout"]
                 },
                 {
                     "key": "RealtimeTableController",

--- a/platform/features/table/res/templates/historical-table.html
+++ b/platform/features/table/res/templates/historical-table.html
@@ -1,4 +1,4 @@
-<div ng-controller="HistoricalTableController">
+<div ng-controller="HistoricalTableController" ng-class="{'loading': loading}">
     <mct-table
         headers="headers"
         rows="rows"

--- a/platform/features/table/src/controllers/HistoricalTableController.js
+++ b/platform/features/table/src/controllers/HistoricalTableController.js
@@ -52,18 +52,6 @@ define(
 
         HistoricalTableController.prototype = Object.create(TableController.prototype);
 
-        function fastPromise(value) {
-            if (value && value.then) {
-                return value;
-            } else {
-                return {
-                    then: function (callback) {
-                        return fastPromise(callback(value));
-                    }
-                };
-            }
-        }
-
         /**
          * Cancels outstanding processing
          * @private

--- a/platform/features/table/src/controllers/RealtimeTableController.js
+++ b/platform/features/table/src/controllers/RealtimeTableController.js
@@ -91,6 +91,7 @@ define(
                         self.$scope.rows.length - 1);
                 }
             });
+            this.$scope.loading = false;
         };
 
         return RealtimeTableController;

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -83,16 +83,24 @@ define(
          * @private
          */
         TelemetryTableController.prototype.registerChangeListeners = function () {
+            var self=this;
             this.unregisterChangeListeners();
 
             // When composition changes, re-subscribe to the various
             // telemetry subscriptions
             this.changeListeners.push(this.$scope.$watchCollection(
-                'domainObject.getModel().composition', this.subscribe.bind(this)));
+                'domainObject.getModel().composition',
+                function (newVal, oldVal) {
+                    if (newVal !== oldVal) {
+                        self.subscribe();
+                    }
+                })
+            );
 
             //Change of bounds in time conductor
             this.changeListeners.push(this.$scope.$on('telemetry:display:bounds',
-                this.subscribe.bind(this)));
+                this.subscribe.bind(this))
+            );
         };
 
         /**

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -140,6 +140,7 @@ define(
             if (this.handle) {
                 this.handle.unsubscribe();
             }
+            this.$scope.loading = true;
 
             this.handle = this.$scope.domainObject && this.telemetryHandler.handle(
                     this.$scope.domainObject,

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -83,7 +83,7 @@ define(
          * @private
          */
         TelemetryTableController.prototype.registerChangeListeners = function () {
-            var self=this;
+            var self = this;
             this.unregisterChangeListeners();
 
             // When composition changes, re-subscribe to the various


### PR DESCRIPTION
### Changes
1. Process large historical data sets in batches, using a setTimeout to allow UI and other processes processor time
1. Small change to TelemetryTableController to prevent unnecessary telemetry subscriptions due to angular watch initialization calls.
1. Loading spinner on historical tables
1. Added tests

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

