### PR TITLE
[Search] 'All' checked upon no filters. Fixes #1117

### DIFF
--- a/platform/search/src/controllers/SearchMenuController.js
+++ b/platform/search/src/controllers/SearchMenuController.js
@@ -80,7 +80,7 @@ define(function () {
                 // If there's still nothing in the filters string, there are no
                 //   filters selected
                 if ($scope.ngModel.filtersString === '') {
-                    $scope.ngModel.filtersString = 'NONE';
+                    $scope.ngModel.checkAll = true;
                 }
             }
 
@@ -95,12 +95,11 @@ define(function () {
                 $scope.ngModel.checked[type] = false;
             });
 
-            // Change the filters string depending on checkAll status
-            if ($scope.ngModel.checkAll) {
-                // This setting will make the filters display hidden
-                $scope.ngModel.filtersString = '';
-            } else {
-                $scope.ngModel.filtersString = 'NONE';
+            // This setting will make the filters display hidden
+            $scope.ngModel.filtersString = '';
+            // Do not let checkAll become unchecked when it is the only checked filter
+            if (!$scope.ngModel.checkAll) {
+                $scope.ngModel.checkAll = true;
             }
 
             // Re-filter results

--- a/platform/search/test/controllers/SearchMenuControllerSpec.js
+++ b/platform/search/test/controllers/SearchMenuControllerSpec.js
@@ -76,13 +76,15 @@ define(
                 expect(mockScope.ngModel.filtersString).not.toEqual('');
             });
 
-            it("changing checkAll status updates the filter string", function () {
+            it("changing checkAll status sets checkAll to true", function () {
                 controller.checkAll();
+                expect(mockScope.ngModel.checkAll).toEqual(true);
                 expect(mockScope.ngModel.filtersString).toEqual('');
 
                 mockScope.ngModel.checkAll = false;
 
                 controller.checkAll();
+                expect(mockScope.ngModel.checkAll).toEqual(true);
                 expect(mockScope.ngModel.filtersString).toEqual('');
             });
 
@@ -117,7 +119,6 @@ define(
 
                 controller.updateOptions();
 
-                expect(mockScope.ngModel.filtersString).not.toEqual('NONE');
                 expect(mockScope.ngModel.filtersString).not.toEqual('');
             });
         });

--- a/platform/search/test/controllers/SearchMenuControllerSpec.js
+++ b/platform/search/test/controllers/SearchMenuControllerSpec.js
@@ -83,7 +83,7 @@ define(
                 mockScope.ngModel.checkAll = false;
 
                 controller.checkAll();
-                expect(mockScope.ngModel.filtersString).toEqual('NONE');
+                expect(mockScope.ngModel.filtersString).toEqual('');
             });
 
             it("checking checkAll option resets other options", function () {
@@ -97,7 +97,7 @@ define(
                 });
             });
 
-            it("tells the user when no options are checked", function () {
+            it("checks checkAll when no options are checked", function () {
                 Object.keys(mockScope.ngModel.checked).forEach(function (type) {
                     mockScope.ngModel.checked[type] = false;
                 });
@@ -105,7 +105,8 @@ define(
 
                 controller.updateOptions();
 
-                expect(mockScope.ngModel.filtersString).toEqual('NONE');
+                expect(mockScope.ngModel.filtersString).toEqual('');
+                expect(mockScope.ngModel.checkAll).toEqual(true);
             });
 
             it("tells the user when options are checked", function () {


### PR DESCRIPTION
# Checklist
* Changes address original issue?
 * Yes. 'All' gets checked when all filters are unchecked.
* Unit tests included and/or updated with changes?
 * Unit test for SearchMenuController has been updated to test for these changes, and succeeds when run. 
* Command line build passes?
 * Yes.
* Changes have been smoke-tested?
 * Yes.