### PR TITLE
[Edit Mode] Canceling edit mode with unsaved changes now shows confirmation dialog to user

### DIFF
--- a/platform/commonUI/browse/bundle.js
+++ b/platform/commonUI/browse/bundle.js
@@ -93,11 +93,9 @@ define([
                         "$scope",
                         "$route",
                         "$location",
-                        "$window",
                         "objectService",
                         "navigationService",
                         "urlService",
-                        "policyService",
                         "DEFAULT_PATH"
                     ]
                 },
@@ -201,7 +199,9 @@ define([
                     "implementation": NavigateAction,
                     "depends": [
                         "navigationService",
-                        "$q"
+                        "$q",
+                        "policyService",
+                        "$window"
                     ]
                 },
                 {

--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -44,11 +44,9 @@ define(
             $scope,
             $route,
             $location,
-            $window,
             objectService,
             navigationService,
             urlService,
-            policyService,
             defaultPath
         ) {
             var path = [ROOT_ID].concat(
@@ -75,31 +73,30 @@ define(
 
             }
 
-            // Callback for updating the in-scope reference to the object
-            // that is currently navigated-to.
-            function setNavigation(domainObject) {
-                var navigationAllowed = true;
-
-                if (domainObject === $scope.navigatedObject) {
-                    //do nothing;
-                    return;
-                }
-
-                policyService.allow("navigation", $scope.navigatedObject, domainObject, function (message) {
-                    navigationAllowed = $window.confirm(message + "\r\n\r\n" +
-                        " Are you sure you want to continue?");
-                });
-
+            function setScopeObjects(domainObject, navigationAllowed) {
                 if (navigationAllowed) {
                     $scope.navigatedObject = domainObject;
                     $scope.treeModel.selectedObject = domainObject;
-                    navigationService.setNavigation(domainObject);
                     updateRoute(domainObject);
                 } else {
                     //If navigation was unsuccessful (ie. blocked), reset
                     // the selected object in the tree to the currently
                     // navigated object
                     $scope.treeModel.selectedObject = $scope.navigatedObject ;
+                }
+            }
+
+            // Callback for updating the in-scope reference to the object
+            // that is currently navigated-to.
+            function setNavigation(domainObject) {
+                if (domainObject === $scope.navigatedObject) {
+                    //do nothing;
+                    return;
+                }
+                if (domainObject) {
+                    domainObject.getCapability("action").perform("navigate").then(setScopeObjects.bind(undefined, domainObject));
+                } else {
+                    setScopeObjects(domainObject, true);
                 }
             }
 

--- a/platform/commonUI/browse/src/navigation/NavigateAction.js
+++ b/platform/commonUI/browse/src/navigation/NavigateAction.js
@@ -33,10 +33,12 @@ define(
          * @constructor
          * @implements {Action}
          */
-        function NavigateAction(navigationService, $q, context) {
+        function NavigateAction(navigationService, $q, policyService, $window, context) {
             this.domainObject = context.domainObject;
             this.$q = $q;
             this.navigationService = navigationService;
+            this.policyService = policyService;
+            this.$window = $window;
         }
 
         /**
@@ -45,9 +47,20 @@ define(
          *          navigation has been updated
          */
         NavigateAction.prototype.perform = function () {
+            var self = this,
+                navigationAllowed = true;
+
+            function allow() {
+                self.policyService.allow("navigation", self.navigationService.getNavigation(), self.domainObject, function (message) {
+                    navigationAllowed = self.$window.confirm(message + "\r\n\r\n" +
+                        " Are you sure you want to continue?");
+                });
+                return navigationAllowed;
+            }
+
             // Set navigation, and wrap like a promise
             return this.$q.when(
-                this.navigationService.setNavigation(this.domainObject)
+                allow() && this.navigationService.setNavigation(this.domainObject)
             );
         };
 

--- a/platform/commonUI/edit/src/actions/CancelAction.js
+++ b/platform/commonUI/edit/src/actions/CancelAction.js
@@ -50,18 +50,24 @@ define(
                 //If the object existed already, navigate to refresh view
                 // with previous object state.
                 if (domainObject.getModel().persisted) {
-                    domainObject.getCapability("action").perform("navigate");
+                    return domainObject.getCapability("action").perform("navigate");
                 } else {
                     //If the object was new, and user has cancelled, then
                     //navigate back to parent because nothing to show.
-                    domainObject.getCapability("location").getOriginal().then(function (original) {
+                    return domainObject.getCapability("location").getOriginal().then(function (original) {
                         parent = original.getCapability("context").getParent();
                         parent.getCapability("action").perform("navigate");
                     });
                 }
             }
-            return this.domainObject.getCapability("editor").cancel()
-                .then(returnToBrowse);
+
+            function cancel(allowed) {
+                return allowed && domainObject.getCapability("editor").cancel();
+            }
+
+            //Do navigation first in order to trigger unsaved changes dialog
+            return returnToBrowse()
+                .then(cancel);
         };
 
         /**

--- a/platform/commonUI/edit/test/actions/CancelActionSpec.js
+++ b/platform/commonUI/edit/test/actions/CancelActionSpec.js
@@ -125,6 +125,9 @@ define(
 
             it("invokes the editor capability's cancel functionality when" +
                 " performed", function () {
+                mockDomainObject.getModel.andReturn({persisted: 1});
+                //Return true from navigate action
+                capabilities.action.perform.andReturn(mockPromise(true));
                 action.perform();
 
                 // Should have called cancel
@@ -134,13 +137,15 @@ define(
                 expect(capabilities.editor.save).not.toHaveBeenCalled();
             });
 
-            it("navigates to object if existing", function () {
+            it("navigates to object if existing using navigate action", function () {
                 mockDomainObject.getModel.andReturn({persisted: 1});
+                //Return true from navigate action
+                capabilities.action.perform.andReturn(mockPromise(true));
                 action.perform();
                 expect(capabilities.action.perform).toHaveBeenCalledWith("navigate");
             });
 
-            it("navigates to parent if new", function () {
+            it("navigates to parent if new using navigate action", function () {
                 mockDomainObject.getModel.andReturn({persisted: undefined});
                 action.perform();
                 expect(parentCapabilities.action.perform).toHaveBeenCalledWith("navigate");

--- a/platform/features/table/src/controllers/TableOptionsController.js
+++ b/platform/features/table/src/controllers/TableOptionsController.js
@@ -72,10 +72,10 @@ define(
              * Maintain a configuration object on scope that stores column
              * configuration. On change, synchronize with object model.
              */
-            $scope.$watchCollection('configuration.table.columns', function (columns) {
-                if (columns) {
+            $scope.$watchCollection('configuration.table.columns', function (newColumns, oldColumns) {
+                if (newColumns !== oldColumns) {
                     self.domainObject.useCapability('mutation', function (model) {
-                        model.configuration.table.columns = columns;
+                        model.configuration.table.columns = newColumns;
                     });
                     self.domainObject.getCapability('persistence').persist();
                 }


### PR DESCRIPTION
### Changes
* Moved navigation policy check from `BrowseController` to `NavigateAction` allowing it to be triggered from anywhere that `NavigateAction` is used (including `CancelAction`).
* Refactored `BrowseController` to use `NavigateAction`
* Updated tests

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y