### PR TITLE
[Build] Skip phantomjs-prebuilt 2.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.11.1",
     "node-bourbon": "^4.2.3",
-    "phantomjs-prebuilt": "^2.1.0",
+    "phantomjs-prebuilt": "2.1.11",
     "requirejs": "2.1.x",
     "split": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mkdirp": "^0.5.1",
     "moment": "^2.11.1",
     "node-bourbon": "^4.2.3",
-    "phantomjs-prebuilt": "2.1.11",
+    "phantomjs-prebuilt": "2.1.11 || >2.1.12 <3.0.0",
     "requirejs": "2.1.x",
     "split": "^1.0.0"
   },


### PR DESCRIPTION
Change version specifier for phantomjs-prebuilt to skip 2.1.12, which has several reported issues installing on Linux (and is similarly failing to install in one of our CI environments.) Fixes #1176

It would be helpful in particular if my usage of npm's [version syntax](https://docs.npmjs.com/misc/semver) is double-checked for correctness and conciseness; haven't used this kind of expression before.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A (changes to build only)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

