### PR TITLE
[Build] Normalize reporting for QA tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,7 @@ var gulp = require('gulp'),
         main: 'main.js',
         dist: 'dist',
         assets: 'dist/assets',
+        reports: 'dist/reports',
         scss: ['./platform/**/*.scss', './example/**/*.scss'],
         scripts: [ 'main.js', 'platform/**/*.js', 'src/**/*.js' ],
         specs: [ 'platform/**/*Spec.js', 'src/**/*Spec.js' ],
@@ -112,6 +113,10 @@ gulp.task('lint', function () {
             .pipe(jshint({ jasmine: true }));
 
     return merge(scriptLint, specLint)
+        .pipe(jshint.reporter('gulp-jshint-html-reporter', {
+            filename: paths.reports + '/lint/jshint-report.html',
+            createMissingFolders : true
+        }))
         .pipe(jshint.reporter('default'))
         .pipe(jshint.reporter('fail'));
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -81,7 +81,7 @@ module.exports = function(config) {
         coverageReporter: {
             dir: process.env.CIRCLE_ARTIFACTS ?
                 process.env.CIRCLE_ARTIFACTS + '/coverage' :
-                "dist/coverage",
+                "dist/reports/coverage",
             check: {
                 global: {
                     lines: 80
@@ -91,13 +91,13 @@ module.exports = function(config) {
 
         // HTML test reporting.
         htmlReporter: {
-            outputDir: "target/tests",
+            outputDir: "dist/reports/tests",
             preserveDescribeNesting: true,
             foldAll: false
         },
 
         junitReporter: {
-            outputDir: process.env.CIRCLE_TEST_REPORTS || 'target/junit'
+            outputDir: process.env.CIRCLE_TEST_REPORTS || 'dist/reports/junit'
         },
 
         // Continuous Integration mode.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp": "^3.9.0",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
+    "gulp-jshint-html-reporter": "^0.1.3",
     "gulp-rename": "^1.2.2",
     "gulp-replace-task": "^0.11.0",
     "gulp-requirejs-optimize": "^0.3.1",


### PR DESCRIPTION
Supports retention of test reports, https://developer.nasa.gov/ResourceProspector/warp/issues/191

Summary of changes:

* Add JSHint reporter for lint errors
* Move all reports to `dist/reports` to simplify retaining the relevant build artifacts