### PR TITLE
[Tree] Check for change before scope.$apply

### DIFF
--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -28,8 +28,10 @@ define([
         function link(scope, element) {
             var treeView = new TreeView(gestureService),
                 unobserve = treeView.observe(function (domainObject) {
-                    scope.mctModel = domainObject;
-                    scope.$apply();
+                    if (scope.mctModel !== domainObject) {
+                        scope.mctModel = domainObject;
+                        scope.$apply();
+                    }
                 });
 
             element.append(angular.element(treeView.elements()));


### PR DESCRIPTION
TreeView's observers will be called when the selected domain object changes, which can occur for one of two reasons:

1. Because a new value was set externally, from `mct-tree`.
2. Because a new value was selected, by the user.

One such observer is `mct-tree` itself, which needs to update scope to match the user's selection. In the latter case a call to `$apply` is needed from this observer, but in the former it is not (and causes an error.) However, when that case occurs, the value in scope will be up to date already (it was a watch that triggered the call to `treeView.value`) so no assignment or `$apply` is necessary.

Checking if scope is already up to date before invoking `$apply` therefore fixes #1114.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y