### PR TITLE
Stop loading bundles.json

### DIFF
--- a/platform/framework/src/Constants.js
+++ b/platform/framework/src/Constants.js
@@ -25,7 +25,6 @@
  */
 define({
     MODULE_NAME: "OpenMCTWeb",
-    BUNDLE_LISTING_FILE: "bundles.json",
     BUNDLE_FILE: "bundle.json",
     SEPARATOR: "/",
     EXTENSION_SUFFIX: "[]",

--- a/platform/framework/src/FrameworkInitializer.js
+++ b/platform/framework/src/FrameworkInitializer.js
@@ -61,8 +61,8 @@ define(
          * @param bundleList
          * @returns {*}
          */
-        FrameworkInitializer.prototype.runApplication = function (bundleList) {
-            return this.loader.loadBundles(bundleList)
+        FrameworkInitializer.prototype.runApplication = function () {
+            return this.loader.loadBundles([])
                 .then(bind(this.resolver.resolveBundles, this.resolver))
                 .then(bind(this.registrar.registerExtensions, this.registrar))
                 .then(bind(this.bootstrapper.bootstrap, this.bootstrapper));

--- a/platform/framework/src/FrameworkLayer.js
+++ b/platform/framework/src/FrameworkLayer.js
@@ -98,7 +98,7 @@ define([
 
         // Initialize the application
         $log.info("Initializing application.");
-        initializer.runApplication(Constants.BUNDLE_LISTING_FILE);
+        initializer.runApplication();
     };
 
     return FrameworkLayer;


### PR DESCRIPTION
Stop application from requesting bundles.json at first load.  This was
confusing to some external developers who would see an error in the
log and not know the cause.

# Author Checklist

1. Changes address original issue? N/A no original issue
2. Unit tests included and/or updated with changes? Y (still work)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y