### PR TITLE
[Tables] Recalculate column dimensions on resize

### DIFF
--- a/platform/features/table/res/templates/mct-table.html
+++ b/platform/features/table/res/templates/mct-table.html
@@ -1,4 +1,4 @@
-<div class="l-view-section scrolling" style="overflow: auto;">
+<div class="l-view-section scrolling" style="overflow: auto;" mct-resize="resize()">
     <table class="sizing-table">
         <tbody>
             <tr>

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -76,6 +76,12 @@ define(
              */
             $scope.$on('add:row', this.addRow.bind(this));
             $scope.$on('remove:row', this.removeRow.bind(this));
+
+            /*
+             * Listen for resize events to trigger recalculation of table width
+             */
+            $scope.resize = this.setElementSizes.bind(this);
+
         }
 
         /**


### PR DESCRIPTION
### Changes
Uses `mct-resize` to detect resize of element, and recalculates column widths. There are non polling alternatives to detecting resize, and we might want to consider switching mct-resize over to using them to avoid a lot of timers. eg. https://www.npmjs.com/package/element-resize-event

Event-driven resize detection methods all rely on injecting invisible elements into the DOM though, so might cause some CSS weirdness in some cases.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A - basically just a markup change
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
