### PR TITLE
[Bower] specify jspdf minor version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "FileSaver.js": "^0.0.2",
     "zepto": "^1.1.6",
     "html2canvas": "^0.4.1",
-    "jspdf": "^1.2.61"
+    "jspdf": "1.2.x"
   }
 }


### PR DESCRIPTION
Specify jsPDF minor version to avoid updating to v1.3.0, which appears to
have problems with requirejs bundling.

Fixes https://github.com/nasa/openmct/issues/1214

@VWoeltjen this seems to fix the issue, and I'm also wondering if it renders 1208b unnecessary.  I'm going to see if we can back that change out and still have this work.  But I can't just straight revert it because of the version changes.

Not yet ready for integration.

