### PR TITLE
[API] Containment

### DIFF
--- a/src/adapter/bundle.js
+++ b/src/adapter/bundle.js
@@ -2,12 +2,14 @@ define([
     'legacyRegistry',
     './directives/MCTView',
     './services/Instantiate',
-    './capabilities/APICapabilityDecorator'
+    './capabilities/APICapabilityDecorator',
+    './policies/AdapterCompositionPolicy'
 ], function (
     legacyRegistry,
     MCTView,
     Instantiate,
-    APICapabilityDecorator
+    APICapabilityDecorator,
+    AdapterCompositionPolicy
 ) {
     legacyRegistry.register('src/adapter', {
         "extensions": {
@@ -41,6 +43,13 @@ define([
                     depends: [
                         "$injector"
                     ]
+                }
+            ],
+            policies: [
+                {
+                    category: "composition",
+                    implementation: AdapterCompositionPolicy,
+                    depends: [ "mct" ]
                 }
             ]
         }

--- a/src/adapter/policies/AdapterCompositionPolicy.js
+++ b/src/adapter/policies/AdapterCompositionPolicy.js
@@ -1,0 +1,26 @@
+define([], function () {
+    function AdapterCompositionPolicy(mct) {
+        this.mct = mct;
+    }
+
+    AdapterCompositionPolicy.prototype.allow = function (
+        containerType,
+        childType
+    ) {
+        var containerObject = containerType.getInitialModel();
+        var childObject = childType.getInitialModel();
+
+        containerObject.type = containerType.getKey();
+        childObject.type = childType.getKey();
+
+        var composition = mct.Composition(containerObject);
+
+        if (composition) {
+            return composition.canContain(childObject);
+        }
+
+        return true;
+    };
+
+    return AdapterCompositionPolicy;
+});

--- a/src/adapter/policies/AdapterCompositionPolicy.js
+++ b/src/adapter/policies/AdapterCompositionPolicy.js
@@ -13,7 +13,7 @@ define([], function () {
         containerObject.type = containerType.getKey();
         childObject.type = childType.getKey();
 
-        var composition = mct.Composition(containerObject);
+        var composition = this.mct.Composition(containerObject);
 
         if (composition) {
             return composition.canContain(childObject);

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -52,6 +52,9 @@ define([
         if (!this._children) {
             throw new Error("Must load composition before you can add!");
         }
+        if (!this.canContain(child)) {
+            throw new Error("This object cannot contain that object.");
+        }
         if (this.contains(child)) {
             if (skipMutate) {
                 return; // don't add twice, don't error.

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -94,6 +94,10 @@ define([
         }
     };
 
+    CompositionCollection.prototype.canContain = function (domainObject) {
+        return this.provider.canContain(this.domainObject, domainObject);
+    };
+
     CompositionCollection.prototype.destroy = function () {
         if (this.provider.off) {
             this.provider.off(

--- a/src/api/composition/DefaultCompositionProvider.js
+++ b/src/api/composition/DefaultCompositionProvider.js
@@ -59,6 +59,10 @@ define([
         );
     };
 
+    DefaultCompositionProvider.prototype.canContain = function (domainObject, child) {
+        return true;
+    };
+
     DefaultCompositionProvider.prototype.remove = function (domainObject, child) {
         // TODO: this needs to be synchronized via mutation
         var index = domainObject.composition.indexOf(child);


### PR DESCRIPTION
WIP for containment API.

Notes:

* Think having `canContain` on CompositionCollection makes sense; that's where it's relevant.
* Delegating to composition provider is good for the cases where custom types have a custom provider (containment will often be a related concern in these cases)
* Requiring a custom provider for containment rules is _not_ such a good thing, I think. It's overkill for cases where you want to add new object types which don't need to do anything else special with their composition. Couple of options here:
  * Expose DefaultCompositionProvider so that it can be overridden (makes things reasonably easy)
  * Have somewhere else (type?) that DefaultCompositionProvider can look to. Downside is that when a custom provider is used and the containment rules specified on a type get ignored, that will be confusing.
  * DEEEEEE-fer! It's technically possible to support containment rules with a CompositionProvider; it's inconvenient, but convenience can be improved after 1.0.0. (On the other hand, there's a risk with deferral that once we get into the details of whatever approach we take it will drive us to want to make broader API changes which would be easier to make now)

Still to-do:

- [ ] Decide how to handle the default case
- [x] Add adapter to wire into existing containment policy