### PR TITLE
R&I tweaks to Timeline scrollbar and splitters

### DIFF
--- a/platform/commonUI/themes/espresso/res/sass/_constants.scss
+++ b/platform/commonUI/themes/espresso/res/sass/_constants.scss
@@ -183,8 +183,9 @@ $scrollbarThumbColorOverlay: lighten($colorOvrBg, 10%);
 $scrollbarThumbColorOverlayHov: lighten($scrollbarThumbColorOverlay, 2%);
 
 // Splitter
-$splitterD: 25px; // splitterD and HandleD should both be odd, or even
+$splitterD: 25px; // splitterD and $splitterHandleD should both be odd, or even
 $splitterHandleD: 1px;
+$splitterDSm: 17px; // Smaller splitter, used inside elements like a Timeline view
 $colorSplitterBg: rgba(#fff, 0.1); //pullForward($colorBodyBg, 5%);
 $splitterShdw: rgba(black, 0.4) 0 0 3px;
 $splitterEndCr: none;

--- a/platform/commonUI/themes/espresso/res/sass/_constants.scss
+++ b/platform/commonUI/themes/espresso/res/sass/_constants.scss
@@ -183,13 +183,13 @@ $scrollbarThumbColorOverlay: lighten($colorOvrBg, 10%);
 $scrollbarThumbColorOverlayHov: lighten($scrollbarThumbColorOverlay, 2%);
 
 // Splitter
-$splitterD: 25px; // splitterD and $splitterHandleD should both be odd, or even
+$splitterD: 17px; // splitterD and $splitterHandleD should both be odd, or even
 $splitterHandleD: 1px;
 $splitterDSm: 17px; // Smaller splitter, used inside elements like a Timeline view
 $colorSplitterBg: rgba(#fff, 0.1); //pullForward($colorBodyBg, 5%);
 $splitterShdw: rgba(black, 0.4) 0 0 3px;
 $splitterEndCr: none;
-$colorSplitterHover: pullForward($colorBodyBg, 15%);
+$colorSplitterHover: pullForward($colorBodyBg, 40%);
 $colorSplitterActive: $colorKey;
 
 // Mobile

--- a/platform/commonUI/themes/snow/res/sass/_constants.scss
+++ b/platform/commonUI/themes/snow/res/sass/_constants.scss
@@ -183,8 +183,9 @@ $scrollbarThumbColorOverlay: darken($colorOvrBg, 50%);
 $scrollbarThumbColorOverlayHov: $scrollbarThumbColorHov;
 
 // Splitter
-$splitterD: 24px;
+$splitterD: 24px; // splitterD and $splitterHandleD should both be odd, or even
 $splitterHandleD: 2px;
+$splitterDSm: 16px; // Smaller splitter, used inside elements like a Timeline view
 $colorSplitterBg: pullForward($colorBodyBg, 10%);
 $splitterShdw: none;
 $splitterEndCr: none;

--- a/platform/commonUI/themes/snow/res/sass/_constants.scss
+++ b/platform/commonUI/themes/snow/res/sass/_constants.scss
@@ -183,13 +183,12 @@ $scrollbarThumbColorOverlay: darken($colorOvrBg, 50%);
 $scrollbarThumbColorOverlayHov: $scrollbarThumbColorHov;
 
 // Splitter
-$splitterD: 24px; // splitterD and $splitterHandleD should both be odd, or even
+$splitterD: 16px; // splitterD and $splitterHandleD should both be odd, or even
 $splitterHandleD: 2px;
-$splitterDSm: 16px; // Smaller splitter, used inside elements like a Timeline view
 $colorSplitterBg: pullForward($colorBodyBg, 10%);
 $splitterShdw: none;
 $splitterEndCr: none;
-$colorSplitterHover: none;
+$colorSplitterHover: pullForward($colorBodyBg, 30%);
 $colorSplitterActive: $colorKey;
 
 // Mobile

--- a/platform/features/timeline/res/sass/_timelines.scss
+++ b/platform/features/timeline/res/sass/_timelines.scss
@@ -58,7 +58,7 @@
                 }
                 &.l-tabular-r {
                     // Start, end, duration, activity modes columns
-                    @include scrollH();
+                    @include scrollH(scroll);
                     left: $timelineTabularTitleW;
 	                .l-width {
 		                @include absPosDefault(0, visible);

--- a/platform/features/timeline/res/sass/_timelines.scss
+++ b/platform/features/timeline/res/sass/_timelines.scss
@@ -23,6 +23,13 @@
 .l-timeline-holder {
     @include absPosDefault();
 
+    &.split-layout {
+        >.splitter {
+            // Top of splitter within Timelines should be 0
+            top: 0;
+        }
+    }
+
     .l-header {
         @include user-select(none);
         cursor: default;
@@ -303,11 +310,6 @@
 			}
 		}
 	}
-
-    .splitter {
-        // Top of splitter within Timelines should be 0
-        top: 0;
-    }
 
 	// Ticks
 	.l-ticks,


### PR DESCRIPTION
Fixes #913 

* Scrollbar now always visible in Timeline tabular right area
* Splitters tightened up to take up less space 

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y