### PR TITLE
Emphasis styling applied to Edit button properly

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_buttons.scss
+++ b/platform/commonUI/general/res/sass/controls/_buttons.scss
@@ -51,7 +51,8 @@ $pad: $interiorMargin * $baseRatio;
     }
 
     &.major,
-    &.key-edit {
+    &.key-edit,
+    &.key-properties {
         $bg: $colorBtnMajorBg;
         $hc: lighten($bg, 10%);
         @include btnSubtle($bg, $hc, $colorBtnMajorFg, $colorBtnMajorFg);


### PR DESCRIPTION
fixes #1014
* Added .key-properties to .major to color the Edit button as intended;

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y