### PR TITLE
[Edit] Undirty objects on refresh

### DIFF
--- a/platform/commonUI/edit/src/actions/SaveAsAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAsAction.js
@@ -141,8 +141,8 @@ define(
                 return copyService.perform(domainObject, parent, allowClone);
             }
 
-            function undirty(domainObject) {
-                return domainObject.getCapability('persistence').refresh();
+            function undirty(object) {
+                return object.getCapability('persistence').refresh();
             }
 
             function undirtyOriginals(object) {

--- a/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
@@ -49,6 +49,7 @@ define(
             this.domainObject = domainObject;
             this.$q = $q;
             this.persistPending = false;
+            this.removeFromTransaction = undefined;
         }
 
         /**
@@ -75,6 +76,7 @@ define(
                     });
                 } else {
                     self.persistPending = false;
+                    self.removeFromTransaction = undefined;
                     //Model is undefined in persistence, so return undefined.
                     return self.$q.when(undefined);
                 }
@@ -82,7 +84,8 @@ define(
 
             if (this.transactionService.isActive()) {
                 if (!this.persistPending) {
-                    this.transactionService.addToTransaction(onCommit, onCancel);
+                    this.removeFromTransaction = this.transactionService
+                        .addToTransaction(onCommit, onCancel);
                     this.persistPending = true;
                 }
                 //Need to return a promise from this function
@@ -93,6 +96,11 @@ define(
         };
 
         TransactionalPersistenceCapability.prototype.refresh = function () {
+            if (this.persistPending) {
+                this.persistPending = false;
+                this.removeFromTransaction();
+                this.removeFromTransaction = undefined;
+            }
             return this.persistenceCapability.refresh();
         };
 

--- a/platform/commonUI/edit/src/services/TransactionService.js
+++ b/platform/commonUI/edit/src/services/TransactionService.js
@@ -81,6 +81,15 @@ define(
                 //Log error because this is a programming error if it occurs.
                 this.$log.error("No transaction in progress");
             }
+
+            return function () {
+                this.onCommits = this.onCommits.filter(function (callback) {
+                    return callback !== onCommit;
+                });
+                this.onCancels = this.onCancels.filter(function (callback) {
+                    return callback !== onCancel;
+                });
+            }.bind(this);
         };
 
         /**

--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -152,6 +152,10 @@ define(
                 }, modified);
             }
 
+            if (domainObject.getModel().persisted === undefined) {
+                return this.$q.when(true);
+            }
+
             return this.persistenceService.readObject(
                     this.getSpace(),
                     this.getKey()

--- a/platform/core/test/capabilities/PersistenceCapabilitySpec.js
+++ b/platform/core/test/capabilities/PersistenceCapabilitySpec.js
@@ -74,7 +74,7 @@ define(
                 );
                 mockQ = jasmine.createSpyObj(
                     "$q",
-                    ["reject"]
+                    ["reject", "when"]
                 );
                 mockNofificationService = jasmine.createSpyObj(
                     "notificationService",
@@ -103,6 +103,7 @@ define(
                 mockIdentifierService.parse.andReturn(mockIdentifier);
                 mockIdentifier.getSpace.andReturn(SPACE);
                 mockIdentifier.getKey.andReturn(key);
+                mockQ.when.andCallFake(asPromise);
                 persistence = new PersistenceCapability(
                     mockCacheService,
                     mockPersistenceService,
@@ -156,6 +157,7 @@ define(
                 });
                 it("refreshes the domain object model from persistence", function () {
                     var refreshModel = {someOtherKey: "some other value"};
+                    model.persisted = 1;
                     mockPersistenceService.readObject.andReturn(asPromise(refreshModel));
                     persistence.refresh();
                     expect(model).toEqual(refreshModel);


### PR DESCRIPTION
Remove domain objects from the active transaction when they
are refreshed, and use this from the SaveAsAction to prevent
saving unintended changes. Fixes #1046

Still to-do:

- [x] Update tests
- [x] ~~Clean up (or file follow up)~~ (see comment below)
- [x] Verify that build completes (code style etc)