### PR TITLE
[Context Menu] New Tab button available in edit mode. #843

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -387,7 +387,7 @@ define([
             "constants": [
                 {
                     "key": "editModeBlacklist",
-                    "value": ["copy", "follow", "window", "link", "locate"]
+                    "value": ["copy", "follow", "link", "locate"]
                 },
                 {
                     "key": "nonEditContextBlacklist",


### PR DESCRIPTION
Removed `window` from the `editModeBlackList`.

This allows the _New Tab_ button to be used while in edit mode.

## Author Checklist
1. Changes address original issue?
 - Yes
1. Unit tests included and/or updated with changes?
 - No
1. Command line build passes?
 - Yes
1. Changes have been smoke-tested?
 - Yes