### PR TITLE
[Tables] Do not persist column configuration for non-editable objects

### DIFF
--- a/platform/features/table/src/TableConfiguration.js
+++ b/platform/features/table/src/TableConfiguration.js
@@ -187,7 +187,9 @@ define(
             });
 
             //Synchronize column configuration with model
-            if (configChanged(configuration, defaultConfig)) {
+            if (this.domainObject.hasCapability('editor') &&
+                this.domainObject.getCapability('editor').isEditContextRoot() &&
+                configChanged(configuration, defaultConfig)) {
                 this.saveColumnConfiguration(configuration);
             }
 

--- a/platform/features/table/test/TableConfigurationSpec.js
+++ b/platform/features/table/test/TableConfigurationSpec.js
@@ -35,10 +35,18 @@ define(
 
             beforeEach(function () {
                 mockDomainObject = jasmine.createSpyObj('domainObject',
-                    ['getModel', 'useCapability', 'getCapability']
+                    ['getModel', 'useCapability', 'getCapability', 'hasCapability']
                 );
                 mockModel = {};
                 mockDomainObject.getModel.andReturn(mockModel);
+                mockDomainObject.getCapability.andCallFake(function (name) {
+                    return name === 'editor' && {
+                        isEditContextRoot: function () {
+                            return true;
+                        }
+                    };
+                });
+
                 mockTelemetryFormatter = jasmine.createSpyObj('telemetryFormatter',
                     [
                         'formatDomainValue',


### PR DESCRIPTION
Temporary fix for #1382. no longer attempts to persist table configuration for non-editable objects.

A more permanent fix requires reconsideration of the method used to communication object configuration changes between views as per [discussion in #1382](https://github.com/nasa/openmct/issues/1382#issuecomment-271383505).

### Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y - Fixed existing unit tests. No new tests defined due to small scope of change, and mutation being removed in future as per #1382
* Command line build passes? Y
* Changes have been smoke-tested? Y