### PR TITLE
[Documentation] Fix added lines in tutorial

### DIFF
--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -2746,14 +2746,14 @@ with the platform):
 ```diff
 define([
     'legacyRegistry',
-    './src/ExampleTelemetryServerAdapter',
-    './src/ExampleTelemetryInitializer',
-    './src/ExampleTelemetryModelProvider'
++   './src/ExampleTelemetryServerAdapter',
++   './src/ExampleTelemetryInitializer',
++   './src/ExampleTelemetryModelProvider'
 ], function (
     legacyRegistry,
-    ExampleTelemetryServerAdapter,
-    ExampleTelemetryInitializer,
-    ExampleTelemetryModelProvider
++   ExampleTelemetryServerAdapter,
++   ExampleTelemetryInitializer,
++   ExampleTelemetryModelProvider
 ) {
     legacyRegistry.register("tutorials/telemetry", {
     "name": "Example Telemetry Adapter",
@@ -2764,7 +2764,7 @@ define([
                 "key": "example.spacecraft",
                 "glyph": "o"
             },
-            {
++           {
 +               "name": "Subsystem",
 +               "key": "example.subsystem",
 +               "glyph": "o",


### PR DESCRIPTION
Just stumbled upon this, in the 2nd bundle.js block the diff was incomplete. It's a minor thing but it can save you a few seconds of confusion when you move through the tutorial & progressively update your code.

## Author Checklist
1. Changes address original issue? - Y
2. Unit tests included and/or updated with changes? - N/A, it's a documentation formatting fix
3. Command line build passes? - N/A
4. Changes have been smoke-tested? - N/A
