### PR TITLE
Add .swp to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.gzip
 *.tgz
 *.DS_Store
+*.swp
 
 # Compiled CSS, unless directly added
 *.sass-cache


### PR DESCRIPTION
I was testing this repo, and when a opened a file using my favorite editor (vim) I saw that you forgot (or don't need) to put [`swp`](http://vimdoc.sourceforge.net/htmldoc/recover.html) files into the `.gitignore`.

# Author Checklist
Changes address original issue? - N/A
Unit tests included and/or updated with changes? - N/A, it's a adding type of file to `.gitignore`
Command line build passes? - N/A
Changes have been smoke-tested? - N/A

