### PR TITLE
[API] Enable example bundles

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,14 @@
     </script>
     <script>
         require(['openmct'], function (openmct) {
-            require([
-                './example/imagery/bundle',
-                './example/eventGenerator/bundle',
-                './example/generator/bundle'
-            ], openmct.start.bind(openmct));
+            [
+                'example/imagery',
+                'example/eventGenerator',
+                'example/generator'
+            ].forEach(
+                openmct.legacyRegistry.enable.bind(openmct.legacyRegistry)
+            );
+            openmct.start();
         });
     </script>
     <link rel="stylesheet" href="platform/commonUI/general/res/css/startup-base.css">


### PR DESCRIPTION
Enable example bundles in the default build. Addresses regression in development environments introduced by #1212, wherein Sine Wave Generator became an unknown object type.

### Author Checklist

1. Changes address original issue? PR is self-reporting of issue
2. Unit tests included and/or updated with changes? N/A (changes out of scope for unit test)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y