### PR TITLE
[BUILD] Adds URLIndicator

### DIFF
--- a/API.md
+++ b/API.md
@@ -879,6 +879,21 @@ openmct.install(openmct.plugins.CouchDB('http://localhost:9200'))
 * `openmct.plugins.Espresso` and `openmct.plugins.Snow` are two different
   themes (dark and light) available for Open MCT. Note that at least one
   of these themes must be installed for Open MCT to appear correctly.
+* `openmct.plugins.URLIndicatorPlugin` adds an indicator which shows the
+availability of a URL with the following options: 
+  - `url` : URL to indicate the status of
+  - `icon`: Icon to show in the status bar, defaults to `database`
+  - `interval`: Interval between checking the connection, defaults to `10000`
+  - `label` Name showing up as text in the status bar, defaults to url
+```javascript
+openmct.install(openmct.plugins.URLIndicatorPlugin({
+  url: 'http://google.com',
+  icon: 'check',
+  interval: 10000,
+  label: 'Google'
+ })
+);
+```
 * `openmct.plugins.LocalStorage` provides persistence of user-created
   objects in browser-local storage. This is particularly useful in
   development environments.
@@ -886,17 +901,6 @@ openmct.install(openmct.plugins.CouchDB('http://localhost:9200'))
   when the application is first started, providing a place for a
   user to store created items.
 * `openmct.plugins.UTCTimeSystem` provides a default time system for Open MCT.
-* `openmct.plugins.URLIndicatorPlugin({
-    url: 'http://google.com',
-    icon: 'check',
-    interval: 10000,
-    label: 'Google'
-  })` adds an indicator which shows the
-  availability of a URL with the following options: 
-   - `url` : URL to indicate the status of
-   - `icon`: Icon to show in the status bar, defaults to `database`
-   - `interval`: Interval between checking the connection, defaults to `10000`
-   - `label` Name showing up as text in the status bar, defaults to url
 
 Generally, you will want to either install these plugins, or install
 different plugins that provide persistence and an initial folder

--- a/API.md
+++ b/API.md
@@ -886,6 +886,17 @@ openmct.install(openmct.plugins.CouchDB('http://localhost:9200'))
   when the application is first started, providing a place for a
   user to store created items.
 * `openmct.plugins.UTCTimeSystem` provides a default time system for Open MCT.
+* `openmct.plugins.URLIndicatorPlugin({
+    url: 'http://google.com',
+    icon: 'check',
+    interval: 10000,
+    label: 'Google'
+  })` adds an indicator which shows the
+  availability of a URL with the following options: 
+   - `url` : URL to indicate the status of
+   - `icon`: Icon to show in the status bar, defaults to `database`
+   - `interval`: Interval between checking the connection, defaults to `10000`
+   - `label` Name showing up as text in the status bar, defaults to url
 
 Generally, you will want to either install these plugins, or install
 different plugins that provide persistence and an initial folder

--- a/API.md
+++ b/API.md
@@ -882,13 +882,13 @@ openmct.install(openmct.plugins.CouchDB('http://localhost:9200'))
 * `openmct.plugins.URLIndicatorPlugin` adds an indicator which shows the
 availability of a URL with the following options: 
   - `url` : URL to indicate the status of
