### PR TITLE
cssclass is now cssClass

### DIFF
--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -320,7 +320,7 @@ define([
 +          {
 +              "key": "example.todo",
 +              "name": "To-Do List",
-+              "cssclass": "icon-check",
++              "cssClass": "icon-check",
 +              "description": "A list of things that need to be done.",
 +              "features": ["creation"]
 +          }
@@ -340,7 +340,7 @@ Going through the properties we've defined:
 domain objects of this type.
 * The `name` of "To-Do List" is the human-readable name for this type, and will 
 be shown to users.
-* The `cssclass` maps to an icon that will be shown for each To-Do List. The icons 
+* The `cssClass` maps to an icon that will be shown for each To-Do List. The icons 
 are defined in our [custom open MCT icon set](https://github.com/nasa/openmct/blob/master/platform/commonUI/general/res/sass/_glyphs.scss). 
 A complete list of available icons will be provided in the future.
 * The `description` is also human-readable, and will be used whenever a longer 
@@ -416,7 +416,7 @@ define([
             {
                 "key": "example.todo",
                 "name": "To-Do List",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "description": "A list of things that need to be done.",
                 "features": ["creation"]
             }
@@ -425,7 +425,7 @@ define([
 +           {
 +               "key": "example.todo",
 +               "type": "example.todo",
-+               "cssclass": "icon-check",
++               "cssClass": "icon-check",
 +               "name": "List",
 +               "templateUrl": "templates/todo.html",
 +               "editable": true
@@ -447,7 +447,7 @@ the domain object type, but could have chosen any unique name.
 domain objects of that type. This means that we'll see this view for To-do Lists 
 that we create, but not for other domain objects (such as Folders.)
 
-* The `cssclass` and `name` properties describe the icon and human-readable name 
+* The `cssClass` and `name` properties describe the icon and human-readable name 
 for this view to display in the UI where needed (if multiple views are available 
 for To-do Lists, the user will be able to choose one.)
 
@@ -473,7 +473,7 @@ define([
             {
                 "key": "example.todo",
                 "name": "To-Do List",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "description": "A list of things that need to be done.",
                 "features": ["creation"],
 +               "model": {
@@ -488,7 +488,7 @@ define([
             {
                 "key": "example.todo",
                 "type": "example.todo",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "name": "List",
                 "templateUrl": "templates/todo.html",
                 "editable": true
@@ -647,7 +647,7 @@ define([
             {
                 "key": "example.todo",
                 "name": "To-Do List",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "description": "A list of things that need to be done.",
                 "features": ["creation"],
                 "model": {
@@ -662,7 +662,7 @@ define([
             {
                 "key": "example.todo",
                 "type": "example.todo",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "name": "List",
                 "templateUrl": "templates/todo.html",
                 "editable": true
@@ -741,7 +741,7 @@ define([
             {
                 "key": "example.todo",
                 "name": "To-Do List",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "description": "A list of things that need to be done.",
                 "features": ["creation"],
                 "model": {
@@ -756,7 +756,7 @@ define([
             {
                 "key": "example.todo",
                 "type": "example.todo",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "name": "List",
                 "templateUrl": "templates/todo.html",
                 "editable": true,
@@ -766,7 +766,7 @@ define([
 +                           "items": [
 +                               {
 +                                   "text": "Add Task",
-+                                   "cssclass": "icon-plus",
++                                   "cssClass": "icon-plus",
 +                                   "method": "addTask",
 +                                   "control": "button"
 +                               }
@@ -775,7 +775,7 @@ define([
 +                       {
 +                           "items": [
 +                               {
-+                                   "cssclass": "icon-trash",
++                                   "cssClass": "icon-trash",
 +                                   "method": "removeTask",
 +                                   "control": "button"
 +                               }
@@ -971,7 +971,7 @@ define([
             {
                 "key": "example.todo",
                 "name": "To-Do List",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "description": "A list of things that need to be done.",
                 "features": ["creation"],
                 "model": {
@@ -986,7 +986,7 @@ define([
             {
                 "key": "example.todo",
                 "type": "example.todo",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "name": "List",
                 "templateUrl": "templates/todo.html",
                 "editable": true,
@@ -996,7 +996,7 @@ define([
                             "items": [
                                 {
                                     "text": "Add Task",
-                                    "cssclass": "icon-plus",
+                                    "cssClass": "icon-plus",
                                     "method": "addTask",
                                     "control": "button"
                                 }
@@ -1005,7 +1005,7 @@ define([
                         {
                             "items": [
                                 {
-                                    "cssclass": "icon-trash",
+                                    "cssClass": "icon-trash",
                                     "method": "removeTask",
                                     "control": "button"
                                 }
@@ -1236,7 +1236,7 @@ define([
             {
                 "key": "example.todo",
                 "name": "To-Do List",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "description": "A list of things that need to be done.",
                 "features": ["creation"],
                 "model": {
@@ -1248,7 +1248,7 @@ define([
             {
                 "key": "example.todo",
                 "type": "example.todo",
-                "cssclass": "icon-check",
+                "cssClass": "icon-check",
                 "name": "List",
                 "templateUrl": "templates/todo.html",
                 "editable": true,
@@ -1258,7 +1258,7 @@ define([
                             "items": [
                                 {
                                     "text": "Add Task",
-                                    "cssclass": "icon-plus",
+                                    "cssClass": "icon-plus",
                                     "method": "addTask",
                                     "control": "button"
                                 }
@@ -1267,7 +1267,7 @@ define([
                         {
                             "items": [
                                 {
-                                    "cssclass": "icon-trash",
+                                    "cssClass": "icon-trash",
                                     "method": "removeTask",
                                     "control": "button"
                                 }
@@ -1374,7 +1374,7 @@ define([
             {
                 "name": "Bar Graph",
                 "key": "example.bargraph",
-                "cssclass": "icon-autoflow-tabular",
+                "cssClass": "icon-autoflow-tabular",
                 "templateUrl": "templates/bargraph.html",
                 "needs": [ "telemetry" ],
                 "delegation": true
@@ -1677,7 +1677,7 @@ define([
             {
                 "name": "Bar Graph",
                 "key": "example.bargraph",
-                "cssclass": "icon-autoflow-tabular",
+                "cssClass": "icon-autoflow-tabular",
                 "templateUrl": "templates/bargraph.html",
                 "needs": [ "telemetry" ],
                 "delegation": true
@@ -1843,7 +1843,7 @@ define([
             {
                 "name": "Bar Graph",
                 "key": "example.bargraph",
-                "cssclass": "icon-autoflow-tabular",
+                "cssClass": "icon-autoflow-tabular",
                 "templateUrl": "templates/bargraph.html",
                 "needs": [ "telemetry" ],
                 "delegation": true,
@@ -2320,7 +2320,7 @@ define([
                 {
                     "name": "Spacecraft",
                     "key": "example.spacecraft",
-                    "cssclass": "icon-object"
+                    "cssClass": "icon-object"
                 }
             ],
             "roots": [
@@ -2706,18 +2706,18 @@ define([
             {
                 "name": "Spacecraft",
                 "key": "example.spacecraft",
-                "cssclass": "icon-object"
+                "cssClass": "icon-object"
             },
 +           {
 +               "name": "Subsystem",
 +               "key": "example.subsystem",
-+               "cssclass": "icon-object",
++               "cssClass": "icon-object",
 +               "model": { "composition": [] }
 +           },
 +           {
 +               "name": "Measurement",
 +               "key": "example.measurement",
-+               "cssclass": "icon-telemetry",
++               "cssClass": "icon-telemetry",
 +               "model": { "telemetry": {} },
 +               "telemetry": {
 +                   "source": "example.source",
@@ -3031,18 +3031,18 @@ define([
             {
                 "name": "Spacecraft",
                 "key": "example.spacecraft",
-                "cssclass": "icon-object"
+                "cssClass": "icon-object"
             },
             {
                 "name": "Subsystem",
                 "key": "example.subsystem",
-                "cssclass": "icon-object",
+                "cssClass": "icon-object",
                 "model": { "composition": [] }
             },
             {
                 "name": "Measurement",
                 "key": "example.measurement",
-                "cssclass": "icon-telemetry",
+                "cssClass": "icon-telemetry",
                 "model": { "telemetry": {} },
                 "telemetry": {
                     "source": "example.source",

--- a/example/eventGenerator/bundle.js
+++ b/example/eventGenerator/bundle.js
@@ -49,7 +49,7 @@ define([
                 {
                     "key": "eventGenerator",
                     "name": "Event Message Generator",
-                    "cssclass": "icon-folder-new",
+                    "cssClass": "icon-folder-new",
                     "description": "For development use. Creates sample event message data that mimics a live data stream.",
                     "priority": 10,
                     "features": "creation",

--- a/example/export/bundle.js
+++ b/example/export/bundle.js
@@ -36,7 +36,7 @@ define([
                     "name": "Export Telemetry as CSV",
                     "implementation": ExportTelemetryAsCSVAction,
                     "category": "contextual",
-                    "cssclass": "icon-download",
+                    "cssClass": "icon-download",
                     "depends": [ "exportService" ]
                 }
             ]

--- a/example/generator/bundle.js
+++ b/example/generator/bundle.js
@@ -86,7 +86,7 @@ define([
                 {
                     "key": "generator",
                     "name": "Sine Wave Generator",
-                    "cssclass": "icon-telemetry",
+                    "cssClass": "icon-telemetry",
                     "description": "For development use. Generates example streaming telemetry data using a simple sine wave algorithm.",
                     "priority": 10,
                     "features": "creation",
@@ -130,7 +130,7 @@ define([
                         {
                             "name": "Period",
                             "control": "textfield",
-                            "cssclass": "l-input-sm l-numeric",
+                            "cssClass": "l-input-sm l-numeric",
                             "key": "period",
                             "required": true,
                             "property": [
@@ -142,7 +142,7 @@ define([
                         {
                             "name": "Amplitude",
                             "control": "textfield",
-                            "cssclass": "l-input-sm l-numeric",
+                            "cssClass": "l-input-sm l-numeric",
                             "key": "amplitude",
                             "required": true,
                             "property": [
@@ -154,7 +154,7 @@ define([
                         {
                             "name": "Offset",
                             "control": "textfield",
-                            "cssclass": "l-input-sm l-numeric",
+                            "cssClass": "l-input-sm l-numeric",
                             "key": "offset",
                             "required": true,
                             "property": [
@@ -166,7 +166,7 @@ define([
                         {
                             "name": "Data Rate (hz)",
                             "control": "textfield",
-                            "cssclass": "l-input-sm l-numeric",
+                            "cssClass": "l-input-sm l-numeric",
                             "key": "dataRateInHz",
                             "required": true,
                             "property": [

--- a/example/imagery/bundle.js
+++ b/example/imagery/bundle.js
@@ -49,7 +49,7 @@ define([
                 {
                     "key": "imagery",
                     "name": "Example Imagery",
-                    "cssclass": "icon-image",
+                    "cssClass": "icon-image",
                     "features": "creation",
                     "description": "For development use. Creates example imagery data that mimics a live imagery stream.",
                     "priority": 10,

--- a/example/localTimeSystem/src/LADTickSource.js
+++ b/example/localTimeSystem/src/LADTickSource.js
@@ -31,7 +31,7 @@ define(['../../../platform/features/conductor/core/src/timeSystems/LocalClock'],
         this.metadata = {
             key: 'test-lad',
             mode: 'lad',
-            cssclass: 'icon-clock',
+            cssClass: 'icon-clock',
             label: 'Latest Available Data',
             name: 'Latest available data',
             description: 'Monitor real-time streaming data as it comes in. The Time Conductor and displays will automatically advance themselves based on a UTC clock.'

--- a/example/msl/bundle.js
+++ b/example/msl/bundle.js
@@ -41,18 +41,18 @@ define([
                 {
                     "name":"Mars Science Laboratory",
                     "key": "msl.curiosity",
-                    "cssclass": "icon-object"
+                    "cssClass": "icon-object"
                 },
                 {
                     "name": "Instrument",
                     "key": "msl.instrument",
-                    "cssclass": "icon-object",
+                    "cssClass": "icon-object",
                     "model": {"composition": []}
                 },
                 {
                     "name": "Measurement",
                     "key": "msl.measurement",
-                    "cssclass": "icon-telemetry",
+                    "cssClass": "icon-telemetry",
                     "model": {"telemetry": {}},
                     "telemetry": {
                         "source": "rems.source",

--- a/example/plotOptions/bundle.js
+++ b/example/plotOptions/bundle.js
@@ -81,7 +81,7 @@ define([
                 {
                     "key": "plot",
                     "name": "Example Telemetry Plot",
-                    "cssclass": "icon-telemetry-panel",
+                    "cssClass": "icon-telemetry-panel",
                     "description": "For development use. A plot for displaying telemetry.",
                     "priority": 10,
                     "delegates": [
@@ -129,7 +129,7 @@ define([
                         {
                             "name": "Period",
                             "control": "textfield",
-                            "cssclass": "l-input-sm l-numeric",
+                            "cssClass": "l-input-sm l-numeric",
                             "key": "period",
                             "required": true,
                             "property": [

--- a/example/profiling/src/DigestIndicator.js
+++ b/example/profiling/src/DigestIndicator.js
@@ -63,7 +63,7 @@ define(
                  * Get the CSS class that defines the icon
                  * to display in this indicator. This will appear
                  * as a dataflow icon.
-                 * @returns {string} the cssclass of the dataflow icon
+                 * @returns {string} the cssClass of the dataflow icon
                  */
                 getCssClass: function () {
                     return "icon-connectivity";

--- a/platform/commonUI/browse/bundle.js
+++ b/platform/commonUI/browse/bundle.js
@@ -226,7 +226,7 @@ define([
                         "$window"
                     ],
                     "group": "windowing",
-                    "cssclass": "icon-new-window",
+                    "cssClass": "icon-new-window",
                     "priority": "preferred"
                 },
                 {
@@ -241,7 +241,7 @@ define([
                 {
                     "key": "items",
                     "name": "Items",
-                    "cssclass": "icon-thumbs-strip",
+                    "cssClass": "icon-thumbs-strip",
                     "description": "Grid of available items",
                     "template": itemsTemplate,
                     "uses": [

--- a/platform/commonUI/browse/src/windowing/FullscreenAction.js
+++ b/platform/commonUI/browse/src/windowing/FullscreenAction.js
@@ -46,12 +46,12 @@ define(
         };
 
         FullscreenAction.prototype.getMetadata = function () {
-            // We override getMetadata, because the icon cssclass and
+            // We override getMetadata, because the icon cssClass and
             // description need to be determined at run-time
             // based on whether or not we are currently
             // full screen.
             var metadata = Object.create(FullscreenAction);
-            metadata.cssclass = screenfull.isFullscreen ? "icon-fullscreen-expand" : "icon-fullscreen-collapse";
+            metadata.cssClass = screenfull.isFullscreen ? "icon-fullscreen-expand" : "icon-fullscreen-collapse";
             metadata.description = screenfull.isFullscreen ?
                 EXIT_FULLSCREEN : ENTER_FULLSCREEN;
             metadata.group = "windowing";

--- a/platform/commonUI/browse/test/windowing/FullscreenActionSpec.js
+++ b/platform/commonUI/browse/test/windowing/FullscreenActionSpec.js
@@ -51,7 +51,7 @@ define(
             });
 
             it("provides displayable metadata", function () {
-                expect(action.getMetadata().cssclass).toBeDefined();
+                expect(action.getMetadata().cssClass).toBeDefined();
             });
 
         });

--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -163,7 +163,7 @@ define([
                     ],
                     "description": "Edit",
                     "category": "view-control",
-                    "cssclass": "major icon-pencil"
+                    "cssClass": "major icon-pencil"
                 },
                 {
                     "key": "properties",
@@ -172,7 +172,7 @@ define([
                         "view-control"
                     ],
                     "implementation": PropertiesAction,
-                    "cssclass": "major icon-pencil",
+                    "cssClass": "major icon-pencil",
                     "name": "Edit Properties...",
                     "description": "Edit properties of this object.",
                     "depends": [
@@ -183,7 +183,7 @@ define([
                     "key": "remove",
                     "category": "contextual",
                     "implementation": RemoveAction,
-                    "cssclass": "icon-trash",
+                    "cssClass": "icon-trash",
                     "name": "Remove",
                     "description": "Remove this object from its containing object.",
                     "depends": [
@@ -195,7 +195,7 @@ define([
                     "category": "save",
                     "implementation": SaveAndStopEditingAction,
                     "name": "Save and Finish Editing",
-                    "cssclass": "icon-save labeled",
+                    "cssClass": "icon-save labeled",
                     "description": "Save changes made to these objects.",
                     "depends": [
                         "dialogService",
@@ -207,7 +207,7 @@ define([
                     "category": "save",
                     "implementation": SaveAction,
                     "name": "Save and Continue Editing",
-                    "cssclass": "icon-save labeled",
+                    "cssClass": "icon-save labeled",
                     "description": "Save changes made to these objects.",
                     "depends": [
                         "dialogService",
@@ -219,7 +219,7 @@ define([
                     "category": "save",
                     "implementation": SaveAsAction,
                     "name": "Save As...",
-                    "cssclass": "icon-save labeled",
+                    "cssClass": "icon-save labeled",
                     "description": "Save changes made to these objects.",
                     "depends": [
                         "$injector",
@@ -237,7 +237,7 @@ define([
                     // Because we use the name as label for edit buttons and mct-control buttons need
                     // the label to be set to undefined in order to not apply the labeled CSS rule.
                     "name": undefined,
-                    "cssclass": "icon-x no-label",
+                    "cssClass": "icon-x no-label",
                     "description": "Discard changes made to these objects.",
                     "depends": []
                 }

--- a/platform/commonUI/edit/res/templates/create/create-menu.html
+++ b/platform/commonUI/edit/res/templates/create/create-menu.html
@@ -25,14 +25,14 @@
             <li ng-repeat="createAction in createActions" ng-click="createAction.perform()">
                 <a ng-mouseover="representation.activeMetadata = createAction.getMetadata()"
                    ng-mouseleave="representation.activeMetadata = undefined"
-                   class="menu-item-a {{ createAction.getMetadata().cssclass }}">
+                   class="menu-item-a {{ createAction.getMetadata().cssClass }}">
                     {{createAction.getMetadata().name}}
                 </a>
             </li>
         </ul>
     </div>
     <div class="pane right menu-item-description">
-        <div class="desc-area icon {{ representation.activeMetadata.cssclass }}"></div>
+        <div class="desc-area icon {{ representation.activeMetadata.cssClass }}"></div>
         <div class="desc-area title">
             {{representation.activeMetadata.name}}
         </div>

--- a/platform/commonUI/edit/res/templates/edit-action-buttons.html
+++ b/platform/commonUI/edit/res/templates/edit-action-buttons.html
@@ -26,7 +26,7 @@
                      structure="{
                         text: saveActions[0].getMetadata().name,
                         click: actionPerformer(saveActions[0]),
-                        cssclass: 'major ' + saveActions[0].getMetadata().cssclass
+                        cssClass: 'major ' + saveActions[0].getMetadata().cssClass
                      }">
         </mct-control>
     </span>
@@ -36,7 +36,7 @@
                      structure="{
                         options: saveActionsAsMenuOptions,
                         click: saveActionMenuClickHandler,
-                        cssclass: 'btn-bar right icon-save no-label major'
+                        cssClass: 'btn-bar right icon-save no-label major'
                      }">
         </mct-control>
     </span>
@@ -46,7 +46,7 @@
                      structure="{
                         text: currentAction.getMetadata().name,
                         click: actionPerformer(currentAction),
-                        cssclass: currentAction.getMetadata().cssclass
+                        cssClass: currentAction.getMetadata().cssClass
                      }">
         </mct-control>
     </span>

--- a/platform/commonUI/edit/src/controllers/EditActionController.js
+++ b/platform/commonUI/edit/src/controllers/EditActionController.js
@@ -41,7 +41,7 @@ define(
                 return {
                     key: action,
                     name: action.getMetadata().name,
-                    cssclass: action.getMetadata().cssclass
+                    cssClass: action.getMetadata().cssClass
                 };
             }
 

--- a/platform/commonUI/edit/src/creation/AddAction.js
+++ b/platform/commonUI/edit/src/creation/AddAction.js
@@ -51,7 +51,7 @@ define(
         function AddAction(type, parent, context, $q, dialogService, policyService) {
             this.metadata = {
                 key: 'add',
-                cssclass: type.getCssClass(),
+                cssClass: type.getCssClass(),
                 name: type.getName(),
                 type: type.getKey(),
                 description: type.getDescription(),

--- a/platform/commonUI/edit/src/creation/CreateAction.js
+++ b/platform/commonUI/edit/src/creation/CreateAction.js
@@ -47,7 +47,7 @@ define(
         function CreateAction(type, parent, context) {
             this.metadata = {
                 key: 'create',
-                cssclass: type.getCssClass(),
+                cssClass: type.getCssClass(),
                 name: type.getName(),
                 type: type.getKey(),
                 description: type.getDescription(),

--- a/platform/commonUI/edit/src/creation/CreateWizard.js
+++ b/platform/commonUI/edit/src/creation/CreateWizard.js
@@ -91,7 +91,7 @@ define(
             if (includeLocation) {
                 sections.push({
                     name: 'Location',
-                    cssclass: "grows",
+                    cssClass: "grows",
                     rows: [{
                         name: "Save In",
                         control: "locator",

--- a/platform/commonUI/edit/test/controllers/EditActionControllerSpec.js
+++ b/platform/commonUI/edit/test/controllers/EditActionControllerSpec.js
@@ -28,7 +28,7 @@ define(
         describe("The Edit Action controller", function () {
             var mockSaveActionMetadata = {
                 name: "mocked-save-action",
-                cssclass: "mocked-save-action-css"
+                cssClass: "mocked-save-action-css"
             };
 
             function fakeGetActions(actionContext) {
@@ -86,7 +86,7 @@ define(
                 expect(menuOptions[1].key).toEqual(mockScope.saveActions[1]);
                 menuOptions.forEach(function (option) {
                     expect(option.name).toEqual(mockSaveActionMetadata.name);
-                    expect(option.cssclass).toEqual(mockSaveActionMetadata.cssclass);
+                    expect(option.cssClass).toEqual(mockSaveActionMetadata.cssClass);
                 });
             });
 

--- a/platform/commonUI/edit/test/creation/CreateActionSpec.js
+++ b/platform/commonUI/edit/test/creation/CreateActionSpec.js
@@ -138,7 +138,7 @@ define(
 
                 expect(metadata.name).toEqual("Test");
                 expect(metadata.description).toEqual("a test type");
-                expect(metadata.cssclass).toEqual("icon-telemetry");
+                expect(metadata.cssClass).toEqual("icon-telemetry");
             });
 
             describe("the perform function", function () {

--- a/platform/commonUI/general/res/templates/controls/action-button.html
+++ b/platform/commonUI/general/res/templates/controls/action-button.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<a class="s-button key-{{parameters.action.getMetadata().key}} {{parameters.action.getMetadata().cssclass}}"
+<a class="s-button key-{{parameters.action.getMetadata().key}} {{parameters.action.getMetadata().cssClass}}"
    ng-class="{ labeled: parameters.labeled }"
    title="{{parameters.action.getMetadata().description}}"
    ng-click="parameters.action.perform()">

--- a/platform/commonUI/general/res/templates/controls/switcher.html
+++ b/platform/commonUI/general/res/templates/controls/switcher.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <span ng-controller="ViewSwitcherController">
-    <div class="view-switcher menu-element s-menu-button {{ngModel.selected.cssclass}}"
+    <div class="view-switcher menu-element s-menu-button {{ngModel.selected.cssClass}}"
 	    ng-if="view.length > 1"
 	    ng-controller="ClickAwayController as toggle">
 
@@ -33,7 +33,7 @@
             <ul>
                 <li ng-repeat="option in view"
                     ng-click="ngModel.selected = option; toggle.setState(false)"
-                    class="{{option.cssclass}}">
+                    class="{{option.cssClass}}">
                     {{option.name}}
                 </li>
             </ul>

--- a/platform/commonUI/general/res/templates/menu/context-menu.html
+++ b/platform/commonUI/general/res/templates/menu/context-menu.html
@@ -25,7 +25,7 @@
             <li ng-repeat="menuAction in menuActions"
                 ng-click="menuAction.perform()"
                 title="{{menuAction.getMetadata().description}}"
-                class="{{menuAction.getMetadata().cssclass}}">
+                class="{{menuAction.getMetadata().cssClass}}">
                 {{menuAction.getMetadata().name}}
             </li>
         </ul>

--- a/platform/core/bundle.js
+++ b/platform/core/bundle.js
@@ -241,7 +241,7 @@ define([
                             "property": "name",
                             "pattern": "\\S+",
                             "required": true,
-                            "cssclass": "l-input-lg"
+                            "cssClass": "l-input-lg"
                         },
                         {
                             "name": "Notes",
@@ -249,19 +249,19 @@ define([
                             "property": "notes",
                             "control": "textarea",
                             "required": false,
-                            "cssclass": "l-textarea-sm"
+                            "cssClass": "l-textarea-sm"
                         }
                     ]
                 },
                 {
                     "key": "root",
                     "name": "Root",
-                    "cssclass": "icon-folder"
+                    "cssClass": "icon-folder"
                 },
                 {
                     "key": "folder",
                     "name": "Folder",
-                    "cssclass": "icon-folder",
+                    "cssClass": "icon-folder",
                     "features": "creation",
                     "description": "Create folders to organize other objects or links to objects.",
                     "priority": 1000,
@@ -272,11 +272,11 @@ define([
                 {
                     "key": "unknown",
                     "name": "Unknown Type",
-                    "cssclass": "icon-object-unknown"
+                    "cssClass": "icon-object-unknown"
                 },
                 {
                     "name": "Unknown Type",
-                    "cssclass": "icon-object-unknown"
+                    "cssClass": "icon-object-unknown"
                 }
             ],
             "capabilities": [

--- a/platform/core/src/actions/ActionAggregator.js
+++ b/platform/core/src/actions/ActionAggregator.js
@@ -58,7 +58,7 @@ define(
          * @property {string} key machine-readable identifier for this action
          * @property {string} name human-readable name for this action
          * @property {string} description human-readable description
-         * @property {string} cssclass CSS class for icon
+         * @property {string} cssClass CSS class for icon
          * @property {ActionContext} context the context in which the action
          *           will be performed.
          */

--- a/platform/core/src/types/TypeImpl.js
+++ b/platform/core/src/types/TypeImpl.js
@@ -56,12 +56,12 @@ define(
          * @method Type#getDescription
          */
         /**
-         * Get the cssclass associated with this type. cssclass is a
+         * Get the cssClass associated with this type. cssClass is a
          * string which will appear as an icon (when
          * displayed in an appropriate font) which visually
          * distinguish types from one another.
          *
-         * @returns {string} the cssclass for this type
+         * @returns {string} the cssClass for this type
          * @method Type#getCssClass
          */
         /**
@@ -145,7 +145,7 @@ define(
         };
 
         TypeImpl.prototype.getCssClass = function () {
-            return this.typeDef.cssclass;
+            return this.typeDef.cssClass;
         };
 
         TypeImpl.prototype.getProperties = function () {

--- a/platform/core/test/types/TypeImplSpec.js
+++ b/platform/core/test/types/TypeImplSpec.js
@@ -33,7 +33,7 @@ define(
                     key: 'test-type',
                     name: 'Test Type',
                     description: 'A type, for testing',
-                    cssclass: 'icon-telemetry-panel',
+                    cssClass: 'icon-telemetry-panel',
                     inherits: ['test-parent-1', 'test-parent-2'],
                     features: ['test-feature-1'],
                     properties: [{}],

--- a/platform/core/test/types/TypeProviderSpec.js
+++ b/platform/core/test/types/TypeProviderSpec.js
@@ -30,18 +30,18 @@ define(
                 testTypeDefinitions = [
                     {
                         key: 'basic',
-                        cssclass: "icon-magnify-in",
+                        cssClass: "icon-magnify-in",
                         name: "Basic Type"
                     },
                     {
                         key: 'multi1',
-                        cssclass: "icon-trash",
+                        cssClass: "icon-trash",
                         description: "Multi1 Description",
                         capabilities: ['a1', 'b1']
                     },
                     {
                         key: 'multi2',
-                        cssclass: "icon-magnify-out",
+                        cssClass: "icon-magnify-out",
                         capabilities: ['a2', 'b2', 'c2']
                     },
                     {

--- a/platform/entanglement/bundle.js
+++ b/platform/entanglement/bundle.js
@@ -66,7 +66,7 @@ define([
                     "key": "move",
                     "name": "Move",
                     "description": "Move object to another location.",
-                    "cssclass": "icon-move",
+                    "cssClass": "icon-move",
                     "category": "contextual",
                     "implementation": MoveAction,
                     "depends": [
@@ -79,7 +79,7 @@ define([
                     "key": "copy",
                     "name": "Duplicate",
                     "description": "Duplicate object to another location.",
-                    "cssclass": "icon-duplicate",
+                    "cssClass": "icon-duplicate",
                     "category": "contextual",
                     "implementation": CopyAction,
                     "depends": [
@@ -95,7 +95,7 @@ define([
                     "key": "link",
                     "name": "Create Link",
                     "description": "Create Link to object in another location.",
-                    "cssclass": "icon-link",
+                    "cssClass": "icon-link",
                     "category": "contextual",
                     "implementation": LinkAction,
                     "depends": [
@@ -108,7 +108,7 @@ define([
                     "key": "follow",
                     "name": "Go To Original",
                     "description": "Go to the original, un-linked instance of this object.",
-                    "cssclass": "",
+                    "cssClass": "",
                     "category": "contextual",
                     "implementation": GoToOriginalAction
                 },
@@ -116,7 +116,7 @@ define([
                     "key": "locate",
                     "name": "Set Primary Location",
                     "description": "Set a domain object's primary location.",
-                    "cssclass": "",
+                    "cssClass": "",
                     "category": "contextual",
                     "implementation": SetPrimaryLocationAction
                 }

--- a/platform/entanglement/src/services/LocationService.js
+++ b/platform/entanglement/src/services/LocationService.js
@@ -58,7 +58,7 @@ define(
                         sections: [
                             {
                                 name: 'Location',
-                                cssclass: "grows",
+                                cssClass: "grows",
                                 rows: [
                                     {
                                         name: label,

--- a/platform/features/clock/bundle.js
+++ b/platform/features/clock/bundle.js
@@ -136,7 +136,7 @@ define([
                     ],
                     "category": "contextual",
                     "name": "Start",
-                    "cssclass": "icon-play",
+                    "cssClass": "icon-play",
                     "priority": "preferred"
                 },
                 {
@@ -147,7 +147,7 @@ define([
                     ],
                     "category": "contextual",
                     "name": "Restart at 0",
-                    "cssclass": "icon-refresh",
+                    "cssClass": "icon-refresh",
                     "priority": "preferred"
                 }
             ],
@@ -155,7 +155,7 @@ define([
                 {
                     "key": "clock",
                     "name": "Clock",
-                    "cssclass": "icon-clock",
+                    "cssClass": "icon-clock",
                     "description": "A UTC-based clock that supports a variety of display formats. Clocks can be added to Display Layouts.",
                     "priority": 101,
                     "features": [
@@ -183,7 +183,7 @@ define([
                                             "name": "hh:mm:ss"
                                         }
                                     ],
-                                    "cssclass": "l-inline"
+                                    "cssClass": "l-inline"
                                 },
                                 {
                                     "control": "select",
@@ -197,7 +197,7 @@ define([
                                             "name": "24hr"
                                         }
                                     ],
-                                    "cssclass": "l-inline"
+                                    "cssClass": "l-inline"
                                 }
                             ]
                         }
@@ -212,7 +212,7 @@ define([
                 {
                     "key": "timer",
                     "name": "Timer",
-                    "cssclass": "icon-timer",
+                    "cssClass": "icon-timer",
                     "description": "A timer that counts up or down to a datetime. Timers can be started, stopped and reset whenever needed, and support a variety of display formats. Each Timer displays the same value to all users. Timers can be added to Display Layouts.",
                     "priority": 100,
                     "features": [

--- a/platform/features/clock/src/controllers/TimerController.js
+++ b/platform/features/clock/src/controllers/TimerController.js
@@ -131,11 +131,11 @@ define(
         /**
          * Get the CSS class to display the right icon
          * for the start/restart button.
-         * @returns {string} cssclass to display
+         * @returns {string} cssClass to display
          */
         TimerController.prototype.buttonCssClass = function () {
             return this.relevantAction ?
-                    this.relevantAction.getMetadata().cssclass : "";
+                    this.relevantAction.getMetadata().cssClass : "";
         };
 
         /**

--- a/platform/features/clock/test/controllers/TimerControllerSpec.js
+++ b/platform/features/clock/test/controllers/TimerControllerSpec.js
@@ -85,8 +85,8 @@ define(
                         'timer.restart': mockRestart
                     }[k]];
                 });
-                mockStart.getMetadata.andReturn({ cssclass: "icon-play", name: "Start" });
-                mockRestart.getMetadata.andReturn({ cssclass: "icon-refresh", name: "Restart" });
+                mockStart.getMetadata.andReturn({ cssClass: "icon-play", name: "Start" });
+                mockRestart.getMetadata.andReturn({ cssClass: "icon-refresh", name: "Restart" });
                 mockScope.domainObject = mockDomainObject;
 
                 testModel = {};
@@ -144,7 +144,7 @@ define(
                 expect(controller.text()).toEqual("0D 00:00:00");
             });
 
-            it("shows cssclass & name for the applicable start/restart action", function () {
+            it("shows cssClass & name for the applicable start/restart action", function () {
                 invokeWatch('domainObject', mockDomainObject);
                 expect(controller.buttonCssClass()).toEqual("icon-play");
                 expect(controller.buttonText()).toEqual("Start");

--- a/platform/features/conductor/core/res/templates/mode-selector/mode-menu.html
+++ b/platform/features/conductor/core/res/templates/mode-selector/mode-menu.html
@@ -26,7 +26,7 @@
                 ng-click="ngModel.selectedKey=key">
                 <a ng-mouseover="ngModel.activeMetadata = metadata"
                    ng-mouseleave="ngModel.activeMetadata = undefined"
-                   class="menu-item-a {{metadata.cssclass}}">
+                   class="menu-item-a {{metadata.cssClass}}">
                     {{metadata.name}}
                 </a>
             </li>
@@ -34,7 +34,7 @@
     </div>
     <div class="pane right menu-item-description">
         <div
-                class="desc-area ui-symbol icon type-icon {{ngModel.activeMetadata.cssclass}}"></div>
+                class="desc-area ui-symbol icon type-icon {{ngModel.activeMetadata.cssClass}}"></div>
         <div class="desc-area title">
             {{ngModel.activeMetadata.name}}
         </div>

--- a/platform/features/conductor/core/src/timeSystems/LocalClock.js
+++ b/platform/features/conductor/core/src/timeSystems/LocalClock.js
@@ -31,7 +31,7 @@ define(['./TickSource'], function (TickSource) {
         this.metadata = {
             key: 'local',
             mode: 'realtime',
-            cssclass: 'icon-clock',
+            cssClass: 'icon-clock',
             label: 'Real-time',
             name: 'Real-time Mode',
             description: 'Monitor real-time streaming data as it comes in. The Time Conductor and displays will automatically advance themselves based on a UTC clock.'

--- a/platform/features/conductor/core/src/ui/TimeConductorViewService.js
+++ b/platform/features/conductor/core/src/ui/TimeConductorViewService.js
@@ -60,7 +60,7 @@ define(
             this.availModes = {
                 'fixed': {
                     key: 'fixed',
-                    cssclass: 'icon-calendar',
+                    cssClass: 'icon-calendar',
                     label: 'Fixed',
                     name: 'Fixed Timespan Mode',
                     description: 'Query and explore data that falls between two fixed datetimes.'
@@ -81,7 +81,7 @@ define(
             if (timeSystemsForMode('realtime').length > 0) {
                 var realtimeMode = {
                     key: 'realtime',
-                    cssclass: 'icon-clock',
+                    cssClass: 'icon-clock',
                     label: 'Real-time',
                     name: 'Real-time Mode',
                     description: 'Monitor real-time streaming data as it comes in. The Time Conductor and displays will automatically advance themselves based on a UTC clock.'
@@ -93,7 +93,7 @@ define(
             if (timeSystemsForMode('lad').length > 0) {
                 var ladMode = {
                     key: 'lad',
-                    cssclass: 'icon-database',
+                    cssClass: 'icon-database',
                     label: 'LAD',
                     name: 'LAD Mode',
                     description: 'Latest Available Data mode monitors real-time streaming data as it comes in. The Time Conductor and displays will only advance when data becomes available.'

--- a/platform/features/conductor/utcTimeSystem/src/UTCTimeSystem.js
+++ b/platform/features/conductor/utcTimeSystem/src/UTCTimeSystem.js
@@ -38,12 +38,12 @@ define([
         /**
          * Some metadata, which will be used to identify the time system in
          * the UI
-         * @type {{key: string, name: string, cssclass: string}}
+         * @type {{key: string, name: string, cssClass: string}}
          */
         this.metadata = {
             'key': 'utc',
             'name': 'UTC',
-            'cssclass': 'icon-clock'
+            'cssClass': 'icon-clock'
         };
 
         this.fmts = ['utc'];

--- a/platform/features/fixed/bundle.js
+++ b/platform/features/fixed/bundle.js
@@ -36,7 +36,7 @@ define([
                 {
                     "key": "fixed-display",
                     "name": "Fixed Position Display",
-                    "cssclass": "icon-box-with-dashed-lines",
+                    "cssClass": "icon-box-with-dashed-lines",
                     "type": "telemetry.fixed",
                     "template": fixedTemplate,
                     "uses": [
@@ -49,28 +49,28 @@ define([
                                 "items": [
                                     {
                                         "method": "add",
-                                        "cssclass": "icon-plus",
+                                        "cssClass": "icon-plus",
                                         "control": "menu-button",
                                         "text": "Add",
                                         "options": [
                                             {
                                                 "name": "Box",
-                                                "cssclass": "icon-box",
+                                                "cssClass": "icon-box",
                                                 "key": "fixed.box"
                                             },
                                             {
                                                 "name": "Line",
-                                                "cssclass": "icon-line-horz",
+                                                "cssClass": "icon-line-horz",
                                                 "key": "fixed.line"
                                             },
                                             {
                                                 "name": "Text",
-                                                "cssclass": "icon-T",
+                                                "cssClass": "icon-T",
                                                 "key": "fixed.text"
                                             },
                                             {
                                                 "name": "Image",
-                                                "cssclass": "icon-image",
+                                                "cssClass": "icon-image",
                                                 "key": "fixed.image"
                                             }
                                         ]
@@ -81,50 +81,50 @@ define([
                                 "items": [
                                     {
                                         "method": "order",
-                                        "cssclass": "icon-layers",
+                                        "cssClass": "icon-layers",
                                         "control": "menu-button",
                                         "title": "Layering",
                                         "description": "Move the selected object above or below other objects",
                                         "options": [
                                             {
                                                 "name": "Move to Top",
-                                                "cssclass": "icon-arrow-double-up",
+                                                "cssClass": "icon-arrow-double-up",
                                                 "key": "top"
                                             },
                                             {
                                                 "name": "Move Up",
-                                                "cssclass": "icon-arrow-up",
+                                                "cssClass": "icon-arrow-up",
                                                 "key": "up"
                                             },
                                             {
                                                 "name": "Move Down",
-                                                "cssclass": "icon-arrow-down",
+                                                "cssClass": "icon-arrow-down",
                                                 "key": "down"
                                             },
                                             {
                                                 "name": "Move to Bottom",
-                                                "cssclass": "icon-arrow-double-down",
+                                                "cssClass": "icon-arrow-double-down",
                                                 "key": "bottom"
                                             }
                                         ]
                                     },
                                     {
                                         "property": "fill",
-                                        "cssclass": "icon-paint-bucket",
+                                        "cssClass": "icon-paint-bucket",
                                         "title": "Fill color",
                                         "description": "Set fill color",
                                         "control": "color"
                                     },
                                     {
                                         "property": "stroke",
-                                        "cssclass": "icon-line-horz",
+                                        "cssClass": "icon-line-horz",
                                         "title": "Border color",
                                         "description": "Set border color",
                                         "control": "color"
                                     },
                                     {
                                         "property": "color",
-                                        "cssclass": "icon-T",
+                                        "cssClass": "icon-T",
                                         "title": "Text color",
                                         "description": "Set text color",
                                         "mandatory": true,
@@ -132,20 +132,20 @@ define([
                                     },
                                     {
                                         "property": "url",
-                                        "cssclass": "icon-image",
+                                        "cssClass": "icon-image",
                                         "control": "dialog-button",
                                         "title": "Image Properties",
                                         "description": "Edit image properties",
                                         "dialog": {
                                             "control": "textfield",
                                             "name": "Image URL",
-                                            "cssclass": "l-input-lg",
+                                            "cssClass": "l-input-lg",
                                             "required": true
                                         }
                                     },
                                     {
                                         "property": "text",
-                                        "cssclass": "icon-gear",
+                                        "cssClass": "icon-gear",
                                         "control": "dialog-button",
                                         "title": "Text Properties",
                                         "description": "Edit text properties",
@@ -157,14 +157,14 @@ define([
                                     },
                                     {
                                         "method": "showTitle",
-                                        "cssclass": "icon-two-parts-both",
+                                        "cssClass": "icon-two-parts-both",
                                         "control": "button",
                                         "title": "Show title",
                                         "description": "Show telemetry element title"
                                     },
                                     {
                                         "method": "hideTitle",
-                                        "cssclass": "icon-two-parts-one-only",
+                                        "cssClass": "icon-two-parts-one-only",
                                         "control": "button",
                                         "title": "Hide title",
                                         "description": "Hide telemetry element title"
@@ -176,7 +176,7 @@ define([
                                     {
                                         "method": "remove",
                                         "control": "button",
-                                        "cssclass": "icon-trash"
+                                        "cssClass": "icon-trash"
                                     }
                                 ]
                             }
@@ -188,7 +188,7 @@ define([
                 {
                     "key": "telemetry.fixed",
                     "name": "Fixed Position Display",
-                    "cssclass": "icon-box-with-dashed-lines",
+                    "cssClass": "icon-box-with-dashed-lines",
                     "description": "Collect and display telemetry elements in " +
                     "alphanumeric format in a simple canvas workspace. " +
                     "Elements can be positioned and sized. " +
@@ -215,12 +215,12 @@ define([
                                 {
                                     "name": "Horizontal grid (px)",
                                     "control": "textfield",
-                                    "cssclass": "l-input-sm l-numeric"
+                                    "cssClass": "l-input-sm l-numeric"
                                 },
                                 {
                                     "name": "Vertical grid (px)",
                                     "control": "textfield",
-                                    "cssclass": "l-input-sm l-numeric"
+                                    "cssClass": "l-input-sm l-numeric"
                                 }
                             ],
                             "pattern": "^(\\d*[1-9]\\d*)?$",

--- a/platform/features/imagery/bundle.js
+++ b/platform/features/imagery/bundle.js
@@ -41,7 +41,7 @@ define([
                 {
                     "name": "Imagery",
                     "key": "imagery",
-                    "cssclass": "icon-image",
+                    "cssClass": "icon-image",
                     "template": imageryTemplate,
                     "priority": "preferred",
                     "needs": [

--- a/platform/features/layout/bundle.js
+++ b/platform/features/layout/bundle.js
@@ -56,7 +56,7 @@ define([
                 {
                     "key": "layout",
                     "name": "Display Layout",
-                    "cssclass": "icon-layout",
+                    "cssClass": "icon-layout",
                     "type": "layout",
                     "template": layoutTemplate,
                     "editable": true,
@@ -65,7 +65,7 @@ define([
                 {
                     "key": "fixed",
                     "name": "Fixed Position",
-                    "cssclass": "icon-box-with-dashed-lines",
+                    "cssClass": "icon-box-with-dashed-lines",
                     "type": "telemetry.panel",
                     "template": fixedTemplate,
                     "uses": [
@@ -77,7 +77,7 @@ define([
                                 "items": [
                                     {
                                         "method": "add",
-                                        "cssclass": "icon-plus",
+                                        "cssClass": "icon-plus",
                                         "control": "menu-button",
                                         "text": "Add",
                                         "title": "Add",
@@ -85,22 +85,22 @@ define([
                                         "options": [
                                             {
                                                 "name": "Box",
-                                                "cssclass": "icon-box",
+                                                "cssClass": "icon-box",
                                                 "key": "fixed.box"
                                             },
                                             {
                                                 "name": "Line",
-                                                "cssclass": "icon-line-horz",
+                                                "cssClass": "icon-line-horz",
                                                 "key": "fixed.line"
                                             },
                                             {
                                                 "name": "Text",
-                                                "cssclass": "icon-T",
+                                                "cssClass": "icon-T",
                                                 "key": "fixed.text"
                                             },
                                             {
                                                 "name": "Image",
-                                                "cssclass": "icon-image",
+                                                "cssClass": "icon-image",
                                                 "key": "fixed.image"
                                             }
                                         ]
@@ -111,50 +111,50 @@ define([
                                 "items": [
                                     {
                                         "method": "order",
-                                        "cssclass": "icon-layers",
+                                        "cssClass": "icon-layers",
                                         "control": "menu-button",
                                         "title": "Layering",
                                         "description": "Move the selected object above or below other objects",
                                         "options": [
                                             {
                                                 "name": "Move to Top",
-                                                "cssclass": "icon-arrow-double-up",
+                                                "cssClass": "icon-arrow-double-up",
                                                 "key": "top"
                                             },
                                             {
                                                 "name": "Move Up",
-                                                "cssclass": "icon-arrow-up",
+                                                "cssClass": "icon-arrow-up",
                                                 "key": "up"
                                             },
                                             {
                                                 "name": "Move Down",
-                                                "cssclass": "icon-arrow-down",
+                                                "cssClass": "icon-arrow-down",
                                                 "key": "down"
                                             },
                                             {
                                                 "name": "Move to Bottom",
-                                                "cssclass": "icon-arrow-double-down",
+                                                "cssClass": "icon-arrow-double-down",
                                                 "key": "bottom"
                                             }
                                         ]
                                     },
                                     {
                                         "property": "fill",
-                                        "cssclass": "icon-paint-bucket",
+                                        "cssClass": "icon-paint-bucket",
                                         "title": "Fill color",
                                         "description": "Set fill color",
                                         "control": "color"
                                     },
                                     {
                                         "property": "stroke",
-                                        "cssclass": "icon-line-horz",
+                                        "cssClass": "icon-line-horz",
                                         "title": "Border color",
                                         "description": "Set border color",
                                         "control": "color"
                                     },
                                     {
                                         "property": "color",
-                                        "cssclass": "icon-T",
+                                        "cssClass": "icon-T",
                                         "title": "Text color",
                                         "description": "Set text color",
                                         "mandatory": true,
@@ -162,20 +162,20 @@ define([
                                     },
                                     {
                                         "property": "url",
-                                        "cssclass": "icon-image",
+                                        "cssClass": "icon-image",
                                         "control": "dialog-button",
                                         "title": "Image Properties",
                                         "description": "Edit image properties",
                                         "dialog": {
                                             "control": "textfield",
                                             "name": "Image URL",
-                                            "cssclass": "l-input-lg",
+                                            "cssClass": "l-input-lg",
                                             "required": true
                                         }
                                     },
                                     {
                                         "property": "text",
-                                        "cssclass": "icon-gear",
+                                        "cssClass": "icon-gear",
                                         "control": "dialog-button",
                                         "title": "Text Properties",
                                         "description": "Edit text properties",
@@ -187,14 +187,14 @@ define([
                                     },
                                     {
                                         "method": "showTitle",
-                                        "cssclass": "icon-two-parts-both",
+                                        "cssClass": "icon-two-parts-both",
                                         "control": "button",
                                         "title": "Show title",
                                         "description": "Show telemetry element title"
                                     },
                                     {
                                         "method": "hideTitle",
-                                        "cssclass": "icon-two-parts-one-only",
+                                        "cssClass": "icon-two-parts-one-only",
                                         "control": "button",
                                         "title": "Hide title",
                                         "description": "Hide telemetry element title"
@@ -206,7 +206,7 @@ define([
                                     {
                                         "method": "remove",
                                         "control": "button",
-                                        "cssclass": "icon-trash",
+                                        "cssClass": "icon-trash",
                                         "title": "Delete",
                                         "description": "Delete the selected item"
                                     }
@@ -275,7 +275,7 @@ define([
                 {
                     "key": "layout",
                     "name": "Display Layout",
-                    "cssclass": "icon-layout",
+                    "cssClass": "icon-layout",
                     "description": "Assemble other objects and components together into a reusable screen layout. Working in a simple canvas workspace, simply drag in the objects you want, position and size them. Save your design and view or edit it at any time.",
                     "priority": 900,
                     "features": "creation",
@@ -291,12 +291,12 @@ define([
                                 {
                                     "name": "Horizontal grid (px)",
                                     "control": "textfield",
-                                    "cssclass": "l-input-sm l-numeric"
+                                    "cssClass": "l-input-sm l-numeric"
                                 },
                                 {
                                     "name": "Vertical grid (px)",
                                     "control": "textfield",
-                                    "cssclass": "l-input-sm l-numeric"
+                                    "cssClass": "l-input-sm l-numeric"
                                 }
                             ],
                             "key": "layoutGrid",
@@ -307,7 +307,7 @@ define([
                 {
                     "key": "telemetry.panel",
                     "name": "Telemetry Panel",
-                    "cssclass": "icon-telemetry-panel",
+                    "cssClass": "icon-telemetry-panel",
                     "description": "A panel for collecting telemetry elements.",
                     "priority": 899,
                     "delegates": [
@@ -330,12 +330,12 @@ define([
                                 {
                                     "name": "Horizontal grid (px)",
                                     "control": "textfield",
-                                    "cssclass": "l-input-sm l-numeric"
+                                    "cssClass": "l-input-sm l-numeric"
                                 },
                                 {
                                     "name": "Vertical grid (px)",
                                     "control": "textfield",
-                                    "cssclass": "l-input-sm l-numeric"
+                                    "cssClass": "l-input-sm l-numeric"
                                 }
                             ],
                             "pattern": "^(\\d*[1-9]\\d*)?$",

--- a/platform/features/layout/src/elements/ElementFactory.js
+++ b/platform/features/layout/src/elements/ElementFactory.js
@@ -55,7 +55,7 @@ define(
                                     key: "url",
                                     control: "textfield",
                                     name: "Image URL",
-                                    "cssclass": "l-input-lg",
+                                    "cssClass": "l-input-lg",
                                     required: true
                                 }
                             ]

--- a/platform/features/pages/bundle.js
+++ b/platform/features/pages/bundle.js
@@ -36,7 +36,7 @@ define([
                 {
                     "key": "example.page",
                     "name": "Web Page",
-                    "cssclass": "icon-page",
+                    "cssClass": "icon-page",
                     "description": "Embed a web page or web-based image in a resizeable window component. Can be added to Display Layouts. Note that the URL being embedded must allow iframing.",
                     "priority": 50,
                     "features": [
@@ -49,7 +49,7 @@ define([
                             "control": "textfield",
                             "pattern": "^(ftp|https?)\\:\\/\\/\\w+(\\.\\w+)*(\\:\\d+)?(\\/\\S*)*$",
                             "required": true,
-                            "cssclass": "l-input-lg"
+                            "cssClass": "l-input-lg"
                         }
                     ]
                 }

--- a/platform/features/plot/bundle.js
+++ b/platform/features/plot/bundle.js
@@ -47,7 +47,7 @@ define([
                 {
                     "name": "Plot",
                     "key": "plot",
-                    "cssclass": "icon-sine",
+                    "cssClass": "icon-sine",
                     "template": plotTemplate,
                     "needs": [
                         "telemetry"

--- a/platform/features/plot/res/templates/plot.html
+++ b/platform/features/plot/res/templates/plot.html
@@ -121,7 +121,7 @@
                            ng-show="plot.isZoomed()"
                            title="Reset pan/zoom">
                         </a>
-                        <div class="menu-element s-menu-button menus-to-left {{plot.getMode().cssclass}}"
+                        <div class="menu-element s-menu-button menus-to-left {{plot.getMode().cssClass}}"
                              ng-if="plot.getModeOptions().length > 1"
                              ng-controller="ClickAwayController as toggle">
                             <span class="l-click-area" ng-click="toggle.toggle()"></span>
@@ -130,7 +130,7 @@
                                 <ul>
                                     <li ng-repeat="option in plot.getModeOptions()"
                                         ng-click="plot.setMode(option); toggle.setState(false)"
-                                        class="{{option.cssclass}}">
+                                        class="{{option.cssClass}}">
                                         {{option.name}}
                                     </li>
                                 </ul>

--- a/platform/features/plot/src/PlotController.js
+++ b/platform/features/plot/src/PlotController.js
@@ -352,7 +352,7 @@ define(
 
         /**
          * Get the current mode that is applicable to this plot. This
-         * will include key, name, and cssclass fields.
+         * will include key, name, and cssClass fields.
          */
         PlotController.prototype.getMode = function () {
             return this.modeOptions.getMode();

--- a/platform/features/plot/src/modes/PlotModeOptions.js
+++ b/platform/features/plot/src/modes/PlotModeOptions.js
@@ -27,13 +27,13 @@ define(
         var STACKED = {
                 key: "stacked",
                 name: "Stacked",
-                cssclass: "icon-plot-stacked",
+                cssClass: "icon-plot-stacked",
                 Constructor: PlotStackMode
             },
             OVERLAID = {
                 key: "overlaid",
                 name: "Overlaid",
-                cssclass: "icon-plot-overlay",
+                cssClass: "icon-plot-overlay",
                 Constructor: PlotOverlayMode
             };
 
@@ -115,7 +115,7 @@ define(
 
         /**
          * Get all mode options available for each plot. Each
-         * mode contains a `name` and `cssclass` field suitable
+         * mode contains a `name` and `cssClass` field suitable
          * for display in a template.
          * @return {Array} the available modes
          */

--- a/platform/features/static-markup/bundle.js
+++ b/platform/features/static-markup/bundle.js
@@ -36,7 +36,7 @@ define([
                 {
                     "key": "static.markup",
                     "name": "Static Markup",
-                    "cssclass": "icon-pencil",
+                    "cssClass": "icon-pencil",
                     "description": "Static markup sandbox",
                     "features": [
                         "creation"

--- a/platform/features/table/bundle.js
+++ b/platform/features/table/bundle.js
@@ -66,7 +66,7 @@ define([
                 {
                     "key": "table",
                     "name": "Historical Telemetry Table",
-                    "cssclass": "icon-tabular",
+                    "cssClass": "icon-tabular",
                     "description": "A static table of all values over time for all included telemetry elements. Rows are timestamped data values for each telemetry element; columns are data fields. The number of rows is based on the range of your query. New incoming data must be manually re-queried for.",
                     "priority": 861,
                     "features": "creation",
@@ -89,7 +89,7 @@ define([
                 {
                     "key": "rttable",
                     "name": "Real-time Telemetry Table",
-                    "cssclass": "icon-tabular-realtime",
+                    "cssClass": "icon-tabular-realtime",
                     "description": "A scrolling table of latest values for all included telemetry elements. Rows are timestamped data values for each telemetry element; columns are data fields. New incoming data is automatically added to the view.",
                     "priority": 860,
                     "features": "creation",
@@ -134,7 +134,7 @@ define([
                     "name": "Historical Table",
                     "key": "table",
                     "template": historicalTableTemplate,
-                    "cssclass": "icon-tabular",
+                    "cssClass": "icon-tabular",
                     "needs": [
                         "telemetry"
                     ],
@@ -144,7 +144,7 @@ define([
                 {
                     "name": "Real-time Table",
                     "key": "rt-table",
-                    "cssclass": "icon-tabular-realtime",
+                    "cssClass": "icon-tabular-realtime",
                     "template": rtTableTemplate,
                     "needs": [
                         "telemetry"

--- a/platform/features/timeline/bundle.js
+++ b/platform/features/timeline/bundle.js
@@ -153,7 +153,7 @@ define([
                 {
                     "key": "timeline",
                     "name": "Timeline",
-                    "cssclass": "icon-timeline",
+                    "cssClass": "icon-timeline",
                     "description": "A time-oriented container that lets you enclose and organize other Timelines and Activities. The Timeline view provides both tabular and Gantt views as well as resource utilization graphing of Activities.",
                     "priority": 502,
                     "features": [
@@ -206,7 +206,7 @@ define([
                 {
                     "key": "activity",
                     "name": "Activity",
-                    "cssclass": "icon-activity",
+                    "cssClass": "icon-activity",
                     "features": [
                         "creation"
                     ],
@@ -252,7 +252,7 @@ define([
                 {
                     "key": "mode",
                     "name": "Activity Mode",
-                    "cssclass": "icon-activity-mode",
+                    "cssClass": "icon-activity-mode",
                     "features": [
                         "creation"
                     ],
@@ -292,7 +292,7 @@ define([
                 {
                     "key": "values",
                     "name": "Values",
-                    "cssclass": "icon-activity-mode",
+                    "cssClass": "icon-activity-mode",
                     "template": valuesTemplate,
                     "type": "mode",
                     "uses": [
@@ -303,7 +303,7 @@ define([
                 {
                     "key": "timeline",
                     "name": "Timeline",
-                    "cssclass": "icon-timeline",
+                    "cssClass": "icon-timeline",
                     "type": "timeline",
                     "description": "A time-oriented container that lets you enclose and organize other Timelines and Activities. The Timeline view provides both tabular and Gantt views as well as resource utilization graphing of Activities.",
                     "template": timelineTemplate,
@@ -319,12 +319,12 @@ define([
                                         "options": [
                                             {
                                                 "name": "Timeline",
-                                                "cssclass": "icon-timeline",
+                                                "cssClass": "icon-timeline",
                                                 "key": "timeline"
                                             },
                                             {
                                                 "name": "Activity",
-                                                "cssclass": "icon-activity",
+                                                "cssClass": "icon-activity",
                                                 "key": "activity"
                                             }
                                         ]
@@ -334,13 +334,13 @@ define([
                             {
                                 "items": [
                                     {
-                                        "cssclass": "icon-plot-resource",
+                                        "cssClass": "icon-plot-resource",
                                         "description": "Graph Resource Utilization",
                                         "control": "button",
                                         "method": "toggleGraph"
                                     },
                                     {
-                                        "cssclass": "icon-activity-mode",
+                                        "cssClass": "icon-activity-mode",
                                         "control": "dialog-button",
                                         "description": "Apply Activity Modes...",
                                         "title": "Apply Activity Modes",
@@ -353,7 +353,7 @@ define([
                                         "property": "modes"
                                     },
                                     {
-                                        "cssclass": "icon-chain-links",
+                                        "cssClass": "icon-chain-links",
                                         "description": "Edit Activity Link",
                                         "title": "Activity Link",
                                         "control": "dialog-button",
@@ -361,12 +361,12 @@ define([
                                             "control": "textfield",
                                             "name": "Link",
                                             "pattern": "^(ftp|https?)\\:\\/\\/\\w+(\\.\\w+)*(\\:\\d+)?(\\/\\S*)*$",
-                                            "cssclass": "l-input-lg"
+                                            "cssClass": "l-input-lg"
                                         },
                                         "property": "link"
                                     },
                                     {
-                                        "cssclass": "icon-gear",
+                                        "cssClass": "icon-gear",
                                         "description": "Edit Properties...",
                                         "control": "button",
                                         "method": "properties"
@@ -379,7 +379,7 @@ define([
                                         "method": "remove",
                                         "description": "Remove Item",
                                         "control": "button",
-                                        "cssclass": "icon-trash"
+                                        "cssClass": "icon-trash"
                                     }
                                 ]
                             }

--- a/platform/forms/res/templates/controls/button.html
+++ b/platform/forms/res/templates/controls/button.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<a class="s-button {{structure.cssclass}}"
+<a class="s-button {{structure.cssClass}}"
    ng-class="{ labeled: structure.text }"
    ng-click="structure.click()">
     <span class="title-label" ng-if="structure.text">

--- a/platform/forms/res/templates/controls/color.html
+++ b/platform/forms/res/templates/controls/color.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<div class="s-button s-menu-button menu-element t-color-palette {{structure.cssclass}}"
+<div class="s-button s-menu-button menu-element t-color-palette {{structure.cssClass}}"
     ng-controller="ClickAwayController as toggle">
 
     <span class="l-click-area" ng-click="toggle.toggle()"></span>

--- a/platform/forms/res/templates/controls/composite.html
+++ b/platform/forms/res/templates/controls/composite.html
@@ -21,7 +21,7 @@
 -->
 <span ng-controller="CompositeController as compositeCtrl">
     <ng-form name="mctFormItem" ng-repeat="item in structure.items">
-        <div class="l-composite-control l-{{item.control}} {{item.cssclass}}">
+        <div class="l-composite-control l-{{item.control}} {{item.cssClass}}">
             <mct-control key="item.control"
                          ng-model="ngModel[field]"
                          ng-required="ngRequired || compositeCtrl.isNonEmpty(ngModel[field])"

--- a/platform/forms/res/templates/controls/menu-button.html
+++ b/platform/forms/res/templates/controls/menu-button.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<div class="s-menu-button menu-element {{ structure.cssclass }}"
+<div class="s-menu-button menu-element {{ structure.cssClass }}"
      ng-controller="ClickAwayController as toggle">
 
     <span class="l-click-area" ng-click="toggle.toggle()"></span>
@@ -31,7 +31,7 @@
         <ul>
             <li ng-click="structure.click(option.key); toggle.setState(false)"
                 ng-repeat="option in structure.options"
-                class="{{ option.cssclass }}">
+                class="{{ option.cssClass }}">
                     {{option.name}}
             </li>
         </ul>

--- a/platform/forms/res/templates/controls/textarea.html
+++ b/platform/forms/res/templates/controls/textarea.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <span class='form-control shell'>
-    <span class='field control {{structure.cssclass}}'>
+    <span class='field control {{structure.cssClass}}'>
         <textarea ng-required="ngRequired"
                ng-model="ngModel[field]"
                ng-pattern="ngPattern"

--- a/platform/forms/res/templates/controls/textfield.html
+++ b/platform/forms/res/templates/controls/textfield.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <span class='form-control shell'>
-    <span class='field control {{structure.cssclass}}'>
+    <span class='field control {{structure.cssClass}}'>
         <input type="text"
                ng-required="ngRequired"
                ng-model="ngModel[field]"

--- a/platform/forms/res/templates/form.html
+++ b/platform/forms/res/templates/form.html
@@ -21,11 +21,11 @@
 -->
 <form name="mctForm" novalidate class="form l-flex-col">
     <span ng-repeat="section in structure.sections"
-          class="l-form-section l-flex-col flex-elem {{ section.cssclass }}">
+          class="l-form-section l-flex-col flex-elem {{ section.cssClass }}">
         <div class="section-header flex-elem" ng-if="section.name">
             {{section.name}}
         </div>
-        <ng-form class="form-row validates l-flex-row flex-elem {{ section.cssclass }}"
+        <ng-form class="form-row validates l-flex-row flex-elem {{ section.cssClass }}"
                  ng-class="{
                  first:$index < 1,
                  req: row.required,

--- a/platform/forms/src/controllers/DialogButtonController.js
+++ b/platform/forms/src/controllers/DialogButtonController.js
@@ -63,7 +63,7 @@ define(
 
                 // Prepare the structure for the button itself
                 self.buttonStructure = {};
-                self.buttonStructure.cssclass = structure.cssclass;
+                self.buttonStructure.cssClass = structure.cssClass;
                 self.buttonStructure.name = structure.name;
                 self.buttonStructure.description = structure.description;
                 self.buttonStructure.click = showDialog;

--- a/platform/forms/test/controllers/DialogButtonControllerSpec.js
+++ b/platform/forms/test/controllers/DialogButtonControllerSpec.js
@@ -46,7 +46,7 @@ define(
                 );
                 testStructure = {
                     name: "A Test",
-                    cssclass: "icon-T",
+                    cssClass: "icon-T",
                     description: "Test description",
                     control: "dialog-button",
                     title: "Test title",
@@ -83,7 +83,7 @@ define(
                 mockScope.$watch.mostRecentCall.args[1](testStructure);
 
                 buttonStructure = controller.getButtonStructure();
-                expect(buttonStructure.cssclass).toEqual(testStructure.cssclass);
+                expect(buttonStructure.cssClass).toEqual(testStructure.cssClass);
                 expect(buttonStructure.description).toEqual(testStructure.description);
                 expect(buttonStructure.name).toEqual(testStructure.name);
                 expect(buttonStructure.click).toEqual(jasmine.any(Function));

--- a/platform/search/res/templates/search-menu.html
+++ b/platform/search/res/templates/search-menu.html
@@ -40,7 +40,7 @@
             </li>
 
             <!-- The filter options, by type -->
-            <li class="search-menu-item {{ type.cssclass }}"
+            <li class="search-menu-item {{ type.cssClass }}"
                 ng-repeat="type in ngModel.types"
                 ng-click="ngModel.checked[type.key] = !ngModel.checked[type.key]; controller.updateOptions()">
 

--- a/platform/search/test/controllers/SearchControllerSpec.js
+++ b/platform/search/test/controllers/SearchControllerSpec.js
@@ -69,7 +69,7 @@ define([
             );
             mockSearchService.query.andReturn(mockPromise);
 
-            mockTypes = [{key: 'mock.type', name: 'Mock Type', cssclass: 'icon-object-unknown'}];
+            mockTypes = [{key: 'mock.type', name: 'Mock Type', cssClass: 'icon-object-unknown'}];
 
             mockSearchResult = jasmine.createSpyObj(
                 'searchResult',

--- a/platform/search/test/controllers/SearchMenuControllerSpec.js
+++ b/platform/search/test/controllers/SearchMenuControllerSpec.js
@@ -39,8 +39,8 @@ define(
                 );
 
                 mockTypes = [
-                    {key: 'mock.type.1', name: 'Mock Type 1', cssclass: 'icon-layout'},
-                    {key: 'mock.type.2', name: 'Mock Type 2', cssclass: 'icon-telemetry'}
+                    {key: 'mock.type.1', name: 'Mock Type 1', cssClass: 'icon-layout'},
+                    {key: 'mock.type.2', name: 'Mock Type 2', cssClass: 'icon-telemetry'}
                 ];
 
                 mockScope.ngModel = {};

--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -53,7 +53,7 @@ define([
      * A violation of limits defined for a telemetry property.
      * @typedef LimitViolation
      * @memberof {module:openmct.TelemetryAPI~}
-     * @property {string} cssclass the class (or space-separated classes) to
+     * @property {string} cssClass the class (or space-separated classes) to
      *           apply to display elements for values which violate this limit
      * @property {string} name the human-readable name for the limit violation
      */

--- a/src/api/types/Type.js
+++ b/src/api/types/Type.js
@@ -54,7 +54,7 @@ define(function () {
     Type.prototype.toLegacyDefinition = function () {
         var def = {};
         def.name = this.definition.label;
-        def.cssclass = this.definition.cssclass;
+        def.cssClass = this.definition.cssClass;
         def.description = this.definition.description;
         def.properties = this.definition.form;
 

--- a/src/api/types/TypeRegistry.js
+++ b/src/api/types/TypeRegistry.js
@@ -30,7 +30,7 @@ define(['./Type'], function (Type) {
      *           the model for new domain objects of this type
      * @property {boolean} [creatable] true if users should be allowed to
      *           create this type (default: false)
-     * @property {string} [cssclass] the CSS class to apply for icons
+     * @property {string} [cssClass] the CSS class to apply for icons
      */
 
     /**

--- a/src/ui/ViewRegistry.js
+++ b/src/ui/ViewRegistry.js
@@ -143,7 +143,7 @@ define([], function () {
      * @property {string} key a machine-readable name for this view
      * @property {string} [description] a longer-form description (typically
      *           a single sentence or short paragraph) of this kind of view
-     * @property {string} cssclass the CSS class to apply to labels for this
+     * @property {string} cssClass the CSS class to apply to labels for this
      *           view (to add icons, for instance)
      */
 


### PR DESCRIPTION
Make property name consistent with standard camelCase naming.

# Author Checklist

1. Changes address original issue? As reported here.
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y