### PR TITLE
[Dev] develop with stylesheets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,7 +155,7 @@ gulp.task('serve', function () {
     var app = require('./app.js');
 });
 
-gulp.task('develop', ['serve', 'install', 'watch']);
+gulp.task('develop', ['serve', 'stylesheets', 'watch']);
 
 gulp.task('install', [ 'assets', 'scripts' ]);
 


### PR DESCRIPTION
Remove 'install' step from gulp develop task, instead
run 'stylesheets' to build stylesheets.  Result is much
faster execution of gulp develop as is expected for
a development tool.

Fixes https://github.com/nasa/openmct/issues/1268.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A, build only.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y