### PR TITLE
[Views] Update representations on mutation

### DIFF
--- a/platform/core/src/services/Topic.js
+++ b/platform/core/src/services/Topic.js
@@ -67,6 +67,7 @@ define(
                                 listener(message);
                             } catch (e) {
                                 $log.error(ERROR_PREFIX + e.message);
+                                $log.error(e);
                             }
                         });
                     }

--- a/platform/representation/src/MCTRepresentation.js
+++ b/platform/representation/src/MCTRepresentation.js
@@ -90,7 +90,7 @@ define(
                     couldRepresent = false,
                     lastIdPath = [],
                     lastKey,
-                    statusListener,
+                    mutationListener,
                     changeTemplate = templateLinker.link($scope, element);
 
                 // Populate scope with any capabilities indicated by the
@@ -101,7 +101,16 @@ define(
                         uses = ((representation || {}).uses || []),
                         myCounter = counter;
 
+                    if (mutationListener) {
+                        mutationListener();
+                        mutationListener = undefined;
+                    }
+
                     if (domainObject) {
+                        mutationListener = domainObject
+                            .getCapability('mutation')
+                            .listen(refreshCapabilities);
+
                         // Update model
                         $scope.model = domainObject.getModel();
 
@@ -236,17 +245,12 @@ define(
                 // (to a different object)
                 $scope.$watch("domainObject", refresh);
 
-                // Finally, also update when there is a new version of that
-                // same domain object; these changes should be tracked in the
-                // model's "modified" field, by the mutation capability.
-                $scope.$watch("domainObject.getModel().modified", refreshCapabilities);
-
                 // Make sure any resources allocated by representers also get
                 // released.
                 $scope.$on("$destroy", destroyRepresenters);
                 $scope.$on("$destroy", function () {
-                    if (statusListener) {
-                        statusListener();
+                    if (mutationListener) {
+                        mutationListener();
                     }
                 });
 

--- a/src/api/objects/LegacyObjectAPIInterceptor.js
+++ b/src/api/objects/LegacyObjectAPIInterceptor.js
@@ -62,7 +62,7 @@ define([
 
             //Don't trigger self
             objectEventEmitter.off('mutation', handleMutation);
-            objectEventEmitter.emit(newStyleObject.key.identifier + ":*", newStyleObject);
+            objectEventEmitter.emit(newStyleObject.identifier.key + ":*", newStyleObject);
             objectEventEmitter.on('mutation', handleMutation);
         }.bind(this);
 


### PR DESCRIPTION
Listen for mutation instead of watching the `modified` timestamp for a given domain object. This causes changes on separate model instances to be correctly reflected by legacy views, fixing #1303.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y