### PR TITLE
[API Prototype] Type registration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "node-uuid": "^1.4.7",
     "comma-separated-values": "^3.6.4",
     "FileSaver.js": "^0.0.2",
-    "zepto": "^1.1.6"
+    "zepto": "^1.1.6",
+    "eventemitter3": "^1.2.0"
   }
 }

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
                 './example/imagery/bundle',
                 './example/eventGenerator/bundle',
                 './example/generator/bundle'
-            ], mct.run.bind(mct));
+            ], mct.start.bind(mct));
         });
     </script>
     <link rel="stylesheet" href="platform/commonUI/general/res/css/startup-base.css">

--- a/index.html
+++ b/index.html
@@ -31,10 +31,15 @@
     <script type="text/javascript">
         require(['main'], function (mct) {
             require([
+                './tutorials/todo/todo',
+                './tutorials/todo/bundle',
                 './example/imagery/bundle',
                 './example/eventGenerator/bundle',
                 './example/generator/bundle'
-            ], mct.start.bind(mct));
+            ], function (todoPlugin) {
+                todoPlugin(mct);
+                mct.start();
+            })
         });
     </script>
     <link rel="stylesheet" href="platform/commonUI/general/res/css/startup-base.css">

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ requirejs.config({
         "angular-route": "bower_components/angular-route/angular-route.min",
         "csv": "bower_components/comma-separated-values/csv.min",
         "es6-promise": "bower_components/es6-promise/promise.min",
+        "EventEmitter": "bower_components/eventemitter3/index",
         "moment": "bower_components/moment/moment",
         "moment-duration-format": "bower_components/moment-duration-format/lib/moment-duration-format",
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",
@@ -42,6 +43,9 @@ requirejs.config({
         },
         "angular-route": {
             "deps": ["angular"]
+        },
+        "EventEmitter": {
+            "exports": "EventEmitter"
         },
         "moment-duration-format": {
             "deps": ["moment"]

--- a/main.js
+++ b/main.js
@@ -62,6 +62,7 @@ requirejs.config({
 define([
     './platform/framework/src/Main',
     'legacyRegistry',
+    './src/MCT',
 
     './platform/framework/bundle',
     './platform/core/bundle',
@@ -97,11 +98,14 @@ define([
     './platform/search/bundle',
     './platform/status/bundle',
     './platform/commonUI/regions/bundle'
-], function (Main, legacyRegistry) {
-    return {
-        legacyRegistry: legacyRegistry,
-        run: function () {
-            return new Main().run(legacyRegistry);
-        }
-    };
+], function (Main, legacyRegistry, MCT) {
+    var mct = new MCT();
+
+    mct.legacyRegistry = legacyRegistry;
+    mct.run = mct.start;
+    mct.on('start', function () {
+        return new Main().run(legacyRegistry);
+    });
+
+    return mct;
 });

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -1,11 +1,29 @@
-define(['EventEmitter'], function (EventEmitter) {
+define([
+    'EventEmitter',
+    'legacyRegistry',
+    './api/api'
+], function (EventEmitter, legacyRegistry, api) {
     function MCT() {
         EventEmitter.call(this);
+        this.legacyBundle = { extensions: {} };
     }
 
     MCT.prototype = Object.create(EventEmitter.prototype);
 
+    Object.keys(api).forEach(function (k) {
+        MCT.prototype[k] = api[k];
+    });
+
+    MCT.prototype.type = function (key, type) {
+        var legacyDef = type.toLegacyDefinition();
+        legacyDef.key = key;
+        this.legacyBundle.extensions.types =
+            this.legacyBundle.extensions.types || [];
+        this.legacyBundle.extensions.types.push(legacyDef);
+    };
+
     MCT.prototype.start = function () {
+        legacyRegistry.register('adapter', this.legacyBundle);
         this.emit('start');
     };
 

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -1,0 +1,13 @@
+define(['EventEmitter'], function (EventEmitter) {
+    function MCT() {
+        EventEmitter.call(this);
+    }
+
+    MCT.prototype = Object.create(EventEmitter.prototype);
+
+    MCT.prototype.start = function () {
+        this.emit('start');
+    };
+
+    return MCT;
+});

--- a/src/api/Type.js
+++ b/src/api/Type.js
@@ -1,0 +1,43 @@
+define(function () {
+    /**
+     * @typedef TypeDefinition
+     * @property {Metadata} metadata displayable metadata about this type
+     * @property {function (object)} [initialize] a function which initializes
+     *           the model for new domain objects of this type
+     * @property {boolean} [creatable] true if users should be allowed to
+     *           create this type (default: false)
+     */
+
+    /**
+     *
+     * @param {TypeDefinition} definition
+     * @constructor
+     */
+    function Type(definition) {
+        this.definition = definition;
+    }
+
+    /**
+     * Get a definition for this type that can be registered using the
+     * legacy bundle format.
+     * @private
+     */
+    Type.prototype.toLegacyDefinition = function () {
+        var def = {};
+        def.name = this.definition.metadata.label;
+        def.glyph = this.definition.metadata.glyph;
+        def.description = this.definition.metadata.description;
+
+        if (this.definition.initialize) {
+            def.model = {};
+            this.definition.initialize(def.model);
+        }
+
+        if (this.definition.creatable) {
+            def.features = ['creation'];
+        }
+        return def;
+    };
+
+    return Type;
+});

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,9 @@
+define([
+    './Type'
+], function (
+    Type
+) {
+    return {
+        Type: Type
+    };
+});

--- a/test-main.js
+++ b/test-main.js
@@ -48,6 +48,7 @@ requirejs.config({
         "angular-route": "bower_components/angular-route/angular-route.min",
         "csv": "bower_components/comma-separated-values/csv.min",
         "es6-promise": "bower_components/es6-promise/promise.min",
+        "EventEmitter": "bower_components/eventemitter3/index",
         "moment": "bower_components/moment/moment",
         "moment-duration-format": "bower_components/moment-duration-format/lib/moment-duration-format",
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",
@@ -63,6 +64,9 @@ requirejs.config({
         },
         "angular-route": {
             "deps": [ "angular" ]
+        },
+        "EventEmitter": {
+            "exports": "EventEmitter"
         },
         "moment-duration-format": {
             "deps": [ "moment" ]

--- a/tutorials/todo/bundle.js
+++ b/tutorials/todo/bundle.js
@@ -9,18 +9,6 @@ define([
         "name": "To-do Plugin",
         "description": "Allows creating and editing to-do lists.",
         "extensions": {
-            "types": [
-                {
-                    "key": "example.todo",
-                    "name": "To-Do List",
-                    "glyph": "2",
-                    "description": "A list of things that need to be done.",
-                    "features": ["creation"],
-                    "model": {
-                        "tasks": []
-                    }
-                }
-            ],
             "views": [
                 {
                     "key": "example.todo",

--- a/tutorials/todo/todo.js
+++ b/tutorials/todo/todo.js
@@ -1,0 +1,19 @@
+define(function () {
+    return function todoPlugin(mct) {
+        var todoType = new mct.Type({
+            metadata: {
+                label: "To-Do List",
+                glyph: "2",
+                description: "A list of things that need to be done."
+            },
+            initialize: function (model) {
+                model.tasks = [];
+            },
+            creatable: true
+        });
+
+        mct.type('example.todo', todoType);
+
+        return mct;
+    };
+});


### PR DESCRIPTION
Summary of changes:

* Move types from a declarative to an imperative registration style
* Make MCT an EventEmitter such that lifecycle events (e.g. `start`) can be listened to. (Replaces the `runs` category-of-extension)

Work toward #462 / #463. Note that destination branch is for API prototypes.