### PR TITLE
[Date Input] Addressed issues with date selector. Fixes #1000

### DIFF
--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -29,10 +29,12 @@
                                 !structure.validate(ngModel[field])),
                         'picker-icon': structure.format === 'utc' || !structure.format
                      }">
-    </input><a class="ui-symbol icon icon-calendar"
-       ng-if="structure.format === 'utc' || !structure.format"
-       ng-click="picker.active = !picker.active">
-    </a>
+    </input>
+    <a class="ui-symbol icon icon-calendar"
+       ng-if="!picker.active && (structure.format === 'utc' || !structure.format)"
+       ng-click="picker.active = !picker.active"></a>
+    <!-- If picker active show icon with no onclick to prevent double registration of clicks -->
+    <a class="ui-symbol icon icon-calendar" ng-if="picker.active"></a>
     <mct-popup ng-if="picker.active">
         <div mct-click-elsewhere="picker.active = false">
             <mct-control key="'datetime-picker'"

--- a/platform/commonUI/general/src/controllers/DateTimeFieldController.js
+++ b/platform/commonUI/general/src/controllers/DateTimeFieldController.js
@@ -72,6 +72,17 @@ define(
                     if ($scope.ngBlur) {
                         $scope.ngBlur();
                     }
+
+                    // If picker is active, dismiss it when valid value has been selected
+                    // This 'if' is to avoid unnecessary validation if picker is not active
+                    if ($scope.picker.active) {
+                        if ($scope.structure.validate && $scope.structure.validate($scope.ngModel[$scope.field])) {
+                            $scope.picker.active = false;
+                        } else if (!$scope.structure.validate) {
+                            //If picker visible, but no validation function, hide picker
+                            $scope.picker.active = false;
+                        }
+                    }
                 }
             }
 
@@ -93,7 +104,6 @@ define(
             $scope.$watch('ngModel[field]', updateFromModel);
             $scope.$watch('pickerModel.value', updateFromPicker);
             $scope.$watch('textValue', updateFromView);
-
         }
 
         return DateTimeFieldController;

--- a/platform/commonUI/general/src/directives/MCTClickElsewhere.js
+++ b/platform/commonUI/general/src/directives/MCTClickElsewhere.js
@@ -51,7 +51,9 @@ define(
                         yMax = yMin + rect.height;
 
                     if (x < xMin || x > xMax || y < yMin || y > yMax) {
-                        scope.$eval(attrs.mctClickElsewhere);
+                        scope.$apply(function () {
+                            scope.$eval(attrs.mctClickElsewhere);
+                        });
                     }
                 }
 

--- a/platform/commonUI/general/test/directives/MCTClickElsewhereSpec.js
+++ b/platform/commonUI/general/test/directives/MCTClickElsewhereSpec.js
@@ -104,6 +104,8 @@ define(
                 });
 
                 it("triggers an evaluation of its related Angular expression", function () {
+                    expect(mockScope.$apply).toHaveBeenCalled();
+                    mockScope.$apply.mostRecentCall.args[0]();
                     expect(mockScope.$eval)
                         .toHaveBeenCalledWith(testAttrs.mctClickElsewhere);
                 });


### PR DESCRIPTION
## Changes
1. Popup can now be dismissed via the calendar button. Problem was double triggering of click events.
2. Modified `MctClickElsewhere` to trigger a digest. Popup is now instantly dismissed
3. Selecting a __valid__ date from the date picker will close picker
4. Fixed test

Was tempted to use `ClickAwayController` and do away with `MctClickElsewhere` to simplify code base. Problem is that ClickAwayController triggers a click away when you click anywhere in document. For the date picker this is not ideal. Have a slight preference for conditionally dismissing after validation of selection. Prefer MctClickElsewhere's functionality in that it ignores clicks within the element it is attached to.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y