### PR TITLE
[Tutorial] Replace glyph mentions with cssclass

### DIFF
--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -340,8 +340,7 @@ Going through the properties we've defined:
 domain objects of this type.
 * The `name` of "To-Do List" is the human-readable name for this type, and will 
 be shown to users.
-* The `glyph` refers to a special character in Open MCT's custom font set; 
-this will be used as an icon.
+* The `cssclass` describes the icon that will be shown for each To-Do List.
 * The `description` is also human-readable, and will be used whenever a longer 
 explanation of what this type is should be shown.
 * Finally, the `features` property describes some special features of objects of 
@@ -446,7 +445,7 @@ the domain object type, but could have chosen any unique name.
 domain objects of that type. This means that we'll see this view for To-do Lists 
 that we create, but not for other domain objects (such as Folders.)
 
-* The `glyph` and `name` properties describe the icon and human-readable name 
+* The `cssclass` and `name` properties describe the icon and human-readable name 
 for this view to display in the UI where needed (if multiple views are available 
 for To-do Lists, the user will be able to choose one.)
 

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -340,7 +340,9 @@ Going through the properties we've defined:
 domain objects of this type.
 * The `name` of "To-Do List" is the human-readable name for this type, and will 
 be shown to users.
-* The `cssclass` describes the icon that will be shown for each To-Do List.
+* The `cssclass` maps to an icon that will be shown for each To-Do List. The icons 
+are defined in our [custom open MCT icon set](platform/commonUI/general/res/sass/_glyphs.scss). 
+A complete list of available icons will be provided in the future.
 * The `description` is also human-readable, and will be used whenever a longer 
 explanation of what this type is should be shown.
 * Finally, the `features` property describes some special features of objects of 

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -341,7 +341,7 @@ domain objects of this type.
 * The `name` of "To-Do List" is the human-readable name for this type, and will 
 be shown to users.
 * The `cssclass` maps to an icon that will be shown for each To-Do List. The icons 
-are defined in our [custom open MCT icon set](platform/commonUI/general/res/sass/_glyphs.scss). 
+are defined in our [custom open MCT icon set](https://github.com/nasa/openmct/blob/master/platform/commonUI/general/res/sass/_glyphs.scss). 
 A complete list of available icons will be provided in the future.
 * The `description` is also human-readable, and will be used whenever a longer 
 explanation of what this type is should be shown.


### PR DESCRIPTION
`glyph` properties were still mentioned in the explanations. I'm not sure the custom font set part still applies; if it does let me know and I'll bring it back.

## Author Checklist
- [x] **Changes address original issue?**
- [x] **Unit tests included and/or updated with changes?** N/A
- [x] **Command line build passes?**
- [x] **Changes have been smoke-tested?**