### PR TITLE
[Bug] Fix verticle splitter wiggly-jigglys

### DIFF
--- a/platform/commonUI/general/res/sass/helpers/_splitter.scss
+++ b/platform/commonUI/general/res/sass/helpers/_splitter.scss
@@ -103,6 +103,8 @@
             top: 0;
             bottom: 0;
             width: $splitterD;
+            position: relative;
+            height: 100%;
             &:after {
                 left: $inset; right: $inset;
                 //width: $splitterHandleD;


### PR DESCRIPTION
Resolves #1141. It appears to be a bug in the browser when retrieving the
offsetWidth of certain absolute positioned elements at various zoom levels.
It is not being set in the styles directly and the CSS attributes aren't
changing either. It appears to be that the offsetWidth changes based on its
surrounding elements instead which shouldn't happen.
- [X] Changes address original issue?
- Unit tests included and/or updated with changes? _N/A Stylesheet change only_
- [X]  Command line build passes?
- [X]  Changes have been smoke-tested?
