### PR TITLE
[Locator] Don't reset root unnecessarily

### DIFF
--- a/platform/commonUI/edit/src/creation/LocatorController.js
+++ b/platform/commonUI/edit/src/creation/LocatorController.js
@@ -50,7 +50,7 @@ define(
                         $scope.rootObject =
                             (context && context.getRoot()) || $scope.rootObject;
                     }, 0);
-                } else if (!contextRoot) {
+                } else if (!contextRoot && !$scope.rootObject) {
                     //If no context root is available, default to the root
                     // object
                     $scope.rootObject = undefined;

--- a/platform/commonUI/edit/src/creation/LocatorController.js
+++ b/platform/commonUI/edit/src/creation/LocatorController.js
@@ -51,9 +51,6 @@ define(
                             (context && context.getRoot()) || $scope.rootObject;
                     }, 0);
                 } else if (!contextRoot && !$scope.rootObject) {
-                    //If no context root is available, default to the root
-                    // object
-                    $scope.rootObject = undefined;
                     // Update the displayed tree on a timeout to avoid
                     // an infinite digest exception.
                     objectService.getObjects(['ROOT'])

--- a/platform/commonUI/edit/test/creation/LocatorControllerSpec.js
+++ b/platform/commonUI/edit/test/creation/LocatorControllerSpec.js
@@ -138,23 +138,34 @@ define(
                     });
             });
             describe("when no context is available", function () {
-                    var defaultRoot = "DEFAULT_ROOT";
+                var defaultRoot = "DEFAULT_ROOT";
 
-                    beforeEach(function () {
-                        mockContext.getRoot.andReturn(undefined);
-                        getObjectsPromise.then.andCallFake(function (callback) {
-                            callback({'ROOT': defaultRoot});
-                        });
-                        controller = new LocatorController(mockScope, mockTimeout, mockObjectService);
+                beforeEach(function () {
+                    mockContext.getRoot.andReturn(undefined);
+                    getObjectsPromise.then.andCallFake(function (callback) {
+                        callback({'ROOT': defaultRoot});
                     });
-
-                    it("provides a default context where none is available", function () {
-                        mockScope.$watch.mostRecentCall.args[1](mockDomainObject);
-                        mockTimeout.mostRecentCall.args[0]();
-                        expect(mockScope.rootObject).toBe(defaultRoot);
-
-                    });
+                    controller = new LocatorController(mockScope, mockTimeout, mockObjectService);
                 });
+
+                it("provides a default context where none is available", function () {
+                    mockScope.$watch.mostRecentCall.args[1](mockDomainObject);
+                    mockTimeout.mostRecentCall.args[0]();
+                    expect(mockScope.rootObject).toBe(defaultRoot);
+                });
+
+                it("does not issue redundant requests for the root object", function () {
+                    mockScope.$watch.mostRecentCall.args[1](mockDomainObject);
+                    mockTimeout.mostRecentCall.args[0]();
+                    mockScope.$watch.mostRecentCall.args[1](undefined);
+                    mockTimeout.mostRecentCall.args[0]();
+                    mockScope.$watch.mostRecentCall.args[1](mockDomainObject);
+                    mockTimeout.mostRecentCall.args[0]();
+                    expect(mockObjectService.getObjects.calls.length)
+                        .toEqual(1);
+                });
+
+            });
         });
     }
 );


### PR DESCRIPTION
...as this will trigger a refresh of the mct-representation for
the tree, which will in turn create a new mct-tree instance,
resulting in any expanded/collapsed state being lost.

Fixes #1008.

Also normalizes some whitespace in the associated spec.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y