### PR TITLE
[Documentation] Fixed typo

### DIFF
--- a/docs/src/architecture/platform.md
+++ b/docs/src/architecture/platform.md
@@ -1,6 +1,6 @@
 # Overview
 
-The Open MCT platform utilizes the [framework layer](Framework.md)
+The Open MCT platform utilizes the [framework layer](framework.md)
 to provide an extensible baseline for applications which includes:
 
 * A common user interface (and user interface paradigm) for dealing with


### PR DESCRIPTION
"Framework.md" was showing a 404 error. Changed it to "framework.md", which is the actual file name.