### PR TITLE
[Persistence] Use identifier service to get key

### DIFF
--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -60,11 +60,6 @@ define(
             this.$q = $q;
         }
 
-        function getKey(id) {
-            var parts = id.split(":");
-            return parts.length > 1 ? parts.slice(1).join(":") : id;
-        }
-
         /**
          * Checks if the value returned is falsey, and if so returns a
          * rejected promise
@@ -131,7 +126,7 @@ define(
             // ...and persist
             return persistenceFn.apply(persistenceService, [
                 this.getSpace(),
-                getKey(domainObject.getId()),
+                this.getKey(),
                 domainObject.getModel()
             ]).then(function (result) {
                 return rejectIfFalsey(result, self.$q);
@@ -159,7 +154,7 @@ define(
 
             return this.persistenceService.readObject(
                     this.getSpace(),
-                    this.domainObject.getId()
+                    this.getKey()
                 ).then(updateModel);
         };
 
@@ -176,6 +171,17 @@ define(
         PersistenceCapability.prototype.getSpace = function () {
             var id = this.domainObject.getId();
             return this.identifierService.parse(id).getSpace();
+        };
+
+
+        /**
+         * Get the key for this domain object in the given space.
+         *
+         * @returns {string} the key of the object in it's space.
+         */
+        PersistenceCapability.prototype.getKey = function () {
+            var id = this.domainObject.getId();
+            return this.identifierService.parse(id).getKey();
         };
 
         return PersistenceCapability;

--- a/platform/core/test/capabilities/PersistenceCapabilitySpec.js
+++ b/platform/core/test/capabilities/PersistenceCapabilitySpec.js
@@ -101,6 +101,7 @@ define(
                 });
                 mockIdentifierService.parse.andReturn(mockIdentifier);
                 mockIdentifier.getSpace.andReturn(SPACE);
+                mockIdentifier.getKey.andReturn(id);
                 persistence = new PersistenceCapability(
                     mockCacheService,
                     mockPersistenceService,

--- a/platform/core/test/capabilities/PersistenceCapabilitySpec.js
+++ b/platform/core/test/capabilities/PersistenceCapabilitySpec.js
@@ -35,7 +35,8 @@ define(
                 mockNofificationService,
                 mockCacheService,
                 mockQ,
-                id = "object id",
+                key = "persistence key",
+                id = "object identifier",
                 model,
                 SPACE = "some space",
                 persistence,
@@ -101,7 +102,7 @@ define(
                 });
                 mockIdentifierService.parse.andReturn(mockIdentifier);
                 mockIdentifier.getSpace.andReturn(SPACE);
-                mockIdentifier.getKey.andReturn(id);
+                mockIdentifier.getKey.andReturn(key);
                 persistence = new PersistenceCapability(
                     mockCacheService,
                     mockPersistenceService,
@@ -125,7 +126,7 @@ define(
 
                     expect(mockPersistenceService.createObject).toHaveBeenCalledWith(
                         SPACE,
-                        id,
+                        key,
                         model
                     );
                 });
@@ -139,7 +140,7 @@ define(
 
                     expect(mockPersistenceService.updateObject).toHaveBeenCalledWith(
                         SPACE,
-                        id,
+                        key,
                         model
                     );
                 });


### PR DESCRIPTION
Retrieve key from identifier service for all persist operations.

Fixes https://github.com/nasa/openmct/issues/1013

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y