### PR TITLE
[Build] Fix jsPDF dependency

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,7 +29,7 @@ requirejs.config({
         "csv": "bower_components/comma-separated-values/csv.min",
         "es6-promise": "bower_components/es6-promise/es6-promise.min",
         "html2canvas": "bower_components/html2canvas/build/html2canvas.min",
-        "jsPDF": "bower_components/jspdf/dist/jspdf.min",
+        "jsPDF": "bower_components/jspdf/dist/jspdf.debug",
         "moment": "bower_components/moment/moment",
         "moment-duration-format": "bower_components/moment-duration-format/lib/moment-duration-format",
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "0.11.3",
+  "version": "0.11.4-SNAPSHOT",
   "description": "The Open MCT core platform",
   "dependencies": {
     "express": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "0.11.4-SNAPSHOT",
+  "version": "0.11.4",
   "description": "The Open MCT core platform",
   "dependencies": {
     "express": "^4.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "0.11.4",
+  "version": "0.12.0-SNAPSHOT",
   "description": "The Open MCT core platform",
   "dependencies": {
     "express": "^4.13.1",

--- a/test-main.js
+++ b/test-main.js
@@ -55,7 +55,7 @@ requirejs.config({
         "csv": "bower_components/comma-separated-values/csv.min",
         "es6-promise": "bower_components/es6-promise/es6-promise.min",
         "html2canvas": "bower_components/html2canvas/build/html2canvas.min",
-        "jsPDF": "bower_components/jspdf/dist/jspdf.min",
+        "jsPDF": "bower_components/jspdf/dist/jspdf.debug",
         "moment": "bower_components/moment/moment",
         "moment-duration-format": "bower_components/moment-duration-format/lib/moment-duration-format",
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",


### PR DESCRIPTION
### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

It appears from MrRio/jsPDF#122 that there are (or have been) various RequireJS issues with that library. The `define` call in the minified version looks a little different, but since this is minified it's not clear what the root cause is. I'm unable to reproduce the issue when switching to the unminified version, and we put this through our own minification step, so I'm satisfied with that.

Included an intermediary commit with an intermediate version number to allow this to be tagged and included as a release; #1208 effects any version of VISTA/WARP which depends on a specific Open MCT build, so these will need a new build to depend upon