### PR TITLE
[Frontend] Ensure stacking order of save drop-down Fixes #1205

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_menus.scss
+++ b/platform/commonUI/general/res/sass/controls/_menus.scss
@@ -258,6 +258,7 @@
 
 .btn-bar.right .menu,
 .menus-to-left .menu {
+        z-index: 79;
 	left: auto;
 	right: 0;
 	width: auto;


### PR DESCRIPTION
Update the z-index of the save drop-down element so that it is always in front.

Fixes #1205 

**Changes address original issue?** Yes
**Unit tests included and/or updated with changes?** N/A
**Command line build passes?** Yes
**Changes have been smoke-tested?** Yes

<img width="219" alt="screen shot 2016-10-06 at 6 20 25 pm" src="https://cloud.githubusercontent.com/assets/10946524/19172772/988c6100-8bf1-11e6-807a-d6aaf731a9a6.png">
