### PR TITLE
[Plugins] Expose plugin functions

### DIFF
--- a/API.md
+++ b/API.md
@@ -265,6 +265,26 @@ openmct.install(myPlugin);
 
 The plugin will be invoked to configure Open MCT before it is started.
 
+### Included Plugins
+
+Open MCT is packaged along with a few general-purpose plugins:
+
+* `openmct.plugins.localStorage` provides persistence of user-created
+  objects in browser-local storage. This is particularly useful in
+  development environments.
+* `openmct.plugins.myItems` adds a top-level folder named "My Items"
+  when the application is first started, providing a place for a
+  user to store created items.
+
+Generally, you will want to either install these plugins, or install
+different plugins that provide persistence and an initial folder
+hierarchy. Installation is as described [above](#installing-plugins):
+
+```
+openmct.install(openmct.plugins.localStorage);
+openmct.install(openmct.plugins.myItems);
+```
+
 ### Writing Plugins
 
 Plugins configure Open MCT, and should utilize the

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -27,6 +27,7 @@ define([
     './api/api',
     './selection/Selection',
     './api/objects/object-utils',
+    './plugins/plugins',
     './ui/ViewRegistry'
 ], function (
     EventEmitter,
@@ -35,6 +36,7 @@ define([
     api,
     Selection,
     objectUtils,
+    plugins,
     ViewRegistry
 ) {
     /**
@@ -277,6 +279,8 @@ define([
     MCT.prototype.install = function (plugin) {
         plugin(this);
     };
+
+    MCT.prototype.plugins = plugins;
 
     return MCT;
 });

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -1,0 +1,30 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+], function () {
+    return {
+        localStorage: function (openmct) {
+            openmct.legacyRegistry.enable('platform/persistence/local');
+        }
+    };
+});

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -25,6 +25,9 @@ define([
     return {
         localStorage: function (openmct) {
             openmct.legacyRegistry.enable('platform/persistence/local');
+        },
+        myItems: function (openmct) {
+            openmct.legacyRegistry.enable('platform/features/my-items');
         }
     };
 });


### PR DESCRIPTION
Expose functions for registering useful legacy plugins using the current plugin API. This allows simple inclusion of these common features in both application variants and in tutorials.

### Author Checklist

1. Changes address original issue? Partial (see above)
2. Unit tests included and/or updated with changes? No (see #1218)
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes