### PR TITLE
[Tree] Simplify synchronization

### DIFF
--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -381,7 +381,7 @@ define([
                 {
                     "key": "mctTree",
                     "implementation": MCTTree,
-                    "depends": ['$parse', 'gestureService']
+                    "depends": ['gestureService']
                 }
             ],
             "constants": [

--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -24,20 +24,17 @@ define([
     'angular',
     '../ui/TreeView'
 ], function (angular, TreeView) {
-    function MCTTree($parse, gestureService) {
-        function link(scope, element, attrs) {
+    function MCTTree(gestureService) {
+        function link(scope, element) {
             var treeView = new TreeView(gestureService),
-                expr = $parse(attrs.mctModel),
                 unobserve = treeView.observe(function (domainObject) {
-                    if (domainObject !== expr(scope.$parent)) {
-                        expr.assign(scope.$parent, domainObject);
-                        scope.$apply();
-                    }
+                    scope.mctModel = domainObject;
+                    scope.$apply();
                 });
 
             element.append(angular.element(treeView.elements()));
 
-            scope.$parent.$watch(attrs.mctModel, treeView.value.bind(treeView));
+            scope.$watch('mctModel', treeView.value.bind(treeView));
             scope.$watch('mctObject', treeView.model.bind(treeView));
             scope.$on('$destroy', unobserve);
         }
@@ -45,7 +42,7 @@ define([
         return {
             restrict: "E",
             link: link,
-            scope: { mctObject: "=" }
+            scope: { mctObject: "=", mctModel: "=" }
         };
     }
 

--- a/platform/commonUI/general/test/directives/MCTTreeSpec.js
+++ b/platform/commonUI/general/test/directives/MCTTreeSpec.js
@@ -46,8 +46,8 @@ define([
             expect(mctTree.restrict).toEqual("E");
         });
 
-        it("two-way binds to mctObject", function () {
-            expect(mctTree.scope).toEqual({ mctObject: "=" });
+        it("two-way binds to mctObject and mctModel", function () {
+            expect(mctTree.scope).toEqual({ mctObject: "=", mctModel: "=" });
         });
 
         describe("link", function () {
@@ -69,8 +69,8 @@ define([
             });
 
             it("watches for mct-model's expression in the parent", function () {
-                expect(mockScope.$parent.$watch).toHaveBeenCalledWith(
-                    testAttrs.mctModel,
+                expect(mockScope.$watch).toHaveBeenCalledWith(
+                    "mctModel",
                     jasmine.any(Function)
                 );
             });


### PR DESCRIPTION
Simplify synchronization of selection in tree with state passed-in, letting Angular deal with more of the specifics. Fixes #1008.

It's a little unclear why this was failing to begin with; the `$watch` on `$parent` wasn't firing when I'd expect it to. That said, the reason for doing this was essentially to replicate functionality already provided by Angular for synchronizing changes between an isolate scope and its parent. I'm comfortable with say "whatever was going on here, the Angular team has encountered and solved" instead of investing further time developing our own understanding.

There's a modest cost to this change, insofar as it introduces more watches (per tree, not per node). Think this cost is incidental.

This does not address any of the UX changes proposed for #1008; just fixes the originally reported bug as it currently manifests.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y