### PR TITLE
Use series.getDatum when available

### DIFF
--- a/platform/telemetry/src/TelemetryHandle.js
+++ b/platform/telemetry/src/TelemetryHandle.js
@@ -122,9 +122,12 @@ define(
              */
             self.getDatum = function (telemetryObject, index) {
                 function makeNewDatum(series) {
-                    return series ?
-                        subscription.makeDatum(telemetryObject, series, index) :
-                        undefined;
+                    if (series) {
+                        if (series.getDatum) {
+                            return series.getDatum(index);
+                        }
+                        return subscription.makeDatum(telemetryObject, series, index);
+                    }
                 }
 
                 return typeof index !== 'number' ?

--- a/src/api/telemetry/LegacyTelemetryProvider.js
+++ b/src/api/telemetry/LegacyTelemetryProvider.js
@@ -45,6 +45,9 @@ define([
     };
 
     function createDatum(domainObject, metadata, legacySeries, i) {
+        if (legacySeries.getDatum) {
+            return legacySeries.getDatum(i);
+        }
         var datum = {};
 
         metadata.domains.reduce(function (d, domain) {


### PR DESCRIPTION
Updates the legacy provider and the telemetry subscription to use series.getDatum when it is available instead of recreating datums manually.  

# Reviewer Checklist

1. Changes appear to address issue? Y
2. Appropriate unit tests included? N/A, no tests for legacy adapters.
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y