### PR TITLE
[Edit] Set key on represent

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -374,7 +374,6 @@ define([
                 {
                     "implementation": EditRepresenter,
                     "depends": [
-                        "$q",
                         "$log"
                     ]
                 },

--- a/platform/commonUI/edit/src/representers/EditRepresenter.js
+++ b/platform/commonUI/edit/src/representers/EditRepresenter.js
@@ -43,57 +43,51 @@ define(
          * @implements {Representer}
          * @constructor
          */
-        function EditRepresenter($q, $log, scope) {
-            var self = this;
+        function EditRepresenter($log, $scope) {
+            this.$log = $log;
+            this.$scope = $scope;
 
-            this.scope = scope;
-
-            // Mutate and persist a new version of a domain object's model.
-            function doMutate(model) {
-                var domainObject = self.domainObject;
-
-                // First, mutate; then, persist.
-                return $q.when(domainObject.useCapability("mutation", function () {
-                    return model;
-                }));
-            }
-
-            // Handle changes to model and/or view configuration
-            function commit(message) {
-                // Look up from scope; these will have been populated by
-                // mct-representation.
-                var model = scope.model,
-                    configuration = scope.configuration,
-                    domainObject = self.domainObject;
-
-                // Log the commit message
-                $log.debug([
-                    "Committing ",
-                    domainObject && domainObject.getModel().name,
-                    "(" + (domainObject && domainObject.getId()) + "):",
-                    message
-                ].join(" "));
-
-                // Update the configuration stored in the model, and persist.
-                if (domainObject) {
-                    // Configurations for specific views are stored by
-                    // key in the "configuration" field of the model.
-                    if (self.key && configuration) {
-                        model.configuration = model.configuration || {};
-                        model.configuration[self.key] = configuration;
-                    }
-                    doMutate(model);
-                }
-            }
-
-            // Place the "commit" method in the scope
-            scope.commit = commit;
-
+            this.$scope.commit = this.commit.bind(this);
         }
+
+        /**
+         * Commit any changes made to the in-scope model to the domain object.
+         * Also commits any changes made to $scope.configuration to the proper
+         * configuration value for the current representation.
+         *
+         * @param {String} message a message to log with the commit message.
+         */
+        EditRepresenter.prototype.commit = function (message) {
+            var model = this.$scope.model,
+                configuration = this.$scope.configuration,
+                domainObject = this.domainObject;
+
+            this.$log.debug([
+                "Committing ",
+                domainObject && domainObject.getModel().name,
+                "(" + (domainObject && domainObject.getId()) + "):",
+                message
+            ].join(" "));
+
+            if (this.domainObject) {
+                if (this.key && configuration) {
+                    model.configuration = model.configuration || {};
+                    model.configuration[this.key] = configuration;
+                }
+                domainObject.useCapability('mutation', function () {
+                    return model;
+                });
+            }
+        };
 
         // Handle a specific representation of a specific domain object
         EditRepresenter.prototype.represent = function (representation, representedObject) {
             this.domainObject = representedObject;
+            if (representation) {
+                this.key = representation.key;
+            } else {
+                delete this.key;
+            }
         };
 
         // Respond to the destruction of the current representation.

--- a/platform/commonUI/edit/test/representers/EditRepresenterSpec.js
+++ b/platform/commonUI/edit/test/representers/EditRepresenterSpec.js
@@ -1,0 +1,89 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    '../../src/representers/EditRepresenter'
+], function (
+    EditRepresenter
+) {
+    describe('EditRepresenter', function () {
+        var $log,
+            $scope,
+            representer;
+
+
+        beforeEach(function () {
+            $log = jasmine.createSpyObj('$log', ['debug']);
+            $scope = {};
+            representer = new EditRepresenter($log, $scope);
+        });
+
+        it('injects a commit function in scope', function () {
+            expect($scope.commit).toEqual(jasmine.any(Function));
+        });
+
+        describe('representation', function () {
+            var domainObject,
+                representation;
+
+            beforeEach(function () {
+                domainObject = jasmine.createSpyObj('domainObject', [
+                    'getId',
+                    'getModel',
+                    'useCapability'
+                ]);
+
+                domainObject.getId.andReturn('anId');
+                domainObject.getModel.andReturn({name: 'anObject'});
+
+                representation = {
+                    key: 'someRepresentation'
+                };
+                $scope.model = {name: 'anotherName'};
+                $scope.configuration = {some: 'config'};
+                representer.represent(representation, domainObject);
+            });
+
+            it('logs a message when commiting', function () {
+                $scope.commit('Test Message');
+                expect($log.debug)
+                    .toHaveBeenCalledWith('Committing  anObject (anId): Test Message');
+            });
+
+            it('mutates the object when committing', function () {
+                $scope.commit('Test Message');
+
+                expect(domainObject.useCapability)
+                    .toHaveBeenCalledWith('mutation', jasmine.any(Function));
+
+                var mutateValue = domainObject.useCapability.calls[0].args[1]();
+
+                expect(mutateValue.configuration.someRepresentation)
+                    .toEqual({some: 'config'});
+                expect(mutateValue.name).toEqual('anotherName');
+            });
+
+        });
+
+
+    });
+});


### PR DESCRIPTION
Set key on represent so that commit function can properly persist
configuration per object type.

At the same time, rewrote EditRepresenter to remove some unused dependencies and added tests (previously there were none).

Fixes https://github.com/nasa/openmct/issues/1367

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

Sending to @VWoeltjen.