### PR TITLE
[Time Conductor] Bounds updated when date selected from date selector fixes #1018

### DIFF
--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -204,6 +204,7 @@ define([
                     "implementation": TimeRangeController,
                     "depends": [
                         "$scope",
+                        "$timeout",
                         "formatService",
                         "DEFAULT_TIME_FORMAT",
                         "now"

--- a/platform/commonUI/general/src/controllers/TimeRangeController.js
+++ b/platform/commonUI/general/src/controllers/TimeRangeController.js
@@ -53,7 +53,7 @@ define([
      *        format has been otherwise specified
      * @param {Function} now a function to return current system time
      */
-    function TimeRangeController($scope, formatService, defaultFormat, now) {
+    function TimeRangeController($scope, $timeout, formatService, defaultFormat, now) {
         this.$scope = $scope;
         this.formatService = formatService;
         this.defaultFormat = defaultFormat;
@@ -66,6 +66,7 @@ define([
         this.formatter = formatService.getFormat(defaultFormat);
         this.formStartChanged = false;
         this.formEndChanged = false;
+        this.$timeout = $timeout;
 
         this.$scope.ticks = [];
 
@@ -259,18 +260,23 @@ define([
     };
 
     TimeRangeController.prototype.updateBoundsFromForm = function () {
-        if (this.formStartChanged) {
-            this.$scope.ngModel.outer.start =
-                this.$scope.ngModel.inner.start =
-                this.$scope.formModel.start;
-            this.formStartChanged = false;
-        }
-        if (this.formEndChanged) {
-            this.$scope.ngModel.outer.end =
-                this.$scope.ngModel.inner.end =
-                this.$scope.formModel.end;
-            this.formEndChanged = false;
-        }
+        var self = this;
+
+        //Allow Angular to trigger watches and determine whether values have changed.
+        this.$timeout(function () {
+            if (self.formStartChanged) {
+                self.$scope.ngModel.outer.start =
+                    self.$scope.ngModel.inner.start =
+                        self.$scope.formModel.start;
+                self.formStartChanged = false;
+            }
+            if (self.formEndChanged) {
+                self.$scope.ngModel.outer.end =
+                    self.$scope.ngModel.inner.end =
+                        self.$scope.formModel.end;
+                self.formEndChanged = false;
+            }
+        });
     };
 
     TimeRangeController.prototype.onFormStartChange = function (

--- a/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/TimeRangeControllerSpec.js
@@ -33,6 +33,7 @@ define(
             var mockScope,
                 mockFormatService,
                 testDefaultFormat,
+                mockTimeout,
                 mockNow,
                 mockFormat,
                 controller;
@@ -54,6 +55,10 @@ define(
             }
 
             beforeEach(function () {
+                mockTimeout = function (fn) {
+                    return fn();
+                };
+
                 mockScope = jasmine.createSpyObj(
                     "$scope",
                     ["$apply", "$watch", "$watchCollection"]
@@ -78,6 +83,7 @@ define(
 
                 controller = new TimeRangeController(
                     mockScope,
+                    mockTimeout,
                     mockFormatService,
                     testDefaultFormat,
                     mockNow


### PR DESCRIPTION
Problem was caused by blur behaviour being invoked before digest could take place.

The [blur behavior](https://github.com/nasa/openmct/blob/open1018-new/platform/commonUI/general/src/controllers/TimeRangeController.js#L267) in `TimeRangeController` is dependent on [a watch](https://github.com/nasa/openmct/blob/open1018-new/platform/commonUI/general/src/controllers/TimeRangeController.js#L282) having been triggered first. It's not triggered because a digest hasn't occurred by the time the [blur behavior](https://github.com/nasa/openmct/blob/open1018-new/platform/commonUI/general/res/templates/controls/datetime-field.html#L25) of the field is called in code.

Rather than investing time in structural changes to the Time Conductor at this time, I've just invoked a digest manually for now.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y