### PR TITLE
[Navigation] Fix errors appearing in console on application load

### DIFF
--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -52,7 +52,7 @@ define(
             var currentIds = $route.current.params.ids;
 
             $scope.treeModel = {
-                selectedObject: {}
+                selectedObject: undefined
             };
 
             function idsForObject(domainObject) {
@@ -139,7 +139,11 @@ define(
 
             // Also listen for changes which come from the tree. Changes in
             // the tree will trigger a change in browse navigation state.
-            $scope.$watch("treeModel.selectedObject", navigateDirectlyToModel);
+            $scope.$watch("treeModel.selectedObject", function (newObject, oldObject) {
+                if (oldObject !== newObject) {
+                    navigateDirectlyToModel(newObject);
+                }
+            });
 
 
             // Listen for route changes which are caused by browser events


### PR DESCRIPTION
In `BrowseController`, `$scope.treeModel` [was being initialized](https://github.com/nasa/openmct/blob/6a32c53d0571193288e5f0862b798bfc2e248c6d/platform/commonUI/browse/src/BrowseController.js#L55) to an invalid default object. This caused issues downstream [in TreeNodeView](https://github.com/nasa/openmct/blob/6a32c53d0571193288e5f0862b798bfc2e248c6d/platform/commonUI/general/src/ui/TreeNodeView.js#L106) when valid `domainObject` methods like `getCapability` were invoked. 

I have changed `BrowseController` to initialize `$scope.treeModel` to `undefined`. [Existing guard code in TreeNodeView](https://github.com/nasa/openmct/blob/6a32c53d0571193288e5f0862b798bfc2e248c6d/platform/commonUI/general/src/ui/TreeNodeView.js#L106) prevents `getCapability` from being invoked on undefined objects. 

Also added guard code to the watch in BrowseController to prevent attempted navigation to an undefined object due to Angular's watch initialization behavior.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A Changes did not break existing unit tests, and did not justify additional ones.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y