### PR TITLE
[Timeline] Provide greater initial width

### DIFF
--- a/platform/features/timeline/src/controllers/TimelineZoomController.js
+++ b/platform/features/timeline/src/controllers/TimelineZoomController.js
@@ -122,7 +122,7 @@ define(
                  */
                 width: function (timestamp) {
                     var pixels = Math.ceil(toPixels(timestamp * (1 + PADDING)));
-                    return Math.max(bounds.width, pixels);
+                    return Math.max(bounds.width * 2, pixels);
                 }
             };
         }

--- a/platform/features/timeline/test/controllers/TimelineZoomControllerSpec.js
+++ b/platform/features/timeline/test/controllers/TimelineZoomControllerSpec.js
@@ -124,7 +124,7 @@ define(
                     var testPixel = mockScope.scroll.width / 4,
                         testMillis = controller.toMillis(testPixel);
                     expect(controller.width(testMillis))
-                        .toEqual(mockScope.scroll.width);
+                        .not.toBeLessThan(mockScope.scroll.width);
                 });
 
                 it("provides a width with some margin past timestamp", function () {


### PR DESCRIPTION
This avoids starting with a scrollable width too small for the
initial scroll position that the zoom controller selects.
Fixes #817

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y