### PR TITLE
Add modelService compatibility adapater

### DIFF
--- a/src/adapter/bundle.js
+++ b/src/adapter/bundle.js
@@ -25,6 +25,7 @@ define([
     './actions/ActionDialogDecorator',
     './directives/MCTView',
     './services/Instantiate',
+    './services/MissingModelCompatibilityDecorator',
     './capabilities/APICapabilityDecorator',
     './policies/AdapterCompositionPolicy',
     './runs/AlternateCompositionInitializer'
@@ -33,6 +34,7 @@ define([
     ActionDialogDecorator,
     MCTView,
     Instantiate,
+    MissingModelCompatibilityDecorator,
     APICapabilityDecorator,
     AdapterCompositionPolicy,
     AlternateCompositionInitializer
@@ -74,6 +76,12 @@ define([
                     type: "decorator",
                     provides: "actionService",
                     implementation: ActionDialogDecorator,
+                    depends: ["openmct"]
+                },
+                {
+                    type: "decorator",
+                    provides: "modelService",
+                    implementation: MissingModelCompatibilityDecorator,
                     depends: ["openmct"]
                 }
             ],

--- a/src/adapter/services/MissingModelCompatibilityDecorator.js
+++ b/src/adapter/services/MissingModelCompatibilityDecorator.js
@@ -1,0 +1,77 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    '../../api/objects/object-utils'
+], function (
+    objectUtils
+) {
+
+    function MissingModelCompatibilityDecorator(api, modelService) {
+        this.api = api;
+        this.modelService = modelService;
+        this.apiFetching = {}; // to prevent loops, if we have already
+    }
+
+    MissingModelCompatibilityDecorator.prototype.apiFetch = function (ids) {
+        var results = {},
+            promises = ids.map(function (id) {
+                if (this.apiFetching[id]) {
+                    return Promise.resolve();
+                }
+                this.apiFetching[id] = true;
+
+                return this.api.objects.get(objectUtils.parseKeyString(id))
+                    .then(function (newDO) {
+                        results[id] = objectUtils.toOldFormat(newDO);
+                    });
+            }, this);
+
+        return Promise.all(promises).then(function () {
+                return results;
+            });
+    };
+
+    MissingModelCompatibilityDecorator.prototype.getModels = function (ids) {
+        return this.modelService.getModels(ids)
+            .then(function (models) {
+                var missingIds = ids.filter(function (id) {
+                        return !models[id];
+                    });
+
+                if (!missingIds.length) {
+                    return models;
+                }
+
+                return this.apiFetch(missingIds)
+                    .then(function (apiResults) {
+                        Object.keys(apiResults).forEach(function (k) {
+                            models[k] = apiResults[k];
+                        });
+                        return models;
+                    });
+            }.bind(this));
+    };
+
+    return MissingModelCompatibilityDecorator;
+});
+

--- a/src/adapter/services/MissingModelCompatibilityDecorator.js
+++ b/src/adapter/services/MissingModelCompatibilityDecorator.js
@@ -26,12 +26,25 @@ define([
     objectUtils
 ) {
 
+    /**
+     * Compatibility decorator for New API.
+     *
+     * When the model service returns no results, this attempts to load
+     * the model from the new Object API and returns that instead.  In order
+     * to prevent infinite recursion, this only tries to fetch from the API
+     * a single time.
+     *
+     */
     function MissingModelCompatibilityDecorator(api, modelService) {
         this.api = api;
         this.modelService = modelService;
         this.apiFetching = {}; // to prevent loops, if we have already
     }
 
+    /**
+     * Fetch a set of ids from the public api and return a promise for their
+     * models.  If a model is requested twice, respond with a missing result.
+     */
     MissingModelCompatibilityDecorator.prototype.apiFetch = function (ids) {
         var results = {},
             promises = ids.map(function (id) {
@@ -51,6 +64,10 @@ define([
             });
     };
 
+    /**
+     * Return a promise for model results based on provided ids.  Will attempt
+     * to fetch any missing results from the object api.
+     */
     MissingModelCompatibilityDecorator.prototype.getModels = function (ids) {
         return this.modelService.getModels(ids)
             .then(function (models) {

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -150,10 +150,6 @@ define([
                 throw new Error('Provider does not support [' + method + '].');
             }
 
-            if (method === 'get') {
-                return provider.get(identifier.key);
-            }
-
             return provider[method].apply(provider, arguments);
         };
     });


### PR DESCRIPTION
Implements an adapter to ensure that objects registered via the new API can be fetched via the model service.  Resolves a bug where objects provided via the new API would not be included in search results.

The changes here to the ObjectProvider `get` signature bring us back in line with API docs, but I need to look at the WARP code and see if this will cause a regression with the new provider.