### PR TITLE
[Time Conductor] V2 Public API

### DIFF
--- a/src/api/TimeConductor.js
+++ b/src/api/TimeConductor.js
@@ -107,8 +107,8 @@ define(['EventEmitter'],
          * @fires TimeConductor#timeSystem
          * @returns {TimeSystem} The currently applied time system
          */
-        TimeConductor.prototype.timeSystem = function (newTimeSystem) {
-            if (arguments.length === 1) {
+        TimeConductor.prototype.timeSystem = function (newTimeSystem, bounds) {
+            if (arguments.length === 2) {
                 this.system = newTimeSystem;
                 /**
                  * @event TimeConductor#timeSystem The time system used by the time
@@ -121,8 +121,9 @@ define(['EventEmitter'],
                 // Do something with bounds here. Try and convert between
                 // time systems? Or just set defaults when time system changes?
                 // eg.
-                // this.bounds(this.system.DEFAULT_BOUNDS);
-                this.emit('bounds', this.bounds());
+                this.bounds(bounds);
+            } else if (arguments.length === 1) {
+                throw new Error('Must set bounds when changing time system');
             }
             return this.system;
         };

--- a/src/api/TimeConductor.js
+++ b/src/api/TimeConductor.js
@@ -1,151 +1,183 @@
-define(['EventEmitter'],
-    function (EventEmitter) {
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
 
-        /**
-         * The public API for setting and querying time conductor state. The
-         * TimeConductor is an event emitter and extends the EventEmitter
-         * class. A number of events are fired when properties of the time
-         * conductor change, and these are documented below.
-         * @constructor
-         */
-        function TimeConductor() {
-            EventEmitter.call(this);
+define(['EventEmitter'], function (EventEmitter) {
 
-            //The Time System
-            this.system = undefined;
-            //The Time Of Interest
-            this.toi = undefined;
+    /**
+     * The public API for setting and querying time conductor state. The
+     * time conductor is the means by which the temporal bounds of a view
+     * are controlled. Time-sensitive views will typically respond to
+     * changes to bounds or other properties of the time conductor and
+     * update the data displayed based on the time conductor state.
+     *
+     * The TimeConductor extends the EventEmitter class. A number of events are
+     * fired when properties of the time conductor change, which are
+     * documented below.
+     * @constructor
+     */
+    function TimeConductor() {
+        EventEmitter.call(this);
 
-            this.boundsVal = {
-                start: undefined,
-                end: undefined
-            };
+        //The Time System
+        this.system = undefined;
+        //The Time Of Interest
+        this.toi = undefined;
 
-            //Default to fixed mode
-            this.followMode = false;
+        this.boundsVal = {
+            start: undefined,
+            end: undefined
+        };
+
+        //Default to fixed mode
+        this.followMode = false;
+    }
+
+    TimeConductor.prototype = Object.create(EventEmitter.prototype);
+
+    /**
+     * Validate the given bounds. This can be used for pre-validation of
+     * bounds, for example by views validating user inputs.
+     * @param bounds The start and end time of the conductor.
+     * @returns {string | true} A validation error, or true if valid
+     */
+    TimeConductor.prototype.validateBounds = function (bounds) {
+        if ((bounds.start === undefined) ||
+            (bounds.end === undefined) ||
+            isNaN(bounds.start) ||
+            isNaN(bounds.end)
+        ) {
+            return "Start and end must be specified as integer values";
+        } else if (bounds.start > bounds.end) {
+            return "Specified start date exceeds end bound";
         }
+        return true;
+    };
 
-        TimeConductor.prototype = Object.create(EventEmitter.prototype);
-
-        /**
-         * Validate the given bounds. This can be used for pre-validation of
-         * bounds, for example by views validating user inputs.
-         * @param bounds The start and end time of the conductor.
-         * @returns {string | true} A validation error, or true if valid
-         */
-        TimeConductor.prototype.validateBounds = function (bounds) {
-            if (!bounds.start ||
-                !bounds.end ||
-                isNaN(bounds.start) ||
-                isNaN(bounds.end)
-            ) {
-                return "Start and end must be specified as integer values";
-            } else if (bounds.start > bounds.end){
-                return "Specified start date exceeds end bound";
-            }
-            return true;
-        };
-
-        function throwOnError(validationResult) {
-            if (validationResult !== true) {
-                throw validationResult;
-            }
+    function throwOnError(validationResult) {
+        if (validationResult !== true) {
+            throw new Error(validationResult);
         }
+    }
 
-        /**
-         * Switch the time conductor between follow and fixed modes. In
-         * follow mode the time conductor ticks.
-         * @fires TimeConductor#follow
-         * @param followMode
-         * @returns {*}
-         */
-        TimeConductor.prototype.follow = function (followMode) {
-            if (arguments.length === 1) {
-                this.followMode = followMode;
-                /**
-                 * @event TimeConductor#follow The TimeConductor has toggled
-                 * into or out of follow mode.
-                 * @property {boolean} followMode true if follow mode is
-                 * enabled, otherwise false.
-                 */
-                this.emit('follow', followMode);
-            }
-            return this.followMode;
-        };
+    /**
+     * Get or set the follow mode of the time conductor. In follow mode the
+     * time conductor ticks, regularly updating the bounds from a timing
+     * source appropriate to the selected time system and mode of the time
+     * conductor.
+     * @fires TimeConductor#follow
+     * @param {boolean} followMode
+     * @returns {boolean}
+     */
+    TimeConductor.prototype.follow = function (followMode) {
+        if (arguments.length > 0) {
+            this.followMode = followMode;
+            /**
+             * @event TimeConductor#follow The TimeConductor has toggled
+             * into or out of follow mode.
+             * @property {boolean} followMode true if follow mode is
+             * enabled, otherwise false.
+             */
+            this.emit('follow', this.followMode);
+        }
+        return this.followMode;
+    };
 
-        /**
-         * @typedef {Object} TimeConductorBounds
-         * @property {number} start The start time displayed by the time conductor in ms since epoch. Epoch determined by current time system
-         * @property {number} end The end time displayed by the time conductor in ms since epoch.
-         */
-        /**
-         * Set the start and end time of the time conductor. Basic validation of bounds is performed.
-         *
-         * @param {TimeConductorBounds} newBounds
-         * @param {TimeConductorBounds} should this change trigger a refresh?
-         * @throws {string} Validation error
-         * @fires TimeConductor#bounds
-         * @returns {TimeConductorBounds}
-         */
-        TimeConductor.prototype.bounds = function (newBounds) {
-            if (arguments.length === 1) {
-                throwOnError(this.validateBounds(newBounds));
-                this.boundsVal = newBounds;
-                /**
-                 * @event TimeConductor#bounds The start time, end time, or
-                 * both have been updated
-                 * @property {TimeConductorBounds} bounds
-                 */
-                this.emit('bounds', this.boundsVal);
-            }
-            return this.boundsVal;
-        };
+    /**
+     * @typedef {Object} TimeConductorBounds
+     * @property {number} start The start time displayed by the time conductor in ms since epoch. Epoch determined by current time system
+     * @property {number} end The end time displayed by the time conductor in ms since epoch.
+     */
+    /**
+     * Get or set the start and end time of the time conductor. Basic validation
+     * of bounds is performed.
+     *
+     * @param {TimeConductorBounds} newBounds
+     * @throws {Error} Validation error
+     * @fires TimeConductor#bounds
+     * @returns {TimeConductorBounds}
+     */
+    TimeConductor.prototype.bounds = function (newBounds) {
+        if (arguments.length > 0) {
+            throwOnError(this.validateBounds(newBounds));
+            this.boundsVal = newBounds;
+            /**
+             * @event TimeConductor#bounds The start time, end time, or
+             * both have been updated
+             * @property {TimeConductorBounds} bounds
+             */
+            this.emit('bounds', this.boundsVal);
+        }
+        return this.boundsVal;
+    };
 
-        /**
-         * Set the time system of the TimeConductor. Time systems determine units, epoch, and other aspects of time representation.
-         * @param newTimeSystem
-         * @fires TimeConductor#timeSystem
-         * @returns {TimeSystem} The currently applied time system
-         */
-        TimeConductor.prototype.timeSystem = function (newTimeSystem, bounds) {
-            if (arguments.length === 2) {
-                this.system = newTimeSystem;
-                /**
-                 * @event TimeConductor#timeSystem The time system used by the time
-                 * conductor has changed. A change in Time System will always be
-                 * followed by a bounds event specifying new query bounds
-                 * @property {TimeSystem} The value of the currently applied
-                 * Time System
-                 * */
-                this.emit('timeSystem', this.system);
-                // Do something with bounds here. Try and convert between
-                // time systems? Or just set defaults when time system changes?
-                // eg.
-                this.bounds(bounds);
-            } else if (arguments.length === 1) {
-                throw new Error('Must set bounds when changing time system');
-            }
-            return this.system;
-        };
+    /**
+     * Get or set the time system of the TimeConductor. Time systems determine
+     * units, epoch, and other aspects of time representation. When changing
+     * the time system in use, new valid bounds must also be provided.
+     * @param {TimeSystem} newTimeSystem
+     * @param {TimeConductorBounds} bounds
+     * @fires TimeConductor#timeSystem
+     * @returns {TimeSystem} The currently applied time system
+     */
+    TimeConductor.prototype.timeSystem = function (newTimeSystem, bounds) {
+        if (arguments.length >= 2) {
+            this.system = newTimeSystem;
+            /**
+             * @event TimeConductor#timeSystem The time system used by the time
+             * conductor has changed. A change in Time System will always be
+             * followed by a bounds event specifying new query bounds
+             * @property {TimeSystem} The value of the currently applied
+             * Time System
+             * */
+            this.emit('timeSystem', this.system);
+            // Do something with bounds here. Try and convert between
+            // time systems? Or just set defaults when time system changes?
+            // eg.
+            this.bounds(bounds);
+        } else if (arguments.length === 1) {
+            throw new Error('Must set bounds when changing time system');
+        }
+        return this.system;
+    };
 
-        /**
-         * The Time of Interest is the temporal focus of the current view. It can be manipulated by the user from the time
-         * conductor or from other views.
-         * @fires TimeConductor#timeOfInterest
-         * @param newTOI
-         * @returns {*}
-         */
-        TimeConductor.prototype.timeOfInterest = function (newTOI) {
-            if (arguments.length === 1) {
-                this.toi = newTOI;
-                /**
-                 * @event TimeConductor#timeOfInterest The Time of Interest has moved.
-                 * @property {number} Current time of interest
-                 */
-                this.emit('timeOfInterest');
-            }
-            return this.toi;
-        };
+    /**
+     * Get or set the Time of Interest. The Time of Interest is the temporal
+     * focus of the current view. It can be manipulated by the user from the
+     * time conductor or from other views.
+     * @fires TimeConductor#timeOfInterest
+     * @param newTOI
+     * @returns {number} the current time of interest
+     */
+    TimeConductor.prototype.timeOfInterest = function (newTOI) {
+        if (arguments.length > 0) {
+            this.toi = newTOI;
+            /**
+             * @event TimeConductor#timeOfInterest The Time of Interest has moved.
+             * @property {number} Current time of interest
+             */
+            this.emit('timeOfInterest', this.toi);
+        }
+        return this.toi;
+    };
 
-        return TimeConductor;
+    return TimeConductor;
 });

--- a/src/api/TimeConductor.js
+++ b/src/api/TimeConductor.js
@@ -1,0 +1,150 @@
+define(['EventEmitter'],
+    function (EventEmitter) {
+
+        /**
+         * The public API for setting and querying time conductor state. The
+         * TimeConductor is an event emitter and extends the EventEmitter
+         * class. A number of events are fired when properties of the time
+         * conductor change, and these are documented below.
+         * @constructor
+         */
+        function TimeConductor() {
+            EventEmitter.call(this);
+
+            //The Time System
+            this.system = undefined;
+            //The Time Of Interest
+            this.toi = undefined;
+
+            this.boundsVal = {
+                start: undefined,
+                end: undefined
+            };
+
+            //Default to fixed mode
+            this.followMode = false;
+        }
+
+        TimeConductor.prototype = Object.create(EventEmitter.prototype);
+
+        /**
+         * Validate the given bounds. This can be used for pre-validation of
+         * bounds, for example by views validating user inputs.
+         * @param bounds The start and end time of the conductor.
+         * @returns {string | true} A validation error, or true if valid
+         */
+        TimeConductor.prototype.validateBounds = function (bounds) {
+            if (!bounds.start ||
+                !bounds.end ||
+                isNaN(bounds.start) ||
+                isNaN(bounds.end)
+            ) {
+                return "Start and end must be specified as integer values";
+            } else if (bounds.start > bounds.end){
+                return "Specified start date exceeds end bound";
+            }
+            return true;
+        };
+
+        function throwOnError(validationResult) {
+            if (validationResult !== true) {
+                throw validationResult;
+            }
+        }
+
+        /**
+         * Switch the time conductor between follow and fixed modes. In
+         * follow mode the time conductor ticks.
+         * @fires TimeConductor#follow
+         * @param followMode
+         * @returns {*}
+         */
+        TimeConductor.prototype.follow = function (followMode) {
+            if (arguments.length === 1) {
+                this.followMode = followMode;
+                /**
+                 * @event TimeConductor#follow The TimeConductor has toggled
+                 * into or out of follow mode.
+                 * @property {boolean} followMode true if follow mode is
+                 * enabled, otherwise false.
+                 */
+                this.emit('follow', followMode);
+            }
+            return this.followMode;
+        };
+
+        /**
+         * @typedef {Object} TimeConductorBounds
+         * @property {number} start The start time displayed by the time conductor in ms since epoch. Epoch determined by current time system
+         * @property {number} end The end time displayed by the time conductor in ms since epoch.
+         */
+        /**
+         * Set the start and end time of the time conductor. Basic validation of bounds is performed.
+         *
+         * @param {TimeConductorBounds} newBounds
+         * @param {TimeConductorBounds} should this change trigger a refresh?
+         * @throws {string} Validation error
+         * @fires TimeConductor#bounds
+         * @returns {TimeConductorBounds}
+         */
+        TimeConductor.prototype.bounds = function (newBounds) {
+            if (arguments.length === 1) {
+                throwOnError(this.validateBounds(newBounds));
+                this.boundsVal = newBounds;
+                /**
+                 * @event TimeConductor#bounds The start time, end time, or
+                 * both have been updated
+                 * @property {TimeConductorBounds} bounds
+                 */
+                this.emit('bounds', this.boundsVal);
+            }
+            return this.boundsVal;
+        };
+
+        /**
+         * Set the time system of the TimeConductor. Time systems determine units, epoch, and other aspects of time representation.
+         * @param newTimeSystem
+         * @fires TimeConductor#timeSystem
+         * @returns {TimeSystem} The currently applied time system
+         */
+        TimeConductor.prototype.timeSystem = function (newTimeSystem) {
+            if (arguments.length === 1) {
+                this.system = newTimeSystem;
+                /**
+                 * @event TimeConductor#timeSystem The time system used by the time
+                 * conductor has changed. A change in Time System will always be
+                 * followed by a bounds event specifying new query bounds
+                 * @property {TimeSystem} The value of the currently applied
+                 * Time System
+                 * */
+                this.emit('timeSystem', this.system);
+                // Do something with bounds here. Try and convert between
+                // time systems? Or just set defaults when time system changes?
+                // eg.
+                // this.bounds(this.system.DEFAULT_BOUNDS);
+                this.emit('bounds', this.bounds());
+            }
+            return this.system;
+        };
+
+        /**
+         * The Time of Interest is the temporal focus of the current view. It can be manipulated by the user from the time
+         * conductor or from other views.
+         * @fires TimeConductor#timeOfInterest
+         * @param newTOI
+         * @returns {*}
+         */
+        TimeConductor.prototype.timeOfInterest = function (newTOI) {
+            if (arguments.length === 1) {
+                this.toi = newTOI;
+                /**
+                 * @event TimeConductor#timeOfInterest The Time of Interest has moved.
+                 * @property {number} Current time of interest
+                 */
+                this.emit('timeOfInterest');
+            }
+            return this.toi;
+        };
+
+        return TimeConductor;
+});

--- a/src/api/TimeConductorSpec.js
+++ b/src/api/TimeConductorSpec.js
@@ -1,0 +1,110 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2015, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(['./TimeConductor'], function (TimeConductor) {
+    describe("The Time Conductor", function () {
+        var tc,
+            timeSystem,
+            bounds,
+            eventListener,
+            toi,
+            follow;
+
+        beforeEach(function () {
+            tc = new TimeConductor();
+            timeSystem = {};
+            bounds = {start: 0, end: 0};
+            eventListener = jasmine.createSpy("eventListener");
+            toi = 111;
+            follow = true;
+        });
+
+        it("Supports setting and querying of time of interest and and follow mode", function () {
+            expect(tc.timeOfInterest()).not.toBe(toi);
+            tc.timeOfInterest(toi);
+            expect(tc.timeOfInterest()).toBe(toi);
+
+            expect(tc.follow()).not.toBe(follow);
+            tc.follow(follow);
+            expect(tc.follow()).toBe(follow);
+        });
+
+        it("Allows setting of valid bounds", function () {
+            bounds = {start: 0, end: 1};
+            expect(tc.bounds()).not.toBe(bounds);
+            expect(tc.bounds.bind(tc, bounds)).not.toThrow();
+            expect(tc.bounds()).toBe(bounds);
+        });
+
+        it("Disallows setting of invalid bounds", function () {
+            bounds = {start: 1, end: 0};
+            expect(tc.bounds()).not.toBe(bounds);
+            expect(tc.bounds.bind(tc, bounds)).toThrow();
+            expect(tc.bounds()).not.toBe(bounds);
+
+            bounds = {start: 1};
+            expect(tc.bounds()).not.toBe(bounds);
+            expect(tc.bounds.bind(tc, bounds)).toThrow();
+            expect(tc.bounds()).not.toBe(bounds);
+        });
+
+        it("Allows setting of time system with bounds", function () {
+            expect(tc.timeSystem()).not.toBe(timeSystem);
+            expect(tc.timeSystem.bind(tc, timeSystem, bounds)).not.toThrow();
+            expect(tc.timeSystem()).toBe(timeSystem);
+        });
+
+        it("Disallows setting of time system without bounds", function () {
+            expect(tc.timeSystem()).not.toBe(timeSystem);
+            expect(tc.timeSystem.bind(tc, timeSystem)).toThrow();
+            expect(tc.timeSystem()).not.toBe(timeSystem);
+        });
+
+        it("Emits an event when time system changes", function () {
+            expect(eventListener).not.toHaveBeenCalled();
+            tc.on("timeSystem", eventListener);
+            tc.timeSystem(timeSystem, bounds);
+            expect(eventListener).toHaveBeenCalledWith(timeSystem);
+        });
+
+        it("Emits an event when time of interest changes", function () {
+            expect(eventListener).not.toHaveBeenCalled();
+            tc.on("timeOfInterest", eventListener);
+            tc.timeOfInterest(toi);
+            expect(eventListener).toHaveBeenCalledWith(toi);
+        });
+
+        it("Emits an event when bounds change", function () {
+            expect(eventListener).not.toHaveBeenCalled();
+            tc.on("bounds", eventListener);
+            tc.bounds(bounds);
+            expect(eventListener).toHaveBeenCalledWith(bounds);
+        });
+
+        it("Emits an event when follow mode changes", function () {
+            expect(eventListener).not.toHaveBeenCalled();
+            tc.on("follow", eventListener);
+            tc.follow(follow);
+            expect(eventListener).toHaveBeenCalledWith(follow);
+        });
+    });
+});

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,14 +1,17 @@
 define([
     './Type',
+    './TimeConductor',
     './View',
     './objects/ObjectAPI'
 ], function (
     Type,
+    TimeConductor,
     View,
     ObjectAPI
 ) {
     return {
         Type: Type,
+        TimeConductor: new TimeConductor(),
         View: View,
         Objects: ObjectAPI
     };


### PR DESCRIPTION
Fresh PR with just API proposed in meeting of 06/29/2016. Included API proposal from meeting below. Note that this PR is based on previous iterations of a notional API captured in #1002

Merge target is api-tutorials

```javascript
/*
 events:
'bounds'
'follow'
'system'
'timeOfInterest'

note: A 'system' event is always followed by a 'bounds' event.
Or more precisely, once a system event has been received, views should wait for
a bounds event before updating their view.  It's probably a good time to show a
loading indicator.

Can we assume that follow "true" + bounds = you should have received data via
subscription?  Nope, but for now, for most future cases, we can.  We know
predicted data that is stored as historic data will cause issues but we think
that is better addressed in the future.

We see some future need for a 'synchronize' to force views to synchronize, but
no need to implement now.  YAGNI!

Tick sources-- tick sources will not be a part of the formal API, time systems
should define tick sources but the time conductor API will not expose a method
for picking which tick source is used.  At this time, the Time Conductor View
will have this sole responsibility.  If it is necessary to add it to the public
API later, we can do that.

*/

tc.on('bounds', plot.panIfNotDisconnected);

tc.on('follow', plot.warnIfFollowingAndDisconnected);

tc.on('system', plot.setSystemAndReconnect);

tc.on('timeOfInterest', plot.highlightTOI);

plot.focusArea = function (start, end) {
    MCT.conductor.follow(false);
    MCT.conductor.bound({start: start, end: end});
}

// YAGNI, so far.  we think we need it, we can wait for a bug report later.
// tc.on('synchronize', plot.reconnect);
```javascript