### PR TITLE
[Frontend] Removed Export buttons from objects when in a Layout

### DIFF
--- a/platform/commonUI/general/res/sass/_views.scss
+++ b/platform/commonUI/general/res/sass/_views.scss
@@ -31,23 +31,10 @@
     .has-control-bar {
         $btnExportH: $btnFrameH;
         .l-control-bar {
-            @include trans-prop-nice(opacity, $dur: 50ms);
-            opacity: 0;
+            display: none;
         }
         .l-view-section {
-            @include trans-prop-nice(top, $dur: 150ms, $delay: 50ms);
             top: 0;
         }
-        &:hover {
-            .l-control-bar {
-                @include trans-prop-nice(opacity, 150ms, 100ms);
-                opacity: 1;
-            }
-            .l-view-section {
-                @include trans-prop-nice(top, $dur: 150ms);
-                top: $btnExportH + $interiorMargin;
-            }
-        }
     }
-
 }


### PR DESCRIPTION
Removed the Export buttons from objects that support them, when that object is in a Layout. See #1202 for more info on why. 

Fixes #1202
CSS modded

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y