### PR TITLE
[Timeline] Reduce flicker

### DIFF
--- a/platform/features/timeline/bundle.js
+++ b/platform/features/timeline/bundle.js
@@ -472,7 +472,7 @@ define([
                     "implementation": TimelineZoomController,
                     "depends": [
                         "$scope",
-                        "$timeout",
+                        "$window",
                         "TIMELINE_ZOOM_CONFIGURATION"
                     ]
                 },

--- a/platform/features/timeline/src/controllers/TimelineZoomController.js
+++ b/platform/features/timeline/src/controllers/TimelineZoomController.js
@@ -28,7 +28,7 @@ define(
          * Controls the pan-zoom state of a timeline view.
          * @constructor
          */
-        function TimelineZoomController($scope, $timeout, ZOOM_CONFIGURATION) {
+        function TimelineZoomController($scope, $window, ZOOM_CONFIGURATION) {
             // Prefer to start with the middle index
             var zoomLevels = ZOOM_CONFIGURATION.levels || [1000],
                 zoomIndex = Math.floor(zoomLevels.length / 2),
@@ -54,9 +54,10 @@ define(
             }
 
             function setScroll(x) {
-                $timeout(function () {
+                $window.requestAnimationFrame(function () {
                     $scope.scroll.x = x;
-                }, 0);
+                    $scope.$apply();
+                });
             }
 
             function initializeZoomFromTimespan(timespan) {

--- a/platform/features/timeline/test/controllers/TimelineZoomControllerSpec.js
+++ b/platform/features/timeline/test/controllers/TimelineZoomControllerSpec.js
@@ -28,7 +28,7 @@ define(
         describe("The timeline zoom state controller", function () {
             var testConfiguration,
                 mockScope,
-                mockTimeout,
+                mockWindow,
                 controller;
 
             beforeEach(function () {
@@ -36,13 +36,16 @@ define(
                     levels: [1000, 2000, 3500],
                     width: 12321
                 };
-                mockScope = jasmine.createSpyObj("$scope", ['$watch']);
+                mockScope =
+                    jasmine.createSpyObj("$scope", ['$watch', '$apply']);
                 mockScope.commit = jasmine.createSpy('commit');
                 mockScope.scroll = { x: 0, width: 1000 };
-                mockTimeout = jasmine.createSpy('$timeout');
+                mockWindow = {
+                    requestAnimationFrame: jasmine.createSpy('raf')
+                };
                 controller = new TimelineZoomController(
                     mockScope,
-                    mockTimeout,
+                    mockWindow,
                     testConfiguration
                 );
             });
@@ -109,7 +112,7 @@ define(
                         call.args[1](mockScope[call.args[0]]);
                     });
 
-                    mockTimeout.calls.forEach(function (call) {
+                    mockWindow.requestAnimationFrame.calls.forEach(function (call) {
                         call.args[0]();
                     });
                 });


### PR DESCRIPTION
Reposition scroll bar in Timeline with RAF instead of timeout;
this ensures that scroll bar is positioned after the current
digest (updating the width) but before the results are rendered
(avoiding flicker.) Fixes #997

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y