### PR TITLE
[Build] Output JSCS reports

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,12 +126,18 @@ gulp.task('lint', function () {
 
 gulp.task('checkstyle', function () {
     var jscs = require('gulp-jscs');
+    var mkdirp = require('mkdirp');
+    var reportName = 'jscs-html-report.html';
+    var reportPath = path.resolve(paths.reports, 'checkstyle', reportName);
+    var moveReport = fs.rename.bind(fs, reportName, reportPath, _.noop);
+
+    mkdirp.sync(path.resolve(paths.reports, 'checkstyle'));
 
     return gulp.src(paths.scripts)
         .pipe(jscs())
         .pipe(jscs.reporter())
-        .pipe(jscs.reporter('jscs-html-reporter'))
-        .pipe(jscs.reporter('fail'));
+        .pipe(jscs.reporter('jscs-html-reporter')).on('finish', moveReport)
+        .pipe(jscs.reporter('fail'))
 });
 
 gulp.task('fixstyle', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,6 +130,7 @@ gulp.task('checkstyle', function () {
     return gulp.src(paths.scripts)
         .pipe(jscs())
         .pipe(jscs.reporter())
+        .pipe(jscs.reporter('jscs-html-reporter'))
         .pipe(jscs.reporter('fail'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,7 @@ gulp.task('checkstyle', function () {
         .pipe(jscs())
         .pipe(jscs.reporter())
         .pipe(jscs.reporter('jscs-html-reporter')).on('finish', moveReport)
-        .pipe(jscs.reporter('fail'))
+        .pipe(jscs.reporter('fail'));
 });
 
 gulp.task('fixstyle', function () {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "jasmine-core": "^2.3.0",
+    "jscs-html-reporter": "^0.1.0",
     "jsdoc": "^3.3.2",
     "jshint": "^2.7.0",
     "karma": "^0.13.3",


### PR DESCRIPTION
Records any style violations to `dist/reports/checkstyle`. Note that `jscs-html-reporter` doesn't allow file path/name to be specified, so an explicit move is triggered after the reporting step is finished.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y