### PR TITLE
Added middleware security options via helmet

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@
     var BUNDLE_FILE = 'bundles.json',
         options = require('minimist')(process.argv.slice(2)),
         express = require('express'),
+        helmet = require('helmet'),
         app = express(),
         fs = require('fs'),
         request = require('request');
@@ -42,7 +43,7 @@
         process.exit(0);
     }
 
-    app.disable('x-powered-by');
+    app.use(helmet());
 
     // Override bundles.json for HTTP requests
     app.use('/' + BUNDLE_FILE, function (req, res) {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The Open MCT core platform",
   "dependencies": {
     "express": "^4.13.1",
+    "helmet": "^2.3.0",
     "minimist": "^1.1.1",
     "request": "^2.69.0"
   },


### PR DESCRIPTION
Middleware can be locked down via helmet as per http://expressjs.com/en/advanced/best-practice-security.html#use-helmet
