### PR TITLE
[Duplicate] Allow copy across spaces

### DIFF
--- a/platform/entanglement/src/policies/CrossSpacePolicy.js
+++ b/platform/entanglement/src/policies/CrossSpacePolicy.js
@@ -24,10 +24,7 @@ define(
     [],
     function () {
 
-        var DISALLOWED_ACTIONS = [
-            "move",
-            "copy"
-        ];
+        var DISALLOWED_ACTIONS = ["move"];
 
         /**
          * This policy prevents performing move/copy/link actions across

--- a/platform/entanglement/test/policies/CrossSpacePolicySpec.js
+++ b/platform/entanglement/test/policies/CrossSpacePolicySpec.js
@@ -70,27 +70,25 @@ define(
                 policy = new CrossSpacePolicy();
             });
 
-            ['move', 'copy'].forEach(function (key) {
-                describe("for " + key + " actions", function () {
-                    beforeEach(function () {
-                        testActionMetadata.key = key;
-                    });
+            describe("for move actions", function () {
+                beforeEach(function () {
+                    testActionMetadata.key = 'move';
+                });
 
-                    it("allows same-space changes", function () {
-                        expect(policy.allow(mockAction, sameSpaceContext))
-                            .toBe(true);
-                    });
+                it("allows same-space changes", function () {
+                    expect(policy.allow(mockAction, sameSpaceContext))
+                        .toBe(true);
+                });
 
-                    it("disallows cross-space changes", function () {
-                        expect(policy.allow(mockAction, crossSpaceContext))
-                            .toBe(false);
-                    });
+                it("disallows cross-space changes", function () {
+                    expect(policy.allow(mockAction, crossSpaceContext))
+                        .toBe(false);
+                });
 
-                    it("allows actions with no selectedObject", function () {
-                        expect(policy.allow(mockAction, {
-                            domainObject: makeObject('a')
-                        })).toBe(true);
-                    });
+                it("allows actions with no selectedObject", function () {
+                    expect(policy.allow(mockAction, {
+                        domainObject: makeObject('a')
+                    })).toBe(true);
                 });
             });
 


### PR DESCRIPTION
Fixes #1007

This was previously disallowed by policy at the time of #245:

> In that vein, a very simple option is to prevent actions between persistence stores and re-enable support for them later.

It's later! Since then, Duplicate has been refactored to instantiate objects in a manner which preserves their persistence space (in #371). Have tested cross-space duplicate with both creatable and non-creatable objects (telemetry) and observe no issues.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested?  Y