### PR TITLE
[API] Address review followup items

### DIFF
--- a/API.md
+++ b/API.md
@@ -129,8 +129,10 @@ provider.
 
 The "composition" of a domain object is the list of objects it contains,
 as shown (for example) in the tree for browsing. Open MCT provides a
-default solution for composition, but there may be cases where you want
-to provide the composition of a certain object (or type of object) dynamically.
+[default solution](#default-composition-provider) for composition, but there
+may be cases where you want to provide the composition of a certain object
+(or type of object) dynamically.
+
 For instance, you may want to populate a hierarchy under a custom root-level
 object based on the contents of a telemetry dictionary.
 To do this, you can add a new CompositionProvider:
@@ -144,6 +146,29 @@ openmct.composition.addProvider({
         return Promise.resolve(myDomainObjects);
     }
 });
+```
+
+#### Default Composition Provider
+
+The default composition provider applies to any domain object with
+a `composition` property. The value of `composition` should be an
+array of identifiers, e.g.:
+
+```js
+var domainObject = {
+    name: "My Object",
+    type: 'folder',
+    composition: [
+        {
+            key: '412229c3-922c-444b-8624-736d85516247',
+            namespace: 'foo'
+        },
+        {
+            key: 'd6e0ce02-5b85-4e55-8006-a8a505b64c75',
+            namespace: 'foo'
+        }
+    ]
+};
 ```
 
 ### Adding Telemetry Providers

--- a/src/api/objects/LegacyObjectAPIInterceptor.js
+++ b/src/api/objects/LegacyObjectAPIInterceptor.js
@@ -25,7 +25,8 @@ define([
 ], function (
     utils
 ) {
-    function ObjectServiceProvider(objectService, instantiate, topic) {
+    function ObjectServiceProvider(eventEmitter, objectService, instantiate, topic) {
+        this.eventEmitter = eventEmitter;
         this.objectService = objectService;
         this.instantiate = instantiate;
 

--- a/src/api/objects/LegacyObjectAPIInterceptor.js
+++ b/src/api/objects/LegacyObjectAPIInterceptor.js
@@ -21,11 +21,9 @@
  *****************************************************************************/
 
 define([
-    './object-utils',
-    './objectEventEmitter'
+    './object-utils'
 ], function (
-    utils,
-    objectEventEmitter
+    utils
 ) {
     function ObjectServiceProvider(objectService, instantiate, topic) {
         this.objectService = objectService;
@@ -61,12 +59,12 @@ define([
             var newStyleObject = utils.toNewFormat(legacyObject.getModel(), legacyObject.getId());
 
             //Don't trigger self
-            objectEventEmitter.off('mutation', handleMutation);
-            objectEventEmitter.emit(newStyleObject.identifier.key + ":*", newStyleObject);
-            objectEventEmitter.on('mutation', handleMutation);
+            this.eventEmitter.off('mutation', handleMutation);
+            this.eventEmitter.emit(newStyleObject.identifier.key + ":*", newStyleObject);
+            this.eventEmitter.on('mutation', handleMutation);
         }.bind(this);
 
-        objectEventEmitter.on('mutation', handleMutation);
+        this.eventEmitter.on('mutation', handleMutation);
         removeGeneralTopicListener = this.generalTopic.listen(handleLegacyMutation);
     };
 
@@ -96,6 +94,8 @@ define([
     // Injects new object API as a decorator so that it hijacks all requests.
     // Object providers implemented on new API should just work, old API should just work, many things may break.
     function LegacyObjectAPIInterceptor(openmct, ROOTS, instantiate, topic, objectService) {
+        var eventEmitter = openmct.objects.eventEmitter;
+
         this.getObjects = function (keys) {
             var results = {},
                 promises = keys.map(function (keyString) {
@@ -114,7 +114,12 @@ define([
         };
 
         openmct.objects.supersecretSetFallbackProvider(
-            new ObjectServiceProvider(objectService, instantiate, topic)
+            new ObjectServiceProvider(
+                eventEmitter,
+                objectService,
+                instantiate,
+                topic
+            )
         );
 
         ROOTS.forEach(function (r) {

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -25,13 +25,15 @@ define([
     './object-utils',
     './MutableObject',
     './RootRegistry',
-    './RootObjectProvider'
+    './RootObjectProvider',
+    './EventEmitter'
 ], function (
     _,
     utils,
     MutableObject,
     RootRegistry,
-    RootObjectProvider
+    RootObjectProvider,
+    EventEmitter
 ) {
 
 
@@ -42,6 +44,7 @@ define([
      */
 
     function ObjectAPI() {
+        this.eventEmitter = new EventEmitter();
         this.providers = {};
         this.rootRegistry = new RootRegistry();
         this.rootProvider = new RootObjectProvider(this.rootRegistry);
@@ -175,7 +178,9 @@ define([
      * @memberof module:openmct.ObjectAPI#
      */
     ObjectAPI.prototype.mutate = function (domainObject, path, value) {
-        return new MutableObject(domainObject).set(path, value);
+        var mutableObject =
+            new MutableObject(this.eventEmitter, domainObject);
+        return mutableObject.set(path, value);
     };
 
     /**
@@ -188,7 +193,8 @@ define([
      * @memberof module:openmct.ObjectAPI#
      */
     ObjectAPI.prototype.observe = function (domainObject, path, callback) {
-        var mutableObject = new MutableObject(domainObject);
+        var mutableObject =
+            new MutableObject(this.eventEmitter, domainObject);
         mutableObject.on(path, callback);
         return mutableObject.stopListening.bind(mutableObject);
     };

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -26,7 +26,7 @@ define([
     './MutableObject',
     './RootRegistry',
     './RootObjectProvider',
-    './EventEmitter'
+    'EventEmitter'
 ], function (
     _,
     utils,


### PR DESCRIPTION
Address API review followup items from #1122:

> - Look at renaming `mainViews` to `views` at making it [more like a namespace](https://github.com/nasa/openmct/pull/1212#discussion_r81480468)

Considered, but don't see a strong reason for this, felt that the "more namespace-like" approach might be confusing.

> - [Link to](https://github.com/nasa/openmct/pull/1212#discussion_r81480528) documentation for using default solution for composition (the `composition` property)

Added and linked to this documentation

> - [Normalize references](https://github.com/nasa/openmct/pull/1212#discussion_r81658898) to `openmct` 

Appears to have been completed under maintenance

> - Remove global singleton [objectEventEmitter](https://github.com/nasa/openmct/pull/1212#discussion_r81882085)

Done

> - Return mutable object from `MutableObject.set` to [support chaining](https://github.com/nasa/openmct/pull/1212#discussion_r81882596)

Not done, since `MutableObject` isn't being used directly by consumers of the public API at this point.

> - Document events for composition provider, or [mark `on` method as private](https://github.com/nasa/openmct/pull/1212#discussion_r81883748)

Documentation was added in another commit and refers to `add` and `remove` events.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
