### PR TITLE
[Search] Amended ClickAwayController to trigger digest via $apply instead of $timeout.

### DIFF
--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -259,7 +259,7 @@ define([
                     "implementation": ClickAwayController,
                     "depends": [
                         "$document",
-                        "$timeout"
+                        "$scope"
                     ]
                 },
                 {

--- a/platform/commonUI/general/src/controllers/ClickAwayController.js
+++ b/platform/commonUI/general/src/controllers/ClickAwayController.js
@@ -34,7 +34,7 @@ define(
          * @param $scope the scope in which this controller is active
          * @param $document the document element, injected by Angular
          */
-        function ClickAwayController($document, $timeout) {
+        function ClickAwayController($document, $scope) {
             var self = this;
 
             this.state = false;
@@ -44,7 +44,7 @@ define(
             // `clickaway` action occurs after `toggle` if `toggle` is
             // triggered by a click/mouseup.
             this.clickaway = function () {
-                $timeout(function () {
+                $scope.$apply(function () {
                     self.deactivate();
                 });
             };

--- a/platform/commonUI/general/test/controllers/ClickAwayControllerSpec.js
+++ b/platform/commonUI/general/test/controllers/ClickAwayControllerSpec.js
@@ -26,7 +26,7 @@ define(
 
         describe("The click-away controller", function () {
             var mockDocument,
-                mockTimeout,
+                mockScope,
                 controller;
 
             beforeEach(function () {
@@ -34,10 +34,11 @@ define(
                     "$document",
                     ["on", "off"]
                 );
-                mockTimeout = jasmine.createSpy('timeout');
+                mockScope = jasmine.createSpyObj('$scope', ['$apply']);
+
                 controller = new ClickAwayController(
                     mockDocument,
-                    mockTimeout
+                    mockScope
                 );
             });
 
@@ -77,18 +78,15 @@ define(
             });
 
             it("deactivates and detaches listener on document click", function () {
-                var callback, timeout;
+                var callback, apply;
                 controller.setState(true);
                 callback = mockDocument.on.mostRecentCall.args[1];
                 callback();
-                timeout = mockTimeout.mostRecentCall.args[0];
-                timeout();
+                apply = mockScope.$apply.mostRecentCall.args[0];
+                apply();
                 expect(controller.isActive()).toEqual(false);
                 expect(mockDocument.off).toHaveBeenCalledWith("mouseup", callback);
             });
-
-
-
         });
     }
 );


### PR DESCRIPTION
## Changes
* On click trigger digest via $scope.$apply rather than via $timeout as was occurring previously. The `ClickAwayController` attaches a dismiss event via `document.on('mouseup'...`. The `search-menu` sets the `ClickAwayController` active when the user clicks anywhere inside it, but the document event is also triggered. This means it is dependent on the order in which those two events are fired. 

    Using `$timeout` meant that the document event was deferred until after click event inside the menu, causing the controller to be deactivated and the menu to be dismissed. Using `$apply` instead still triggers a digest, which is needed, but retains the necessary ordering of events due to its synchronous nature.
* Updated tests

## Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y