### PR TITLE
[Plot] Set min height

### DIFF
--- a/platform/commonUI/general/res/sass/_constants.scss
+++ b/platform/commonUI/general/res/sass/_constants.scss
@@ -97,9 +97,8 @@ $plotLegendH: 20px;
 $plotSwatchD: 8px;
 // 1: Top, 2: right, 3: bottom, 4: left
 $plotDisplayArea: ($plotLegendH + $interiorMargin, 0, $plotXBarH + $interiorMargin, $plotYBarW);
-/* Based on current implementation of ~ 5 ticks per plot element;
-Include legend, plot-display-area and X ticks */
-$plotMinH: $plotLegendH + ($interiorMargin * 2) + ($plotYLabelMinH * 5) + nth($plotDisplayArea,3);
+/* min plot height is based on user testing to find minimum useful height */
+$plotMinH: 95px;
 /*************** Bubbles */
 $bubbleArwSize: 10px;
 $bubblePad: $interiorMargin;


### PR DESCRIPTION
Set the min height for the plot element based on user feedback for
minimum plot size that they find useful.  Plot ticks may overlap
but that is expected to be fixed in a future release.

Fixes https://github.com/nasa/openmct/issues/1048

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A (style only change)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y