### PR TITLE
[Fixed] Specify default layout grid

### DIFF
--- a/platform/features/fixed/bundle.js
+++ b/platform/features/fixed/bundle.js
@@ -204,6 +204,7 @@ define([
                         }
                     ],
                     "model": {
+                        "layoutGrid": [64, 16],
                         "composition": []
                     },
                     "properties": [

--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -24,8 +24,7 @@ define(
     ['./FixedProxy', './elements/ElementProxies', './FixedDragHandle'],
     function (FixedProxy, ElementProxies, FixedDragHandle) {
 
-        var DEFAULT_DIMENSIONS = [2, 1],
-            DEFAULT_GRID_SIZE = [64, 16];
+        var DEFAULT_DIMENSIONS = [2, 1];
 
         /**
          * The FixedController is responsible for supporting the
@@ -132,7 +131,7 @@ define(
             // Update element positions when grid size changes
             function updateElementPositions(layoutGrid) {
                 // Update grid size from model
-                self.gridSize = layoutGrid || DEFAULT_GRID_SIZE;
+                self.gridSize = layoutGrid;
 
                 self.elementProxies.forEach(function (elementProxy) {
                     elementProxy.style = convertPosition(elementProxy);
@@ -293,7 +292,6 @@ define(
                 });
             }
 
-            this.gridSize = DEFAULT_GRID_SIZE;
             this.elementProxies = [];
             this.generateDragHandle = generateDragHandle;
             this.generateDragHandles = generateDragHandles;

--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -308,14 +308,14 @@ define(
                 }
             }.bind(this));
 
+            // Detect changes to grid size
+            $scope.$watch("model.layoutGrid", updateElementPositions);
+
             // Refresh list of elements whenever model changes
             $scope.$watch("model.modified", refreshElements);
 
             // Position panes when the model field changes
             $scope.$watch("model.composition", updateComposition);
-
-            // Detect changes to grid size
-            $scope.$watch("model.layoutGrid", updateElementPositions);
 
             // Subscribe to telemetry when an object is available
             $scope.$watch("domainObject", subscribe);

--- a/platform/features/layout/test/FixedControllerSpec.js
+++ b/platform/features/layout/test/FixedControllerSpec.js
@@ -147,6 +147,7 @@ define(
                     mockFormatter
                 );
 
+                findWatch("model.layoutGrid")(testModel.layoutGrid);
                 findWatch("selection")(mockScope.selection);
             });
 


### PR DESCRIPTION
Previously users would see blank values for grid size
even though a default was applyied.  Users will now
see default values for grid size which should prevent
them from accidentally changing grid size.

Fixes https://github.com/nasa/openmct/issues/1285
# Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A (config only
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

Sending to @akhenry for R&I.
