### PR TITLE
[Test Fix] Mock cloned object in SaveAsActionSpec

### DIFF
--- a/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
+++ b/platform/commonUI/edit/test/actions/SaveAsActionSpec.js
@@ -27,6 +27,7 @@ define(
 
         describe("The Save As action", function () {
             var mockDomainObject,
+                mockClonedObject,
                 mockEditorCapability,
                 mockActionCapability,
                 mockObjectService,
@@ -58,7 +59,8 @@ define(
                     [
                         "getCapability",
                         "hasCapability",
-                        "getModel"
+                        "getModel",
+                        "getId"
                     ]
                 );
                 mockDomainObject.hasCapability.andReturn(true);
@@ -66,6 +68,15 @@ define(
                     return capabilities[capability];
                 });
                 mockDomainObject.getModel.andReturn({location: 'a', persisted: undefined});
+                mockDomainObject.getId.andReturn(0);
+
+                mockClonedObject = jasmine.createSpyObj(
+                    "clonedObject",
+                    [
+                        "getId"
+                    ]
+                );
+                mockClonedObject.getId.andReturn(1);
 
                 mockParent = jasmine.createSpyObj(
                     "parentObject",
@@ -112,6 +123,7 @@ define(
                         "perform"
                     ]
                 );
+                mockCopyService.perform.andReturn(mockPromise(mockClonedObject));
 
                 mockNotificationService = jasmine.createSpyObj(
                     "notificationService",


### PR DESCRIPTION
This fixes https://github.com/nasa/openmct/issues/1361

After https://github.com/nasa/openmct/commit/2708562872aa2f8e78450fb408ebaabb449bc0b0 the cloned object is being used for more than passing around so I've mocked it separately in the spec.

## Author Checklist

- Changes address original issue? Y
- Unit tests included and/or updated with changes? Y
- Command line build passes? Y
- Changes have been smoke-tested? No runtime behavior altered, tests pass.