### PR TITLE
[Build] Check dependencies for vulnerabilities

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,6 +157,6 @@ gulp.task('develop', ['serve', 'stylesheets', 'watch']);
 
 gulp.task('install', [ 'static', 'scripts' ]);
 
-gulp.task('verify', [ 'lint', 'test', 'checkstyle' ]);
+gulp.task('verify', [ 'lint', 'test', 'checkstyle', 'nsp' ]);
 
 gulp.task('build', [ 'verify', 'install' ]);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,6 +103,11 @@ gulp.task('stylesheets', function () {
         .pipe(gulp.dest(__dirname));
 });
 
+gulp.task('nsp', function (done) {
+    var nsp = require('gulp-nsp');
+    nsp({package: __dirname + '/package.json'}, done);
+});
+
 gulp.task('lint', function () {
     var nonspecs = paths.specs.map(function (glob) {
             return "!" + glob;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-jshint-html-reporter": "^0.1.3",
+    "gulp-nsp": "^2.4.2",
     "gulp-rename": "^1.2.2",
     "gulp-replace-task": "^0.11.0",
     "gulp-requirejs-optimize": "^0.3.1",


### PR DESCRIPTION
Adds a run of [nsp](https://nodesecurity.io/), the Node Security Platform, to flag any known vulnerabilities associated with dependencies as part of the "verify" build step. Addresses #1130

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A (changes to build only)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y