### PR TITLE
Async root registration

### DIFF
--- a/API.md
+++ b/API.md
@@ -118,18 +118,11 @@ To do so, use the [`addRoot`]{@link module:openmct.ObjectAPI#addRoot} method
 of the [object API]{@link module:openmct.ObjectAPI}:
 
 ```
-openmct.objects.addRoot({
-    identifier: { key: "my-key", namespace: "my-namespace" }
-    name: "My Root-level Object",
-    type: "my-type"
-});
+openmct.objects.addRoot({ key: "my-key", namespace: "my-namespace" });
 ```
 
-You can also remove this root-level object via its identifier:
-
-```
-openmct.objects.removeRoot({ key: "my-key", namespace: "my-namespace" });
-```
+Root objects are loaded just like any other objects, i.e. via an object
+provider.
 
 ### Adding Composition Providers
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
             [
                 'example/imagery',
                 'example/eventGenerator',
-                'example/generator'
+                'example/generator',
+                'platform/features/my-items'
             ].forEach(
                 openmct.legacyRegistry.enable.bind(openmct.legacyRegistry)
             );

--- a/platform/core/bundle.js
+++ b/platform/core/bundle.js
@@ -409,16 +409,6 @@ define([
                     ]
                 }
             ],
-            "roots": [
-                {
-                    "id": "mine",
-                    "model": {
-                        "name": "My Items",
-                        "type": "folder",
-                        "composition": []
-                    }
-                }
-            ],
             "runs": [
                 {
                     "implementation": TransactingMutationListener,

--- a/platform/features/my-items/bundle.js
+++ b/platform/features/my-items/bundle.js
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    'legacyRegistry'
+], function (
+    legacyRegistry
+) {
+
+    legacyRegistry.register("platform/features/my-items", {
+        "name": "My Items",
+        "description": "Defines a root named My Items",
+        "extensions": {
+            "roots": [
+                {
+                    "id": "mine",
+                    "model": {
+                        "name": "My Items",
+                        "type": "folder",
+                        "composition": []
+                    }
+                }
+            ]
+        }
+    });
+});

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -24,12 +24,14 @@ define([
     'lodash',
     './object-utils',
     './MutableObject',
-    './RootRegistry'
+    './RootRegistry',
+    './RootObjectProvider'
 ], function (
     _,
     utils,
     MutableObject,
-    RootRegistry
+    RootRegistry,
+    RootObjectProvider
 ) {
 
 
@@ -43,18 +45,7 @@ define([
     function ObjectAPI() {
         this.providers = {};
         this.rootRegistry = new RootRegistry();
-        this.rootProvider = {
-            'get': function () {
-                return this.rootRegistry.getRoots()
-                    .then(function (roots) {
-                        return {
-                            name: 'The root object',
-                            type: 'root',
-                            composition: roots
-                        };
-                    });
-            }.bind(this)
-        };
+        this.rootProvider = new RootObjectProvider(this.rootRegistry);
     }
 
     ObjectAPI.prototype.supersecretSetFallbackProvider = function (p) {

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -23,11 +23,13 @@
 define([
     'lodash',
     './object-utils',
-    './MutableObject'
+    './MutableObject',
+    './RootRegistry'
 ], function (
     _,
     utils,
-    MutableObject
+    MutableObject,
+    RootRegistry
 ) {
 
 
@@ -40,14 +42,17 @@ define([
 
     function ObjectAPI() {
         this.providers = {};
-        this.rootRegistry = [];
+        this.rootRegistry = new RootRegistry();
         this.rootProvider = {
             'get': function () {
-                return Promise.resolve({
-                    name: 'The root object',
-                    type: 'root',
-                    composition: this.rootRegistry
-                });
+                return this.rootRegistry.getRoots()
+                    .then(function (roots) {
+                        return {
+                            name: 'The root object',
+                            type: 'root',
+                            composition: roots
+                        };
+                    });
             }.bind(this)
         };
     }
@@ -143,29 +148,14 @@ define([
 
     /**
      * Add a root-level object.
-     * @param {module:openmct.DomainObject} domainObject the root-level object
-     *        to add.
+     * @param {module:openmct.ObjectAPI~Identifier|function} an array of
+     *        identifiers for root level objects, or a function that returns a
+     *        promise for an identifier or an array of root level objects.
      * @method addRoot
      * @memberof module:openmct.ObjectAPI#
      */
     ObjectAPI.prototype.addRoot = function (key) {
-        this.rootRegistry.unshift(key);
-    };
-
-    /**
-     * Remove a root-level object.
-     * @param {module:openmct.ObjectAPI~Identifier} id the identifier of the
-     *        root-level object to remove.
-     * @method removeRoot
-     * @memberof module:openmct.ObjectAPI#
-     */
-    ObjectAPI.prototype.removeRoot = function (key) {
-        this.rootRegistry = this.rootRegistry.filter(function (k) {
-            return (
-                k.identifier !== key.identifier ||
-                k.namespace !== key.namespace
-            );
-        });
+        this.rootRegistry.addRoot(key);
     };
 
     /**

--- a/src/api/objects/RootObjectProvider.js
+++ b/src/api/objects/RootObjectProvider.js
@@ -1,0 +1,43 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+], function (
+) {
+
+    function RootObjectProvider(rootRegistry) {
+        this.rootRegistry = rootRegistry;
+    }
+
+    RootObjectProvider.prototype.get = function () {
+        return this.rootRegistry.getRoots()
+            .then(function (roots) {
+                return {
+                    name: 'The root object',
+                    type: 'root',
+                    composition: roots
+                };
+            });
+    }
+
+    return RootObjectProvider;
+});

--- a/src/api/objects/RootRegistry.js
+++ b/src/api/objects/RootRegistry.js
@@ -1,0 +1,59 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    'lodash'
+], function (
+    _
+) {
+
+    function RootRegistry() {
+        this.providers = [];
+    }
+
+    RootRegistry.prototype.getRoots = function () {
+        var promises = this.providers.map(function (provider) {
+            return provider();
+        });
+        return Promise.all(promises)
+            .then(_.flatten);
+    };
+
+
+    RootRegistry.prototype.addRoot = function (key) {
+        if (_.isObject(key) && _.has(key, 'identifier') && _.has(key, 'namespace')) {
+            this.providers.push(function () {
+                return Promise.resolve(key);
+            });
+        } else if (_.isFunction(key)) {
+            this.providers.push(key);
+        }
+    };
+
+    // Assume no one ever removes a root.  everything is opt in.
+    RootRegistry.prototype.removeRoot = function (key) {
+        throw new Error('you should never remove a root');
+    };
+
+    return RootRegistry;
+
+});

--- a/src/api/objects/RootRegistry.js
+++ b/src/api/objects/RootRegistry.js
@@ -52,11 +52,6 @@ define([
         }
     };
 
-    // Assume no one ever removes a root.  everything is opt in.
-    RootRegistry.prototype.removeRoot = function (key) {
-        throw new Error('you should never remove a root');
-    };
-
     return RootRegistry;
 
 });

--- a/src/api/objects/RootRegistry.js
+++ b/src/api/objects/RootRegistry.js
@@ -38,11 +38,14 @@ define([
             .then(_.flatten);
     };
 
+    function isKey(key) {
+        return _.isObject(key) && _.has(key, 'key') && _.has(key, 'namespace');
+    }
 
     RootRegistry.prototype.addRoot = function (key) {
-        if (_.isObject(key) && _.has(key, 'identifier') && _.has(key, 'namespace')) {
+        if (isKey(key) || (_.isArray(key) && _.every(key, isKey))) {
             this.providers.push(function () {
-                return Promise.resolve(key);
+                return key;
             });
         } else if (_.isFunction(key)) {
             this.providers.push(key);

--- a/src/api/objects/test/RootObjectProviderSpec.js
+++ b/src/api/objects/test/RootObjectProviderSpec.js
@@ -19,25 +19,41 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-
 define([
+    '../RootObjectProvider'
 ], function (
+    RootObjectProvider
 ) {
+    describe('RootObjectProvider', function () {
+        var rootRegistry,
+            rootObjectProvider;
 
-    function RootObjectProvider(rootRegistry) {
-        this.rootRegistry = rootRegistry;
-    }
-
-    RootObjectProvider.prototype.get = function () {
-        return this.rootRegistry.getRoots()
-            .then(function (roots) {
-                return {
-                    name: 'The root object',
-                    type: 'root',
-                    composition: roots
-                };
+        function done() {
+            var isDone = false;
+            waitsFor(function () {
+                return isDone;
             });
-    };
+            return function () {
+                isDone = true;
+            };
+        }
 
-    return RootObjectProvider;
+        beforeEach(function () {
+            rootRegistry = jasmine.createSpyObj('rootRegistry', ['getRoots']);
+            rootRegistry.getRoots.andReturn(Promise.resolve(['some root']));
+            rootObjectProvider = new RootObjectProvider(rootRegistry);
+        });
+
+        it('supports fetching root', function () {
+            rootObjectProvider.get()
+                .then(function (root) {
+                    expect(root).toEqual({
+                        name: 'The root object',
+                        type: 'root',
+                        composition: ['some root']
+                    });
+                })
+                .then(done());
+        });
+    });
 });

--- a/src/api/objects/test/RootRegistrySpec.js
+++ b/src/api/objects/test/RootRegistrySpec.js
@@ -1,0 +1,102 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+define([
+    '../RootRegistry'
+], function (
+    RootRegistry
+) {
+    describe('RootRegistry', function () {
+        var idA,
+            idB,
+            idC,
+            registry;
+
+        function done() {
+            var isDone = false;
+            waitsFor(function () {
+                return isDone;
+            });
+            return function () {
+                isDone = true;
+            };
+        }
+
+        beforeEach(function () {
+            idA = {key: 'keyA', namespace: 'something'};
+            idB = {key: 'keyB', namespace: 'something'};
+            idC = {key: 'keyC', namespace: 'something'};
+            registry = new RootRegistry();
+        });
+
+        it('can register a root by key', function () {
+            registry.addRoot(idA);
+            registry.getRoots()
+                .then(function (roots) {
+                    expect(roots).toEqual([idA]);
+                })
+                .then(done());
+        });
+
+        it('can register multiple roots by key', function () {
+            registry.addRoot([idA, idB]);
+            registry.getRoots()
+                .then(function (roots) {
+                    expect(roots).toEqual([idA, idB]);
+                })
+                .then(done());
+        });
+
+        it('can register an asynchronous root ', function () {
+            registry.addRoot(function () {
+                return Promise.resolve(idA);
+            });
+            registry.getRoots()
+                .then(function (roots) {
+                    expect(roots).toEqual([idA]);
+                })
+                .then(done());
+        });
+
+        it('can register multiple asynchronous roots', function () {
+            registry.addRoot(function () {
+                return Promise.resolve([idA, idB]);
+            });
+            registry.getRoots()
+                .then(function (roots) {
+                    expect(roots).toEqual([idA, idB]);
+                })
+                .then(done());
+        });
+
+        it('can combine different types of registration', function () {
+            registry.addRoot([idA, idB]);
+            registry.addRoot(function () {
+                return Promise.resolve([idC]);
+            });
+            registry.getRoots()
+                .then(function (roots) {
+                    expect(roots).toEqual([idA, idB, idC]);
+                })
+                .then(done());
+        });
+    });
+});

--- a/src/defaultRegistry.js
+++ b/src/defaultRegistry.js
@@ -71,6 +71,7 @@ define([
     '../platform/features/conductor-v2/utcTimeSystem/bundle',
     '../platform/features/imagery/bundle',
     '../platform/features/layout/bundle',
+    '../platform/features/my-items/bundle',
     '../platform/features/pages/bundle',
     '../platform/features/plot/bundle',
     '../platform/features/static-markup/bundle',


### PR DESCRIPTION
Sets up for the  expectation that all roots should be opt-in configuration items by disabling the "my items" root by default and removing the `removeRoot` method from the public API.  Also adds support for asynchronous definition of roots by passing a function to `addRoot`.  Updated API documentation which was previously inaccurate.  

@VWoeltjen decided not to add an interface for RootProvider at this time.  Main use case was for ordering down the road which currently can be controlled by careful registration.  Will see how this works for now.

Added tests around root registration to verify implementation.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

Sending to @VWoeltjen for review and integrate.

