### PR TITLE
[Save] Show blocking dialog

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -206,7 +206,9 @@ define([
                     "implementation": SaveAction,
                     "name": "Save",
                     "description": "Save changes made to these objects.",
-                    "depends": [],
+                    "depends": [
+                        "dialogService"
+                    ],
                     "priority": "mandatory"
                 },
                 {

--- a/platform/commonUI/edit/src/actions/SaveAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAction.js
@@ -21,8 +21,8 @@
  *****************************************************************************/
 
 define(
-    [],
-    function () {
+    ['./SaveInProgressDialog'],
+    function (SaveInProgressDialog) {
 
         /**
          * The "Save" action; the action triggered by clicking Save from
@@ -33,9 +33,11 @@ define(
          * @memberof platform/commonUI/edit
          */
         function SaveAction(
+            dialogService,
             context
         ) {
             this.domainObject = (context || {}).domainObject;
+            this.dialogService = dialogService;
         }
 
         /**
@@ -46,7 +48,8 @@ define(
          * @memberof platform/commonUI/edit.SaveAction#
          */
         SaveAction.prototype.perform = function () {
-            var domainObject = this.domainObject;
+            var domainObject = this.domainObject,
+                dialog = new SaveInProgressDialog(this.dialogService);
 
             function resolveWith(object) {
                 return function () {
@@ -72,8 +75,17 @@ define(
                 return object;
             }
 
-            //return doSave().then(returnToBrowse);
-            return doSave().then(returnToBrowse);
+            function hideBlockingDialog(object) {
+                dialog.hide();
+                return object;
+            }
+
+            dialog.show();
+
+            return doSave()
+                .then(hideBlockingDialog)
+                .then(returnToBrowse)
+                .catch(hideBlockingDialog);
         };
 
         /**

--- a/platform/commonUI/edit/src/actions/SaveInProgressDialog.js
+++ b/platform/commonUI/edit/src/actions/SaveInProgressDialog.js
@@ -1,0 +1,20 @@
+define([], function () {
+    function SaveInProgressDialog(dialogService) {
+        this.dialogService = dialogService;
+    }
+
+    SaveInProgressDialog.prototype.show = function () {
+        this.dialogService.showBlockingMessage({
+            title: "Saving...",
+            hint: "Do not navigate away from this page or close this browser tab while this message is displayed.",
+            unknownProgress: true,
+            severity: "info"
+        });
+    };
+
+    SaveInProgressDialog.prototype.hide = function () {
+        this.dialogService.dismiss();
+    };
+
+    return SaveInProgressDialog;
+});

--- a/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
+++ b/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
@@ -100,7 +100,9 @@ define(
                 mockDialogService = jasmine.createSpyObj(
                     "dialogService",
                     [
-                        "getUserInput"
+                        "getUserInput",
+                        "showBlockingMessage",
+                        "dismiss"
                     ]
                 );
                 mockDialogService.getUserInput.andReturn(mockPromise(undefined));
@@ -167,6 +169,19 @@ define(
             it("prompts the user for object details", function () {
                 action.perform();
                 expect(mockDialogService.getUserInput).toHaveBeenCalled();
+            });
+
+            it("shows a blocking dialog while waiting for save", function () {
+                mockEditorCapability.save.andReturn(new Promise(function () {}));
+                action.perform();
+                expect(mockDialogService.showBlockingMessage).toHaveBeenCalled();
+                expect(mockDialogService.dismiss).not.toHaveBeenCalled();
+            });
+
+            it("hides the blocking dialog after saving", function () {
+                action.perform();
+                expect(mockDialogService.showBlockingMessage).toHaveBeenCalled();
+                expect(mockDialogService.dismiss).toHaveBeenCalled();
             });
 
         });


### PR DESCRIPTION
Show a blocking dialog while the save action is being performed.

Prevents users from pressing save a second time or performing
further actions while a save is in progress.

Fixes https://github.jpl.nasa.gov/MissionControl/vista/issues/362

Never ended up with a bug report in OpenMCT, just have seen users hitting walls because of this.  Very odd behavior results when they try and take other actions while saving.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y