### PR TITLE
[Timeline] Update scroll position on timeout

### DIFF
--- a/platform/features/timeline/src/controllers/TimelineZoomController.js
+++ b/platform/features/timeline/src/controllers/TimelineZoomController.js
@@ -32,8 +32,7 @@ define(
             // Prefer to start with the middle index
             var zoomLevels = ZOOM_CONFIGURATION.levels || [1000],
                 zoomIndex = Math.floor(zoomLevels.length / 2),
-                tickWidth = ZOOM_CONFIGURATION.width || 200,
-                bounds = { x: 0, width: tickWidth }; // Default duration in view
+                tickWidth = ZOOM_CONFIGURATION.width || 200;
 
             function toMillis(pixels) {
                 return (pixels / tickWidth) * zoomLevels[zoomIndex];
@@ -63,7 +62,7 @@ define(
             function initializeZoomFromTimespan(timespan) {
                 var timelineDuration = timespan.getDuration();
                 zoomIndex = 0;
-                while (toMillis(bounds.width) < timelineDuration &&
+                while (toMillis($scope.scroll.width) < timelineDuration &&
                         zoomIndex < zoomLevels.length - 1) {
                     zoomIndex += 1;
                 }
@@ -77,9 +76,6 @@ define(
                 }
             }
 
-            $scope.$watch("scroll", function (scroll) {
-                bounds = scroll;
-            });
             $scope.$watch("domainObject", initializeZoom);
 
             return {
@@ -97,8 +93,7 @@ define(
                 zoom: function (amount) {
                     // Update the zoom level if called with an argument
                     if (arguments.length > 0 && !isNaN(amount)) {
-                        //var x = achievedDesiredScroll ?
-                        //    bounds.x : desiredScroll;
+                        var bounds = $scope.scroll;
                         var center = this.toMillis(bounds.x + bounds.width / 2);
                         setZoomLevel(zoomIndex + amount);
                         setScroll(this.toPixels(center) - bounds.width / 2);
@@ -130,7 +125,7 @@ define(
                  */
                 width: function (timestamp) {
                     var pixels = Math.ceil(toPixels(timestamp * (1 + PADDING)));
-                    return Math.max(bounds.width, pixels);
+                    return Math.max($scope.scroll.width, pixels);
                 }
             };
         }

--- a/platform/features/timeline/src/controllers/TimelineZoomController.js
+++ b/platform/features/timeline/src/controllers/TimelineZoomController.js
@@ -33,8 +33,6 @@ define(
             var zoomLevels = ZOOM_CONFIGURATION.levels || [1000],
                 zoomIndex = Math.floor(zoomLevels.length / 2),
                 tickWidth = ZOOM_CONFIGURATION.width || 200,
-                desiredScroll = 0,
-                achievedDesiredScroll,
                 bounds = { x: 0, width: tickWidth }; // Default duration in view
 
             function toMillis(pixels) {
@@ -57,11 +55,8 @@ define(
             }
 
             function setScroll(x) {
-                desiredScroll = x;
-                achievedDesiredScroll = false;
                 $timeout(function () {
-                    $scope.scroll.x = desiredScroll;
-                    achievedDesiredScroll = true;
+                    $scope.scroll.x = x;
                 }, 0);
             }
 

--- a/platform/features/timeline/test/controllers/TimelineZoomControllerSpec.js
+++ b/platform/features/timeline/test/controllers/TimelineZoomControllerSpec.js
@@ -38,6 +38,7 @@ define(
                 };
                 mockScope = jasmine.createSpyObj("$scope", ['$watch']);
                 mockScope.commit = jasmine.createSpy('commit');
+                mockScope.scroll = { x: 0, width: 1000 };
                 mockTimeout = jasmine.createSpy('$timeout');
                 controller = new TimelineZoomController(
                     mockScope,
@@ -65,11 +66,6 @@ define(
             it("allows zoom to be changed", function () {
                 controller.zoom(1);
                 expect(controller.zoom()).toEqual(3500);
-            });
-
-            it("observes scroll bounds", function () {
-                expect(mockScope.$watch)
-                    .toHaveBeenCalledWith("scroll", jasmine.any(Function));
             });
 
             describe("when watches have fired", function () {
@@ -111,6 +107,10 @@ define(
 
                     mockScope.$watch.calls.forEach(function (call) {
                         call.args[1](mockScope[call.args[0]]);
+                    });
+
+                    mockTimeout.calls.forEach(function (call) {
+                        call.args[0]();
                     });
                 });
 


### PR DESCRIPTION
When TimelineZoomController updates scroll position (either to initialize and start at the left edge of the timeline, or to maintain centering when zooming), do so on a timeout. 

Contemporaneous zoom level changes also effect the width of the scrollable region, but the order at which this update occurs in the DOM is unpredictable; as such, an obsolete width may cause the scroll position to get clamped to an undesired value if scroll position and width are updated during the same digest style. Updating scroll on a `$timeout` ensures that this will take place on a subsequent digest cycle, preserving desired ordering.

Addresses #936.