### PR TITLE
[Context] Remove excessive warnings

### DIFF
--- a/platform/core/src/services/Contextualize.js
+++ b/platform/core/src/services/Contextualize.js
@@ -68,7 +68,7 @@ define(
                 // Don't validate while editing; consistency is not
                 // necessarily expected due to unsaved changes.
                 var editor = domainObject.getCapability('editor');
-                if (editor && !editor.inEditContext()) {
+                if (!editor || !editor.inEditContext()) {
                     validate(domainObject.getId(), parentObject);
                 }
 

--- a/platform/core/src/services/Contextualize.js
+++ b/platform/core/src/services/Contextualize.js
@@ -65,7 +65,13 @@ define(
              *        which should appear as the contextual parent
              */
             return function (domainObject, parentObject) {
-                validate(domainObject.getId(), parentObject);
+                // Don't validate while editing; consistency is not
+                // necessarily expected due to unsaved changes.
+                var editor = domainObject.getCapability('editor');
+                if (editor && !editor.inEditContext()) {
+                    validate(domainObject.getId(), parentObject);
+                }
+
                 return new ContextualDomainObject(domainObject, parentObject);
             };
         }

--- a/platform/core/test/services/ContextualizeSpec.js
+++ b/platform/core/test/services/ContextualizeSpec.js
@@ -36,6 +36,7 @@ define(
             var mockLog,
                 mockDomainObject,
                 mockParentObject,
+                mockEditor,
                 testParentModel,
                 contextualize;
 
@@ -52,10 +53,18 @@ define(
                 mockParentObject =
                     jasmine.createSpyObj('parentObject', DOMAIN_OBJECT_METHODS);
 
+                mockEditor =
+                    jasmine.createSpyObj('editor', ['inEditContext']);
+
                 mockDomainObject.getId.andReturn("abc");
                 mockDomainObject.getModel.andReturn({});
                 mockParentObject.getId.andReturn("parent");
                 mockParentObject.getModel.andReturn(testParentModel);
+
+                mockEditor.inEditContext.andReturn(false);
+                mockDomainObject.getCapability.andCallFake(function (c) {
+                    return c === 'editor' && mockEditor;
+                });
 
                 contextualize = new Contextualize(mockLog);
             });
@@ -82,6 +91,12 @@ define(
                 expect(mockLog.warn).toHaveBeenCalled();
             });
 
+            it("does not issue warnings for objects being edited", function () {
+                mockEditor.inEditContext.andReturn(true);
+                testParentModel.composition = ["xyz"];
+                contextualize(mockDomainObject, mockParentObject);
+                expect(mockLog.warn).not.toHaveBeenCalled();
+            });
 
         });
     }


### PR DESCRIPTION
Check if domain objects are in edit mode before validating against their parent's composition; if they are in edit mode, do not expect consistency (and so do not warn about it.) Addresses #624 

Notably, this adds an implicit dependency between core and edit mode. Think this will be resolved by planned longer-term API/architecture changes, particularly to how context is represented (no longer a property of the object, but part of the information passed in to actions/views/etc), after which the `contextualize` service will simply be obsolete.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y