-  - `icon`: Icon to show in the status bar, defaults to `database`
+  - `cssClass`: Icon to show in the status bar, defaults to `icon-database`, [list of all icons](https://nasa.github.io/openmct/style-guide/#/browse/styleguide:home?view=items)
   - `interval`: Interval between checking the connection, defaults to `10000`
   - `label` Name showing up as text in the status bar, defaults to url
 ```javascript
 openmct.install(openmct.plugins.URLIndicatorPlugin({
   url: 'http://google.com',
-  icon: 'check',
+  cssClass: 'check',
   interval: 10000,
   label: 'Google'
  })

--- a/src/plugins/URLIndicatorPlugin/URLIndicator.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicator.js
@@ -40,7 +40,7 @@ define(
             };
         function URLIndicator($http, $interval) {
             var self = this;
-            this.icon = "icon-" + (this.options.icon ? this.options.icon : "database");
+            this.cssClass = this.options.cssClass ? this.options.cssClass : "icon-database";
             this.URLpath = this.options.url;
             this.label = this.options.label ? this.options.label : this.options.url;
             this.interval = this.options.interval || 10000;
@@ -60,7 +60,7 @@ define(
         }
 
         URLIndicator.prototype.getCssClass = function () {
-            return this.icon;
+            return this.cssClass;
         };
         URLIndicator.prototype.getGlyphClass = function () {
             return this.state.glyphClass;

--- a/src/plugins/URLIndicatorPlugin/URLIndicator.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicator.js
@@ -1,0 +1,97 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    [],
+    function () {
+
+        // Set of connection states; changing among these states will be
+        // reflected in the indicator's appearance.
+        // CONNECTED: Everything nominal, expect to be able to read/write.
+        // DISCONNECTED: HTTP failed; maybe misconfigured, disconnected.
+        // PENDING: Still trying to connect, and haven't failed yet.
+        var CONNECTED = {
+                glyphClass: "ok"
+            },
+            PENDING = {
+                glyphClass: 'caution'
+            },
+            DISCONNECTED = {
+                glyphClass: "err"
+            };
+        function URLIndicator($http, $interval) {
+            var self = this;
+            this.icon = "icon-" + (this.options.icon ? this.options.icon : "database");
+            this.URLpath = this.options.url;
+            this.label = this.options.label ? this.options.label : this.options.url;
+            this.interval = this.options.interval || 10000;
+            this.state = PENDING;
+
+            function handleError(e) {
+                self.state = DISCONNECTED;
+            }
+            function handleResponse() {
+                self.state = CONNECTED;
+            }
+            function updateIndicator() {
+                $http.get(self.URLpath).then(handleResponse, handleError);
+            }
+            updateIndicator();
+            $interval(updateIndicator, self.interval, 0, false);
+        }
+
+        URLIndicator.prototype.getCssClass = function () {
+            return this.icon;
+        };
+        URLIndicator.prototype.getGlyphClass = function () {
+            return this.state.glyphClass;
+        };
+        URLIndicator.prototype.getText = function () {
+            switch (this.state) {
+                case CONNECTED: {
+                    return this.label + " is connected";
+                }
+                case PENDING: {
+                    return "Checking status of " + this.label + " please stand by...";
+                }
+                case DISCONNECTED: {
+                    return this.label + " is offline";
+                }
+            }
+        };
+        URLIndicator.prototype.getDescription = function () {
+            switch (this.state) {
+                case CONNECTED: {
+                    return this.label + " is online, checking status every " +
+                    this.interval + " milliseconds.";
+                }
+                case PENDING: {
+                    return "Checking status of " + this.label + " please stand by...";
+                }
+                case DISCONNECTED: {
+                    return this.label + " is offline, checking status every " +
+                    this.interval + " milliseconds";
+                }
+            }
+        };
+        return URLIndicator;
+    });

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorPlugin.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorPlugin.js
@@ -1,0 +1,20 @@
+define(
+  [
+    './URLIndicator'
+  ],
+  function URLIndicatorPlugin(URLIndicator) {
+    return function (opts) {
+        // Wrap the plugin in a function so we can apply the arguments.
+        function URLIndicatorWrapper() {
+            this.options = opts;
+            URLIndicator.apply(this, arguments);
+        }
+        URLIndicatorWrapper.prototype = Object.create(URLIndicator.prototype);
+        return function install(openmct) {
+            openmct.legacyExtension('indicators', {
+                  "implementation": URLIndicatorWrapper,
+                  "depends": ["$http", "$interval"]
+              });
+        };
+    };
+});

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
@@ -57,7 +57,7 @@ define(
                 );
             });
 
-            it("has a database icon as default", function () {
+            it("has a database cssClass as default", function () {
                 expect(indicatorWrapper.getCssClass()).toEqual("icon-database");
             });
 
@@ -102,14 +102,14 @@ define(
                 // Do check for specific class
                 expect(indicatorWrapper.getGlyphClass()).toEqual("err");
             });
-            it("has a customized icon if supplied in initialization", function () {
+            it("has a customized cssClass if supplied in initialization", function () {
                 opts = {
                     url: "http://localhost:8080",
-                    icon: "checked",
+                    cssClass: "cssClass-checked",
                     interval: 10000
                 };
                 indicatorWrapper = new Indicator();
-                expect(indicatorWrapper.getCssClass()).toEqual("icon-checked");
+                expect(indicatorWrapper.getCssClass()).toEqual("cssClass-checked");
             });
             it("has a customized interval if supplied in initialization", function () {
                 opts = {

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
@@ -1,0 +1,158 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    ["./URLIndicator"],
+    function (URLIndicator) {
+
+        describe("The URLIndicator", function () {
+            var mockHttp,
+                mockInterval,
+                mockPromise,
+                opts,
+                Indicator,
+                indicatorWrapper;
+
+            beforeEach(function () {
+                mockHttp = jasmine.createSpyObj("$http", ["get"]);
+                mockInterval = jasmine.createSpy("$interval");
+                mockPromise = jasmine.createSpyObj("promise", ["then"]);
+                opts = {
+                    url: "http://localhost:8080",
+                    interval: 1337 //some number
+                };
+                mockHttp.get.andReturn(mockPromise);
+                Indicator = function () {
+                    this.options = opts;
+                    URLIndicator.call(this, mockHttp, mockInterval);
+                };
+                Indicator.prototype = Object.create(URLIndicator.prototype);
+                indicatorWrapper = new Indicator();
+            });
+            it("polls for changes", function () {
+                expect(mockInterval).toHaveBeenCalledWith(
+                    jasmine.any(Function),
+                    opts.interval,
+                    0,
+                    false
+                );
+            });
+
+            it("has a database icon as default", function () {
+                expect(indicatorWrapper.getCssClass()).toEqual("icon-database");
+            });
+
+            it("consults the url with the path supplied", function () {
+                expect(mockHttp.get).toHaveBeenCalledWith(opts.url);
+            });
+
+            it("changes when the database connection is nominal", function () {
+                var initialText = indicatorWrapper.getText(),
+                    initialDescrption = indicatorWrapper.getDescription(),
+                    initialGlyphClass = indicatorWrapper.getGlyphClass();
+
+                // Nominal just means getting back an object, without
+                // an error field.
+                mockPromise.then.mostRecentCall.args[0]({ data: {} });
+
+                // Verify that these values changed;
+                // don't test for specific text.
+                expect(indicatorWrapper.getText()).not.toEqual(initialText);
+                expect(indicatorWrapper.getGlyphClass()).not.toEqual(initialGlyphClass);
+                expect(indicatorWrapper.getDescription()).not.toEqual(initialDescrption);
+
+                // Do check for specific class
+                expect(indicatorWrapper.getGlyphClass()).toEqual("ok");
+            });
+
+            it("changes when the server cannot be reached", function () {
+                var initialText = indicatorWrapper.getText(),
+                    initialDescrption = indicatorWrapper.getDescription(),
+                    initialGlyphClass = indicatorWrapper.getGlyphClass();
+
+                // Nominal just means getting back an object, without
+                // an error field.
+                mockPromise.then.mostRecentCall.args[1]({ data: {} });
+
+                // Verify that these values changed;
+                // don't test for specific text.
+                expect(indicatorWrapper.getText()).not.toEqual(initialText);
+                expect(indicatorWrapper.getGlyphClass()).not.toEqual(initialGlyphClass);
+                expect(indicatorWrapper.getDescription()).not.toEqual(initialDescrption);
+
+                // Do check for specific class
+                expect(indicatorWrapper.getGlyphClass()).toEqual("err");
+            });
+            it("has a customized icon if supplied in initialization", function () {
+                opts = {
+                    url: "http://localhost:8080",
+                    icon: "checked",
+                    interval: 10000
+                };
+                indicatorWrapper = new Indicator();
+                expect(indicatorWrapper.getCssClass()).toEqual("icon-checked");
+            });
+            it("has a customized interval if supplied in initialization", function () {
+                opts = {
+                    url: "http://localhost:8080",
+                    interval: 1814
+                };
+                indicatorWrapper = new Indicator();
+                expect(mockInterval).toHaveBeenCalledWith(
+                    jasmine.any(Function),
+                    1814,
+                    0,
+                    false
+                );
+            });
+            it("has a custom label if supplied in initialization", function () {
+                opts = {
+                    url: "http://localhost:8080",
+                    label: "Localhost"
+                };
+                indicatorWrapper = new Indicator();
+                expect(indicatorWrapper.getText()).toEqual("Checking status of Localhost please stand by...");
+            });
+            it("has a default label if not supplied in initialization", function () {
+                opts = {
+                    url: "http://localhost:8080"
+                };
+                indicatorWrapper = new Indicator();
+                expect(indicatorWrapper.getText()).toEqual(
+                  "Checking status of http://localhost:8080 please stand by..."
+                );
+            });
+            it("has a default interval if not supplied in initialization", function () {
+                opts = {
+                    url: "http://localhost:8080"
+                };
+                indicatorWrapper = new Indicator();
+                expect(mockInterval).toHaveBeenCalledWith(
+                    jasmine.any(Function),
+                    10000,
+                    0,
+                    false
+                );
+            });
+        });
+    }
+);

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -27,7 +27,8 @@ define([
     '../../platform/features/autoflow/plugin',
     './timeConductor/plugin',
     '../../example/imagery/plugin',
-    '../../platform/import-export/bundle'
+    '../../platform/import-export/bundle',
+    './URLIndicatorPlugin/URLIndicatorPlugin'
 ], function (
     _,
     UTCTimeSystem,
@@ -35,7 +36,8 @@ define([
     AutoflowPlugin,
     TimeConductorPlugin,
     ExampleImagery,
-    ImportExport
+    ImportExport,
+    URLIndicatorPlugin
 ) {
     var bundleMap = {
         CouchDB: 'platform/persistence/couch',
@@ -120,6 +122,8 @@ define([
     };
 
     plugins.ExampleImagery = ExampleImagery;
+
+    plugins.URLIndicatorPlugin = URLIndicatorPlugin;
 
     return plugins;
 });


### PR DESCRIPTION
Adds URLIndicator to the build, testable adding

```js
openmct.install(new openmct.plugins.URLIndicatorPlugin({
url: 'http://localhost:8080/',
icon: 'check',
interval: 15000,
label: 'Localhost'
}))
```

to the openmct file.