### PR TITLE
[Build] Revert check dependencies for vulnerabilities

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,11 +103,6 @@ gulp.task('stylesheets', function () {
         .pipe(gulp.dest(__dirname));
 });
 
-gulp.task('nsp', function (done) {
-    var nsp = require('gulp-nsp');
-    nsp({package: __dirname + '/package.json'}, done);
-});
-
 gulp.task('lint', function () {
     var nonspecs = paths.specs.map(function (glob) {
             return "!" + glob;
@@ -157,6 +152,6 @@ gulp.task('develop', ['serve', 'stylesheets', 'watch']);
 
 gulp.task('install', [ 'static', 'scripts' ]);
 
-gulp.task('verify', [ 'lint', 'test', 'checkstyle', 'nsp' ]);
+gulp.task('verify', [ 'lint', 'test', 'checkstyle' ]);
 
 gulp.task('build', [ 'verify', 'install' ]);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-jshint-html-reporter": "^0.1.3",
-    "gulp-nsp": "^2.4.2",
     "gulp-rename": "^1.2.2",
     "gulp-replace-task": "^0.11.0",
     "gulp-requirejs-optimize": "^0.3.1",


### PR DESCRIPTION
Reverts nasa/openmct#1134

This is causing build failures on hulk because NSP servers can't be reached.

```
[10:11:13] 'nsp' errored after 53 s
[10:11:13] Error in plugin 'gulp-nsp'
Message:
    (+) Error: Client request error: socket hang up
```

There's [limited value](https://github.com/nasa/openmct/issues/1130#issuecomment-241598884) to these checks, in any event.
