### PR TITLE
[Build] Support ES6 (WIP)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,9 @@ var gulp = require('gulp'),
         specs: [ 'platform/**/*Spec.js', 'src/**/*Spec.js' ],
     },
     options = {
+        babel: {
+            presets: ['es2015']
+        },
         requirejsOptimize: {
             name: 'bower_components/almond/almond.js',
             include: paths.main.replace('.js', ''),
@@ -70,10 +73,12 @@ var gulp = require('gulp'),
     };
 
 gulp.task('scripts', function () {
+    var babel = require('gulp-babel');
     var requirejsOptimize = require('gulp-requirejs-optimize');
     var replace = require('gulp-replace-task');
     return gulp.src(paths.main)
         .pipe(sourcemaps.init())
+        .pipe(babel(options.babel))
         .pipe(requirejsOptimize(options.requirejsOptimize))
         .pipe(sourcemaps.write('.'))
         .pipe(replace(options.replace))

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "request": "^2.69.0"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.18.0",
     "bower": "^1.7.7",
     "git-rev-sync": "^1.4.0",
     "glob": ">= 3.0.0",
     "gulp": "^3.9.0",
+    "gulp-babel": "^6.1.2",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-jshint-html-reporter": "^0.1.3",

--- a/src/BundleRegistry.js
+++ b/src/BundleRegistry.js
@@ -20,55 +20,54 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-define(function () {
-
-    function BundleRegistry() {
+define(() => class BundleRegistry {
+    constructor() {
         this.bundles = {};
         this.knownBundles = {};
     }
 
-    BundleRegistry.prototype.register = function (path, definition) {
+    register(path, definition) {
         if (this.knownBundles.hasOwnProperty(path)) {
             throw new Error('Cannot register bundle with duplicate path', path);
         }
         this.knownBundles[path] = definition;
-    };
+    }
 
-    BundleRegistry.prototype.enable = function (path) {
+    enable(path) {
         if (!this.knownBundles[path]) {
             throw new Error('Unknown bundle ' + path);
         }
         this.bundles[path] = this.knownBundles[path];
-    };
+    }
 
-    BundleRegistry.prototype.disable = function (path) {
+    disable(path) {
         if (!this.bundles[path]) {
             throw new Error('Tried to disable inactive bundle ' + path);
         }
         delete this.bundles[path];
-    };
+    }
 
-    BundleRegistry.prototype.contains = function (path) {
+    contains(path) {
         return !!this.bundles[path];
-    };
+    }
 
-    BundleRegistry.prototype.get = function (path) {
+    get(path) {
         return this.bundles[path];
-    };
+    }
 
-    BundleRegistry.prototype.list = function () {
+    list() {
         return Object.keys(this.bundles);
-    };
+    }
 
-    BundleRegistry.prototype.remove = BundleRegistry.prototype.disable;
+    remove() {
+        this.disable.call(this, arguments);
+    }
 
-    BundleRegistry.prototype.delete = function (path) {
+    "delete"(path) {
         if (!this.knownBundles[path]) {
             throw new Error('Cannot remove Unknown Bundle ' + path);
         }
         delete this.bundles[path];
         delete this.knownBundles[path];
-    };
-
-    return BundleRegistry;
+    }
 });


### PR DESCRIPTION
Work-in-progress branch for #1245 (supporting ES6 syntax)

Todos:
- [x] Add babel transpilation step before sending scripts to RJS optimizer
- [x] Convert once class in the `src` hierarchy to use ES6 `class` syntax
- [ ] Fix compatibility with karma/phantom for headless testing
- [ ] Support AMD compatibility without using `define` in scripts
- [ ] Browser shims?
- [ ] Verify that built artifact still runs as expected