### PR TITLE
R&I fixes for Snow button colors and Timeline edit Add menu

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_buttons.scss
+++ b/platform/commonUI/general/res/sass/controls/_buttons.scss
@@ -106,7 +106,6 @@ $pad: $interiorMargin * $baseRatio;
 
     .icon {
         font-size: 0.8rem;
-        color: $colorKey;
     }
 
     .title-label {

--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -391,7 +391,6 @@ body.desktop {
         .l-edit-controls {
             height: 0;
             border-bottom: 1px solid $colorInteriorBorder;
-            overflow: hidden;
             // Transition 2: reveal edit controls
             @include keyframes(editIn) {
                 from { border-bottom: 0px solid transparent; height: 0; margin-bottom: 0; }


### PR DESCRIPTION
Fixes
* #1014: Fixed color definition in _buttons.scss.
* #1019: Removed overflow: hidden from .l-edit-controls; this was a regression due to work in #987.

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y