### PR TITLE
[Edit] Fixed issue with cancel action throwing an error. Fixes #979

### DIFF
--- a/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
@@ -67,10 +67,17 @@ define(
             }
 
             function onCancel() {
-                return self.persistenceCapability.refresh().then(function (result) {
+                if (self.domainObject.getModel().persisted) {
+                    //Fetch clean model from persistence
+                    return self.persistenceCapability.refresh().then(function (result) {
+                        self.persistPending = false;
+                        return result;
+                    });
+                } else {
                     self.persistPending = false;
-                    return result;
-                });
+                    //Model is undefined in persistence, so return undefined.
+                    return self.$q.when(undefined);
+                }
             }
 
             if (this.transactionService.isActive()) {

--- a/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
@@ -67,7 +67,7 @@ define(
             }
 
             function onCancel() {
-                if (self.domainObject.getModel().persisted) {
+                if (self.domainObject.getModel().persisted !== undefined) {
                     //Fetch clean model from persistence
                     return self.persistenceCapability.refresh().then(function (result) {
                         self.persistPending = false;


### PR DESCRIPTION
### Changes
1. Added an additional check in TransactionalPersistenceCapability to determine whether the object has been persisted previously, and therefore whether it can be refreshed. In the case that it cannot be refreshed, the cancel action is essentially a noop.
2. Added an additional test for this condition.


### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

