### PR TITLE
Add grab affordance to Time Conductor ticks

### DIFF
--- a/platform/features/conductor/core/res/sass/_time-conductor-base.scss
+++ b/platform/features/conductor/core/res/sass/_time-conductor-base.scss
@@ -351,13 +351,13 @@
             $grabTicksYOffset: (($r1H - $grabTicksH) / 2) - 2px;
             @include cursorGrab();
             &:hover {
-                $c0: rgba($colorBodyFg, 0.05);
+                $c0: rgba($colorBodyFg, 0.1);
                 $c2: transparent; // Bg
                 @include background-image(linear-gradient(
                     $c0 70%, $c2 100%
                 ));
                 svg {
-                    $c1: rgba($colorBodyFg, 0.15); // Line
+                    $c1: rgba($colorBodyFg, 0.2); // Line
                     $angle: 90deg;
                     @include background-image(linear-gradient($angle,
                         $c1 1px, $c2 1px,

--- a/platform/features/conductor/core/res/sass/_time-conductor-base.scss
+++ b/platform/features/conductor/core/res/sass/_time-conductor-base.scss
@@ -346,27 +346,27 @@
             content: $i;
         }
         .l-axis-holder {
-            $grabTicksH: 8px;
-            $grabTicksXSpace: 3px;
-            $grabTicksYOffset: (($r1H - $grabTicksH) / 2) - 2px;
+            $c0: rgba($colorBodyFg, 0.1);
+            $c2: transparent;
+            $grabTicksH: 3px;
+            $grabTicksXSpace: 4px;
+            $grabTicksYOffset: 0;
             @include cursorGrab();
+            svg {
+                $c1: rgba($colorBodyFg, 0.2);
+                $angle: 90deg;
+                @include background-image(linear-gradient($angle,
+                    $c1 1px, $c2 1px,
+                    $c2 100%
+                ));
+                background-position: center $grabTicksYOffset;
+                background-repeat: repeat-x;
+                background-size: $grabTicksXSpace $grabTicksH;
+            }
             &:hover {
-                $c0: rgba($colorBodyFg, 0.1);
-                $c2: transparent; // Bg
                 @include background-image(linear-gradient(
                     $c0 70%, $c2 100%
                 ));
-                svg {
-                    $c1: rgba($colorBodyFg, 0.2); // Line
-                    $angle: 90deg;
-                    @include background-image(linear-gradient($angle,
-                        $c1 1px, $c2 1px,
-                        $c2 100%
-                    ));
-                    background-position: center $grabTicksYOffset;
-                    background-repeat: repeat-x;
-                    background-size: $grabTicksXSpace $grabTicksH;
-                }
             }
         }
     }

--- a/platform/features/conductor/core/res/sass/_time-conductor-base.scss
+++ b/platform/features/conductor/core/res/sass/_time-conductor-base.scss
@@ -346,7 +346,28 @@
             content: $i;
         }
         .l-axis-holder {
+            $grabTicksH: 8px;
+            $grabTicksXSpace: 3px;
+            $grabTicksYOffset: (($r1H - $grabTicksH) / 2) - 2px;
             @include cursorGrab();
+            &:hover {
+                $c0: rgba($colorBodyFg, 0.05);
+                $c2: transparent; // Bg
+                @include background-image(linear-gradient(
+                    $c0 70%, $c2 100%
+                ));
+                svg {
+                    $c1: rgba($colorBodyFg, 0.15); // Line
+                    $angle: 90deg;
+                    @include background-image(linear-gradient($angle,
+                        $c1 1px, $c2 1px,
+                        $c2 100%
+                    ));
+                    background-position: center $grabTicksYOffset;
+                    background-repeat: repeat-x;
+                    background-size: $grabTicksXSpace $grabTicksH;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
For #1415: adds grab/pan affordance (for Fixed Time mode only) UI elements to Time Conductor ticks area.

Grippys always display
![screen shot 2017-01-27 at 2 13 10 pm](https://cloud.githubusercontent.com/assets/1056412/22389527/cbbf64ee-e49a-11e6-9f47-90549bde23aa.png)

Highlight on hover
![screen shot 2017-01-27 at 2 13 18 pm](https://cloud.githubusercontent.com/assets/1056412/22389529/ce0a2ff4-e49a-11e6-813d-59a6ea783b7d.png)

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y


