### PR TITLE
[Frontend] New message for copy in-progress dialog

### DIFF
--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -81,6 +81,7 @@ define(
             if (phase.toLowerCase() === 'preparing' && !this.dialog) {
                 this.dialog = this.dialogService.showBlockingMessage({
                     title: "Preparing to copy objects",
+                    hint: "Do not navigate away from this page or close this browser tab while this message is displayed.",
                     unknownProgress: true,
                     severity: "info"
                 });


### PR DESCRIPTION
Fixes #339. 

@akhenry @VWoeltjen @larkin  I can't manually invoke the exact dialog that is displayed when copying a large number of items. I think I've found it, and have added a hint message that wasn't there previously, but I have no clear way to test my changes. Also not sure if I've found all instances where this type of messaging would occur. Any thoughts?

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A (hopefully)
1. Command line build passes? Y
1. Changes have been smoke-tested? Y