### PR TITLE
[Edit] Switch other edit actions to mct-control

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -245,7 +245,9 @@ define([
                     "key": "cancel",
                     "category": "conclude-editing",
                     "implementation": CancelAction,
-                    "name": "Cancel",
+                    // Because we use the name as label for edit buttons and mct-control buttons need
+                    // the label to be set to undefined in order to not apply the labeled CSS rule.
+                    "name": undefined,
                     "cssclass": "icon-x no-label",
                     "description": "Discard changes made to these objects.",
                     "depends": []

--- a/platform/commonUI/edit/res/templates/edit-action-buttons.html
+++ b/platform/commonUI/edit/res/templates/edit-action-buttons.html
@@ -25,7 +25,7 @@
         <mct-control key="'button'"
                      structure="{
                         text: saveActions[0].getMetadata().name,
-                        click: saveActions[0].perform,
+                        click: actionPerformer(saveActions[0]),
                         cssclass: 'major ' + saveActions[0].getMetadata().cssclass
                      }">
         </mct-control>
@@ -45,7 +45,7 @@
         <mct-control key="'button'"
                      structure="{
                         text: currentAction.getMetadata().name,
-                        click: currentAction.perform,
+                        click: actionPerformer(currentAction),
                         cssclass: currentAction.getMetadata().cssclass
                      }">
         </mct-control>

--- a/platform/commonUI/edit/res/templates/edit-action-buttons.html
+++ b/platform/commonUI/edit/res/templates/edit-action-buttons.html
@@ -42,11 +42,12 @@
     </span>
 
     <span ng-repeat="currentAction in otherEditActions">
-        <a class='s-button {{currentAction.getMetadata().cssclass}}'
-           title='{{currentAction.getMetadata().name}}'
-           ng-click="currentAction.perform()"
-           ng-class="{ major: $index === 0 && saveActions.length === 0 }">
-            <span class="title-label">{{currentAction.getMetadata().name}}</span>
-        </a>
+        <mct-control key="'button'"
+                     structure="{
+                        text: currentAction.getMetadata().name,
+                        click: currentAction.perform,
+                        cssclass: currentAction.getMetadata().cssclass
+                     }">
+        </mct-control>
     </span>
 </span>

--- a/platform/commonUI/edit/src/controllers/EditActionController.js
+++ b/platform/commonUI/edit/src/controllers/EditActionController.js
@@ -61,6 +61,12 @@ define(
                 $scope.otherEditActions = $scope.action ?
                         $scope.action.getActions(OTHERS_ACTION_CONTEXT) :
                         [];
+
+                // Required because Angular does not allow 'bind'
+                // in expressions.
+                $scope.actionPerformer = function (action) {
+                    return action.perform.bind(action);
+                };
             }
 
             // Update set of actions whenever the action capability


### PR DESCRIPTION
Went back to the edit menu cause it felt like I left the prev issue unfinished. Fixes https://github.com/nasa/openmct/issues/1198

There's a bit of a logic change. This here:

`ng-class="{ major: $index === 0 && saveActions.length === 0 }"`

Was not kept. Used to be `major: $index === 0` before the save button dropdown changes, but back then there was no separation between save actions and other actions, so I'm almost certain that it was just so that the save button shows up as major. 

Now that the save buttons show up as major anyway and are first in the menu, this doesn't seem to be useful anymore. It can only be useful if we have an edit context where we don't allow the user to save changes (no save actions available), which is something that doesn't make much sense (unless we add something like auto-saved objects?). 

It can be brought back pretty easily if needed, via `cssclass: currentAction.getMetadata().cssclass + ($index === 0 && saveActions.length === 0 ? ' major' : '')` but if it's a condition that will/should never pass in practice, I'd rather we just removed it entirely.

Thoughts? 

## Author Checklist
Changes address original issue? - Y
Unit tests included and/or updated with changes? - N/A, it's a markup change
Command line build passes? - Y
Changes have been smoke-tested? - Y