### PR TITLE
[API] "X-Powered-By" Express header disabled. Fixes #1036

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,8 @@
         process.exit(0);
     }
 
+    app.disable('x-powered-by');
+
     // Override bundles.json for HTTP requests
     app.use('/' + BUNDLE_FILE, function (req, res) {
         var bundles;


### PR DESCRIPTION
### Changes
Using the native way for disabling it as Express developers recommend here: http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header

New HTTP response (without the header):
<img width="352" alt="captura de pantalla 2016-06-20 a las 10 02 33" src="https://cloud.githubusercontent.com/assets/2753855/16208966/131bdad4-3735-11e6-92e4-263efe713a96.png">

### Author Checklist
 - Changes address original issue? Y
 - Unit tests included and/or updated with changes? N
 - Command line build passes? Y
 - Changes have been smoke-tested? N