### PR TITLE
[Persistence] Clear transactions selectively

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -42,6 +42,7 @@ define([
     "./src/representers/EditToolbarRepresenter",
     "./src/capabilities/EditorCapability",
     "./src/capabilities/TransactionCapabilityDecorator",
+    "./src/services/TransactionManager",
     "./src/services/TransactionService",
     "./src/creation/CreateMenuController",
     "./src/creation/LocatorController",
@@ -80,6 +81,7 @@ define([
     EditToolbarRepresenter,
     EditorCapability,
     TransactionCapabilityDecorator,
+    TransactionManager,
     TransactionService,
     CreateMenuController,
     LocatorController,
@@ -320,7 +322,7 @@ define([
                     "implementation": TransactionCapabilityDecorator,
                     "depends": [
                         "$q",
-                        "transactionService"
+                        "transactionManager"
                     ],
                     "priority": "fallback"
                 },
@@ -404,6 +406,15 @@ define([
                 {
                     "key": "locator",
                     "template": locatorTemplate
+                }
+            ],
+            "services": [
+                {
+                    "key": "transactionManager",
+                    "implementation": TransactionManager,
+                    "depends": [
+                        "transactionService"
+                    ]
                 }
             ]
         }

--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -222,8 +222,7 @@ define([
                         "policyService",
                         "dialogService",
                         "creationService",
-                        "copyService",
-                        "transactionService"
+                        "copyService"
                     ],
                     "priority": "mandatory"
                 },

--- a/platform/commonUI/edit/src/actions/SaveAsAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAsAction.js
@@ -44,7 +44,6 @@ define([
             dialogService,
             creationService,
             copyService,
-            transactionService,
             context
         ) {
             this.domainObject = (context || {}).domainObject;
@@ -55,7 +54,6 @@ define([
             this.dialogService = dialogService;
             this.creationService = creationService;
             this.copyService = copyService;
-            this.transactionService = transactionService;
         }
 
         /**
@@ -113,8 +111,6 @@ define([
             var self = this,
                 domainObject = this.domainObject,
                 copyService = this.copyService,
-                transactionService = this.transactionService,
-                cancelOldTransaction,
                 dialog = new SaveInProgressDialog(this.dialogService);
 
             function doWizardSave(parent) {
@@ -160,16 +156,6 @@ define([
                     .then(resolveWith(clonedObject));
             }
 
-            function restartTransaction(object) {
-                cancelOldTransaction = transactionService.restartTransaction();
-                return object;
-            }
-
-            function doCancelOldTransaction(object) {
-                cancelOldTransaction();
-                return object;
-            }
-
             function onFailure() {
                 hideBlockingDialog();
                 return false;
@@ -179,10 +165,8 @@ define([
                 .then(doWizardSave)
                 .then(showBlockingDialog)
                 .then(getParent)
-                .then(restartTransaction)
                 .then(cloneIntoParent)
                 .then(commitEditingAfterClone)
-                .then(doCancelOldTransaction)
                 .then(hideBlockingDialog)
                 .catch(onFailure);
         };

--- a/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
@@ -49,6 +49,7 @@ define(
             this.domainObject = domainObject;
             this.$q = $q;
             this.persistPending = false;
+            this.removeFromTransaction = undefined;
         }
 
         /**
@@ -75,6 +76,7 @@ define(
                     });
                 } else {
                     self.persistPending = false;
+                    self.removeFromTransaction = undefined;
                     //Model is undefined in persistence, so return undefined.
                     return self.$q.when(undefined);
                 }
@@ -82,7 +84,8 @@ define(
 
             if (this.transactionService.isActive()) {
                 if (!this.persistPending) {
-                    this.transactionService.addToTransaction(onCommit, onCancel);
+                    this.removeFromTransaction = this.transactionService
+                        .addToTransaction(onCommit, onCancel);
                     this.persistPending = true;
                 }
                 //Need to return a promise from this function
@@ -93,6 +96,11 @@ define(
         };
 
         TransactionalPersistenceCapability.prototype.refresh = function () {
+            if (this.persistPending) {
+                this.persistPending = false;
+                this.removeFromTransaction();
+                this.removeFromTransaction = undefined;
+            }
             return this.persistenceCapability.refresh();
         };
 

--- a/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
@@ -24,7 +24,6 @@
 define(
     [],
     function () {
-        var TRANSACTION_SET = {};
 
         /**
          * Wraps persistence capability to enable transactions. Transactions

--- a/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
+++ b/platform/commonUI/edit/src/capabilities/TransactionalPersistenceCapability.js
@@ -60,7 +60,7 @@ define(
 
             if (this.transactionManager.isActive()) {
                 this.transactionManager.addToTransaction(
-                    this.domainObject,
+                    this.domainObject.getId(),
                     wrappedPersistence.persist.bind(wrappedPersistence),
                     wrappedPersistence.refresh.bind(wrappedPersistence)
                 );
@@ -72,7 +72,8 @@ define(
         };
 
         TransactionalPersistenceCapability.prototype.refresh = function () {
-            this.transactionManager.clearTransactionsFor(this.domainObject);
+            this.transactionManager
+                .clearTransactionsFor(this.domainObject.getId());
             return this.persistenceCapability.refresh();
         };
 

--- a/platform/commonUI/edit/src/services/TransactionManager.js
+++ b/platform/commonUI/edit/src/services/TransactionManager.js
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([], function () {
+    /**
+     * Manages transactions to support the TransactionalPersistenceCapability.
+     */
+    function TransactionManager(transactionService) {
+        this.transactionService = transactionService;
+        this.clearTransactionFns = {};
+    }
+
+    TransactionManager.prototype.isActive = function () {
+        return this.transactionService.isActive();
+    };
+
+    TransactionManager.prototype.isScheduled = function (domainObject) {
+        return !!this.clearTransactionFns[domainObject.getId()];
+    };
+
+    TransactionManager.prototype.addToTransaction = function (
+        domainObject,
+        onCommit,
+        onCancel
+    ) {
+        var release = this.releaseClearFn.bind(this, domainObject);
+
+        function chain(promiseFn, nextFn) {
+            return function () {
+                return promiseFn().then(nextFn);
+            };
+        }
+
+        if (!this.isScheduled(domainObject)) {
+            this.clearTransactionFns[domainObject.getId()] =
+                this.transactionService.addToTransaction(
+                    chain(onCommit, release),
+                    chain(onCancel, release)
+                );
+        }
+    };
+
+    TransactionManager.prototype.clearTransactionsFor = function (domainObject) {
+        if (this.isScheduled(domainObject)) {
+            this.clearTransactionFns[domainObject.getId()]();
+            this.releaseClearFn(domainObject);
+        }
+    };
+
+    TransactionManager.prototype.releaseClearFn = function (domainObject) {
+        delete this.clearTransactionFns[domainObject.getId()];
+    };
+
+    return TransactionManager;
+});

--- a/platform/commonUI/edit/src/services/TransactionManager.js
+++ b/platform/commonUI/edit/src/services/TransactionManager.js
@@ -46,11 +46,11 @@ define([], function () {
      * Check if callbacks associated with this domain object have already
      * been added to the active transaction.
      * @private
-     * @param {DomainObject} domainObject the object to check
+     * @param {string} id the identifier of the domain object to check
      * @returns {boolean} true if callbacks have been added
      */
-    TransactionManager.prototype.isScheduled = function (domainObject) {
-        return !!this.clearTransactionFns[domainObject.getId()];
+    TransactionManager.prototype.isScheduled = function (id) {
+        return !!this.clearTransactionFns[id];
     };
 
     /**
@@ -61,16 +61,16 @@ define([], function () {
      * If callbacks associated with this domain object have already been
      * added to the active transaction, this call will be ignored.
      *
-     * @param {DomainObject} domainObject the associated domain object
+     * @param {string} id the identifier of the associated domain object
      * @param {Function} onCommit behavior to invoke when committing transaction
      * @param {Function} onCancel behavior to invoke when cancelling transaction
      */
     TransactionManager.prototype.addToTransaction = function (
-        domainObject,
+        id,
         onCommit,
         onCancel
     ) {
-        var release = this.releaseClearFn.bind(this, domainObject);
+        var release = this.releaseClearFn.bind(this, id);
 
         function chain(promiseFn, nextFn) {
             return function () {
@@ -78,8 +78,8 @@ define([], function () {
             };
         }
 
-        if (!this.isScheduled(domainObject)) {
-            this.clearTransactionFns[domainObject.getId()] =
+        if (!this.isScheduled(id)) {
+            this.clearTransactionFns[id] =
                 this.transactionService.addToTransaction(
                     chain(onCommit, release),
                     chain(onCancel, release)
@@ -90,23 +90,23 @@ define([], function () {
     /**
      * Remove any callbacks associated with this domain object from the
      * active transaction.
-     * @param {DomainObject} domainObject the domain object
+     * @param {string} id the identifier for the domain object
      */
-    TransactionManager.prototype.clearTransactionsFor = function (domainObject) {
-        if (this.isScheduled(domainObject)) {
-            this.clearTransactionFns[domainObject.getId()]();
-            this.releaseClearFn(domainObject);
+    TransactionManager.prototype.clearTransactionsFor = function (id) {
+        if (this.isScheduled(id)) {
+            this.clearTransactionFns[id]();
+            this.releaseClearFn(id);
         }
     };
 
     /**
      * Release the cached "remove from transaction" function that has been
      * stored in association with this domain object.
-     * @param {DomainObject} domainObject the domain object
+     * @param {string} id the identifier for the domain object
      * @private
      */
-    TransactionManager.prototype.releaseClearFn = function (domainObject) {
-        delete this.clearTransactionFns[domainObject.getId()];
+    TransactionManager.prototype.releaseClearFn = function (id) {
+        delete this.clearTransactionFns[id];
     };
 
     return TransactionManager;

--- a/platform/commonUI/edit/src/services/TransactionService.js
+++ b/platform/commonUI/edit/src/services/TransactionService.js
@@ -140,38 +140,9 @@ define(
             });
         };
 
-        /**
-         * Clear and restart the active transaction.
-         *
-         * This neither cancels nor commits the active transaction;
-         * instead, it returns a function that can be used to cancel that
-         * transaction.
-         *
-         * @returns {Function} a function to cancel the prior transaction
-         * @private
-         */
-        TransactionService.prototype.restartTransaction = function () {
-            var oldOnCancels = this.onCancels;
-
-            this.onCommits = [];
-            this.onCancels = [];
-
-            return function () {
-                while (oldOnCancels.length > 0) {
-                    var onCancel = oldOnCancels.pop();
-                    try {
-                        onCancel();
-                    } catch (error) {
-                        this.$log.error("Error cancelling transaction.");
-                    }
-                }
-            };
-        };
-
         TransactionService.prototype.size = function () {
             return this.onCommits.length;
         };
 
         return TransactionService;
-    }
-);
+    });

--- a/platform/commonUI/edit/src/services/TransactionService.js
+++ b/platform/commonUI/edit/src/services/TransactionService.js
@@ -81,6 +81,15 @@ define(
                 //Log error because this is a programming error if it occurs.
                 this.$log.error("No transaction in progress");
             }
+
+            return function () {
+                this.onCommits = this.onCommits.filter(function (callback) {
+                    return callback !== onCommit;
+                });
+                this.onCancels = this.onCancels.filter(function (callback) {
+                    return callback !== onCancel;
+                });
+            }.bind(this);
         };
 
         /**

--- a/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
+++ b/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
@@ -34,7 +34,6 @@ define(
                 mockCopyService,
                 mockParent,
                 mockUrlService,
-                mockTransactionService,
                 actionContext,
                 capabilities = {},
                 action;
@@ -120,26 +119,11 @@ define(
                     ["urlForLocation"]
                 );
 
-                mockTransactionService = jasmine.createSpyObj(
-                    "transactionService",
-                    ["restartTransaction"]
-                );
-                mockTransactionService.restartTransaction
-                    .andReturn(jasmine.createSpy());
-
                 actionContext = {
                     domainObject: mockDomainObject
                 };
 
-                action = new SaveAsAction(
-                    undefined,
-                    undefined,
-                    mockDialogService,
-                    undefined,
-                    mockCopyService,
-                    mockTransactionService,
-                    actionContext
-                );
+                action = new SaveAsAction(undefined, undefined, mockDialogService, undefined, mockCopyService, actionContext);
 
                 spyOn(action, "getObjectService");
                 action.getObjectService.andReturn(mockObjectService);

--- a/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
+++ b/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
@@ -179,9 +179,15 @@ define(
             });
 
             it("hides the blocking dialog after saving", function () {
-                action.perform();
+                var mockCallback = jasmine.createSpy();
+                action.perform().then(mockCallback);
                 expect(mockDialogService.showBlockingMessage).toHaveBeenCalled();
-                expect(mockDialogService.dismiss).toHaveBeenCalled();
+                waitsFor(function () {
+                    return mockCallback.calls.length > 0;
+                });
+                runs(function () {
+                    expect(mockDialogService.dismiss).toHaveBeenCalled();
+                });
             });
 
         });

--- a/platform/commonUI/edit/test/capabilities/TransactionalPersistenceCapabilitySpec.js
+++ b/platform/commonUI/edit/test/capabilities/TransactionalPersistenceCapabilitySpec.js
@@ -40,9 +40,12 @@ define(
                 mockTransactionManager,
                 mockPersistence,
                 mockDomainObject,
+                testId,
                 capability;
 
             beforeEach(function () {
+                testId = "test-id";
+
                 mockQ = jasmine.createSpyObj("$q", ["when"]);
                 mockQ.when.andCallFake(function (val) {
                     return fastPromise(val);
@@ -60,11 +63,10 @@ define(
 
                 mockDomainObject = jasmine.createSpyObj(
                     "domainObject",
-                    [
-                        "getModel"
-                    ]
+                    ["getModel", "getId"]
                 );
                 mockDomainObject.getModel.andReturn({persisted: 1});
+                mockDomainObject.getId.andReturn(testId);
 
                 capability = new TransactionalPersistenceCapability(
                     mockQ,
@@ -100,7 +102,7 @@ define(
             it("clears transactions and delegates refresh calls", function () {
                 capability.refresh();
                 expect(mockTransactionManager.clearTransactionsFor)
-                    .toHaveBeenCalledWith(mockDomainObject);
+                    .toHaveBeenCalledWith(testId);
                 expect(mockPersistence.refresh)
                     .toHaveBeenCalled();
             });

--- a/platform/commonUI/edit/test/capabilities/TransactionalPersistenceCapabilitySpec.js
+++ b/platform/commonUI/edit/test/capabilities/TransactionalPersistenceCapabilitySpec.js
@@ -92,6 +92,18 @@ define(
                 expect(mockPersistence.refresh).toHaveBeenCalled();
             });
 
+            it("wraps getSpace", function () {
+                mockPersistence.getSpace.andReturn('foo');
+                expect(capability.getSpace()).toEqual('foo');
+            });
+
+            it("clears transactions and delegates refresh calls", function () {
+                capability.refresh();
+                expect(mockTransactionManager.clearTransactionsFor)
+                    .toHaveBeenCalledWith(mockDomainObject);
+                expect(mockPersistence.refresh)
+                    .toHaveBeenCalled();
+            });
 
         });
     }

--- a/platform/commonUI/edit/test/services/TransactionManagerSpec.js
+++ b/platform/commonUI/edit/test/services/TransactionManagerSpec.js
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+/*global define,describe,it,expect,beforeEach,jasmine*/
+
+define(
+    ["../../src/services/TransactionManager"],
+    function (TransactionManager) {
+        describe("TransactionManager", function () {
+            var mockTransactionService,
+                mockOnCommit,
+                mockOnCancel,
+                mockRemoves,
+                manager;
+
+            beforeEach(function () {
+                mockRemoves = [];
+                mockTransactionService = jasmine.createSpyObj(
+                    "transactionService",
+                    [ "addToTransaction", "isActive" ]
+                );
+                mockOnCommit = jasmine.createSpy('commit');
+                mockOnCancel = jasmine.createSpy('cancel');
+
+                mockTransactionService.addToTransaction.andCallFake(function () {
+                    var mockRemove =
+                        jasmine.createSpy('remove-' + mockRemoves.length);
+                    mockRemoves.push(mockRemove);
+                    return mockRemove;
+                });
+
+                manager = new TransactionManager(mockTransactionService);
+            });
+
+            it("delegates isActive calls", function () {
+                [false, true].forEach(function (state) {
+                    mockTransactionService.isActive.andReturn(state);
+                    expect(manager.isActive()).toBe(state);
+                });
+            });
+        });
+    }
+);

--- a/platform/commonUI/edit/test/services/TransactionManagerSpec.js
+++ b/platform/commonUI/edit/test/services/TransactionManagerSpec.js
@@ -26,7 +26,7 @@ define(
     function (TransactionManager) {
         describe("TransactionManager", function () {
             var mockTransactionService,
-                mockDomainObject,
+                testId,
                 mockOnCommit,
                 mockOnCancel,
                 mockRemoves,
@@ -41,11 +41,7 @@ define(
                 );
                 mockOnCommit = jasmine.createSpy('commit');
                 mockOnCancel = jasmine.createSpy('cancel');
-                mockDomainObject = jasmine.createSpyObj(
-                    'domainObject',
-                    ['getId', 'getModel', 'getCapability']
-                );
-                mockDomainObject.getId.andReturn('testId');
+                testId = 'test-id';
                 mockPromise = jasmine.createSpyObj('promise', ['then']);
 
                 mockOnCommit.andReturn(mockPromise);
@@ -71,7 +67,7 @@ define(
             describe("when addToTransaction is called", function () {
                 beforeEach(function () {
                     manager.addToTransaction(
-                        mockDomainObject,
+                        testId,
                         mockOnCommit,
                         mockOnCancel
                     );
@@ -99,7 +95,7 @@ define(
 
                 it("ignores subsequent calls for the same object", function () {
                     manager.addToTransaction(
-                        mockDomainObject,
+                        testId,
                         jasmine.createSpy(),
                         jasmine.createSpy()
                     );
@@ -108,9 +104,8 @@ define(
                 });
 
                 it("accepts subsequent calls for other objects", function () {
-                    mockDomainObject.getId.andReturn('otherId');
                     manager.addToTransaction(
-                        mockDomainObject,
+                        'other-id',
                         jasmine.createSpy(),
                         jasmine.createSpy()
                     );
@@ -124,7 +119,7 @@ define(
 
                 describe("and clearTransactionsFor is subsequently called", function () {
                     beforeEach(function () {
-                        manager.clearTransactionsFor(mockDomainObject);
+                        manager.clearTransactionsFor(testId);
                     });
 
                     it("removes callbacks from the transaction", function () {

--- a/platform/commonUI/edit/test/services/TransactionManagerSpec.js
+++ b/platform/commonUI/edit/test/services/TransactionManagerSpec.js
@@ -37,13 +37,13 @@ define(
                 mockRemoves = [];
                 mockTransactionService = jasmine.createSpyObj(
                     "transactionService",
-                    [ "addToTransaction", "isActive" ]
+                    ["addToTransaction", "isActive"]
                 );
                 mockOnCommit = jasmine.createSpy('commit');
                 mockOnCancel = jasmine.createSpy('cancel');
                 mockDomainObject = jasmine.createSpyObj(
                     'domainObject',
-                    [ 'getId', 'getModel', 'getCapability' ]
+                    ['getId', 'getModel', 'getCapability']
                 );
                 mockDomainObject.getId.andReturn('testId');
                 mockPromise = jasmine.createSpyObj('promise', ['then']);

--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -152,6 +152,10 @@ define(
                 }, modified);
             }
 
+            if (domainObject.getModel().persisted === undefined) {
+                return this.$q.when(true);
+            }
+
             return this.persistenceService.readObject(
                     this.getSpace(),
                     this.getKey()

--- a/platform/core/test/capabilities/PersistenceCapabilitySpec.js
+++ b/platform/core/test/capabilities/PersistenceCapabilitySpec.js
@@ -74,7 +74,7 @@ define(
                 );
                 mockQ = jasmine.createSpyObj(
                     "$q",
-                    ["reject"]
+                    ["reject", "when"]
                 );
                 mockNofificationService = jasmine.createSpyObj(
                     "notificationService",
@@ -103,6 +103,7 @@ define(
                 mockIdentifierService.parse.andReturn(mockIdentifier);
                 mockIdentifier.getSpace.andReturn(SPACE);
                 mockIdentifier.getKey.andReturn(key);
+                mockQ.when.andCallFake(asPromise);
                 persistence = new PersistenceCapability(
                     mockCacheService,
                     mockPersistenceService,
@@ -156,6 +157,7 @@ define(
                 });
                 it("refreshes the domain object model from persistence", function () {
                     var refreshModel = {someOtherKey: "some other value"};
+                    model.persisted = 1;
                     mockPersistenceService.readObject.andReturn(asPromise(refreshModel));
                     persistence.refresh();
                     expect(model).toEqual(refreshModel);


### PR DESCRIPTION
When persisting changes to domain objects from Edit mode via cloning, clear out any persistence tasks from the active transaction for objects that will be represented by clones when the Save operation completes. This prevents persistence calls from being made to the pre-cloned versions of the objects (which can cause errors, as seen in #1046), while avoiding the removal of necessary persistence calls (resolving the erroneous behavior from WARP referenced in #1059)

An intermediary `transactionManager` has been introduced (as an Angular service) to mediate between the TransactionalPersistenceCapability and the TransactionService. In particular, this provides a single place of knowledge about whether domain objects are or are not scheduled for persistence in the active transaction; this avoids redundant persist calls, and also avoids cases in which some persist calls are not unscheduled (as observed with #1051.) Arguably, this behavior could have just been merged into TransactionService (which is not used much elsewhere); preferring to introduce an intermediary to isolate changes/responsibilities.

Also reverts changes from #1050 (since we preferred the approach from #1051 but needed more debugging time to get it to work)

Still to-do:

- [x] Verify #1046 has not regressed in VISTA
- [x] Verify that timeline issues really don't occur in WARP
- [x] Add unit tests
- [x] JSDoc