### PR TITLE
[Documentation] Fixed filename

### DIFF
--- a/docs/src/architecture/framework.md
+++ b/docs/src/architecture/framework.md
@@ -131,7 +131,7 @@ Keeping that in mind, there are a few useful patterns supported by the
 framework that are useful to keep in mind.
 
 The specific service infrastructure provided by the platform is described
-in the [Platform Architecture](Platform.md).
+in the [Platform Architecture](platform.md).
 
 ## Extension Categories
 


### PR DESCRIPTION
Fixed file name "Platform.md" to "platform.md". "Platform.md" was giving a 404 error when clicked, in github and in the official site as well.

### Author Checklist

Changes address original issue? Y
Unit tests included and/or updated with changes? N/A - documentation changes only
Command line build passes? Y
Changes have been smoke-tested? Y