### PR TITLE
[Edit Mode] Fixed issue with save dialog not being displayed for new objects after mutation

### DIFF
--- a/platform/commonUI/browse/src/navigation/NavigateAction.js
+++ b/platform/commonUI/browse/src/navigation/NavigateAction.js
@@ -49,9 +49,7 @@ define(
         NavigateAction.prototype.perform = function () {
             var self = this,
                 navigateTo = this.domainObject,
-                currentObject = self.navigationService.getNavigation(),
-                editing = currentObject.hasCapability('editor') &&
-                    currentObject.getCapability('editor').isEditContextRoot();
+                currentObject = self.navigationService.getNavigation();
 
             function allow() {
                 var navigationAllowed = true;
@@ -63,6 +61,9 @@ define(
             }
 
             function cancelIfEditing() {
+                var editing = currentObject.hasCapability('editor') &&
+                    currentObject.getCapability('editor').isEditContextRoot();
+
                 return self.$q.when(editing && currentObject.getCapability("editor").cancel());
             }
 

--- a/platform/commonUI/browse/src/navigation/NavigateAction.js
+++ b/platform/commonUI/browse/src/navigation/NavigateAction.js
@@ -48,20 +48,34 @@ define(
          */
         NavigateAction.prototype.perform = function () {
             var self = this,
-                navigationAllowed = true;
+                navigateTo = this.domainObject,
+                currentObject = self.navigationService.getNavigation(),
+                editing = currentObject.hasCapability('editor') &&
+                    currentObject.getCapability('editor').isEditContextRoot();
 
             function allow() {
-                self.policyService.allow("navigation", self.navigationService.getNavigation(), self.domainObject, function (message) {
+                var navigationAllowed = true;
+                self.policyService.allow("navigation", currentObject, navigateTo, function (message) {
                     navigationAllowed = self.$window.confirm(message + "\r\n\r\n" +
                         " Are you sure you want to continue?");
                 });
                 return navigationAllowed;
             }
 
-            // Set navigation, and wrap like a promise
-            return this.$q.when(
-                allow() && this.navigationService.setNavigation(this.domainObject)
-            );
+            function cancelIfEditing() {
+                return self.$q.when(editing && currentObject.getCapability("editor").cancel());
+            }
+
+            function navigate() {
+                return self.navigationService.setNavigation(navigateTo);
+            }
+
+            if (allow()) {
+                return cancelIfEditing().then(navigate);
+            } else {
+                return this.$q.when(false);
+            }
+
         };
 
         /**

--- a/platform/commonUI/browse/test/navigation/NavigateActionSpec.js
+++ b/platform/commonUI/browse/test/navigation/NavigateActionSpec.js
@@ -32,7 +32,9 @@ define(
                 mockQ,
                 mockDomainObject,
                 mockPolicyService,
+                mockNavigatedObject,
                 mockWindow,
+                capabilities,
                 action;
 
             function mockPromise(value) {
@@ -44,6 +46,29 @@ define(
             }
 
             beforeEach(function () {
+                capabilities = {};
+
+                mockQ = { when: mockPromise };
+                mockNavigatedObject = jasmine.createSpyObj(
+                    "domainObject",
+                    [
+                        "getId",
+                        "getModel",
+                        "hasCapability",
+                        "getCapability"
+                    ]
+                );
+
+                capabilities.editor = jasmine.createSpyObj("editorCapability", [
+                    "isEditContextRoot",
+                    "cancel"
+                ]);
+
+                mockNavigatedObject.getCapability.andCallFake(function (capability) {
+                    return capabilities[capability];
+                });
+                mockNavigatedObject.hasCapability.andReturn(false);
+
                 mockNavigationService = jasmine.createSpyObj(
                     "navigationService",
                     [
@@ -51,11 +76,14 @@ define(
                         "getNavigation"
                     ]
                 );
-                mockNavigationService.getNavigation.andReturn({});
-                mockQ = { when: mockPromise };
+                mockNavigationService.getNavigation.andReturn(mockNavigatedObject);
+
                 mockDomainObject = jasmine.createSpyObj(
                     "domainObject",
-                    ["getId", "getModel", "getCapability"]
+                    [
+                        "getId",
+                        "getModel"
+                    ]
                 );
 
                 mockPolicyService = jasmine.createSpyObj("policyService",
@@ -108,6 +136,21 @@ define(
                     mockWindow.confirm.andReturn(true);
                     action.perform();
                     expect(mockNavigationService.setNavigation)
+                        .toHaveBeenCalled();
+                });
+            });
+
+            describe("in edit more", function () {
+                beforeEach(function () {
+                    mockNavigatedObject.hasCapability.andCallFake(function (capability) {
+                        return capability === "editor";
+                    });
+                    capabilities.editor.isEditContextRoot.andReturn(true);
+                });
+
+                it("cancels editing if in edit mode", function () {
+                    action.perform();
+                    expect(capabilities.editor.cancel)
                         .toHaveBeenCalled();
                 });
             });

--- a/platform/commonUI/browse/test/navigation/NavigateActionSpec.js
+++ b/platform/commonUI/browse/test/navigation/NavigateActionSpec.js
@@ -140,7 +140,7 @@ define(
                 });
             });
 
-            describe("in edit more", function () {
+            describe("in edit mode", function () {
                 beforeEach(function () {
                     mockNavigatedObject.hasCapability.andCallFake(function (capability) {
                         return capability === "editor";

--- a/platform/commonUI/edit/src/actions/EditAction.js
+++ b/platform/commonUI/edit/src/actions/EditAction.js
@@ -76,7 +76,6 @@ define(
                 this.navigationService.setNavigation(this.domainObject);
             }
 
-            //this.navigationService.addListener(cancelEditing);
             this.domainObject.useCapability("editor");
         };
 

--- a/platform/commonUI/edit/src/actions/EditAction.js
+++ b/platform/commonUI/edit/src/actions/EditAction.js
@@ -69,18 +69,14 @@ define(
          * Enter edit mode.
          */
         EditAction.prototype.perform = function () {
-            var self = this;
-            function cancelEditing() {
-                self.domainObject.getCapability('editor').cancel();
-                self.navigationService.removeListener(cancelEditing);
-            }
+
             //If this is not the currently navigated object, then navigate
             // to it.
             if (this.navigationService.getNavigation() !== this.domainObject) {
                 this.navigationService.setNavigation(this.domainObject);
             }
 
-            this.navigationService.addListener(cancelEditing);
+            //this.navigationService.addListener(cancelEditing);
             this.domainObject.useCapability("editor");
         };
 

--- a/platform/commonUI/edit/src/services/TransactionService.js
+++ b/platform/commonUI/edit/src/services/TransactionService.js
@@ -138,7 +138,7 @@ define(
                 try {
                     results.push(onCancel());
                 } catch (error) {
-                    this.$log.error("Error committing transaction.");
+                    this.$log.error("Error cancelling transaction.");
                 }
             }
             return this.$q.all(results).then(function () {

--- a/platform/commonUI/edit/test/actions/EditActionSpec.js
+++ b/platform/commonUI/edit/test/actions/EditActionSpec.js
@@ -98,13 +98,6 @@ define(
                 expect(EditAction.appliesTo(actionContext)).toBe(false);
             });
 
-            it ("cancels editing when user navigates away", function () {
-                action.perform();
-                expect(mockNavigationService.addListener).toHaveBeenCalled();
-                mockNavigationService.addListener.mostRecentCall.args[0]();
-                expect(mockEditor.cancel).toHaveBeenCalled();
-            });
-
             it ("invokes the Edit capability on the object", function () {
                 action.perform();
                 expect(mockDomainObject.useCapability).toHaveBeenCalledWith("editor");


### PR DESCRIPTION
Fixes #1080 

### Changes
* Removed navigation listener from EditAction which previously cancelled edit mode on navigation
* Added call to `EditorCapability.cancel()' to `NavigateAction`. Although this mixes edit and browse concerns, it does not introduce a hard dependency on edit mode. Another approach I considered was a decorator for the `NavigateAction` in the edit bundle, but decorating actions is awkward in the current API, and would have added indirection that would make the code harder to follow.
* Added a new test to `NavigateActionSpec`

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y