### PR TITLE
[Build] Skip optimize in dev environment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,6 +69,11 @@ var gulp = require('gulp'),
         }
     };
 
+if (process.env.NODE_ENV === 'development') {
+    options.requirejsOptimize.optimize = 'none';
+}
+
+
 gulp.task('scripts', function () {
     var requirejsOptimize = require('gulp-requirejs-optimize');
     var replace = require('gulp-replace-task');


### PR DESCRIPTION
Skip optimize in dev environment to speed up project rebuilds.  Very helpful
when integration testing openmct.js build artifact.

This came out of the api-tutorial sprint, by setting NODE_ENV=development you can cut down rebuild times.

# Author Checklist

1. Changes address original issue? N/A, reported in this PR
2. Unit tests included and/or updated with changes? N/A, build only change
3. Command line build passes? Y
4. Changes have been smoke-tested? Y