### PR TITLE
[API] Use proper key format

### DIFF
--- a/src/api/objects/LegacyObjectAPIInterceptor.js
+++ b/src/api/objects/LegacyObjectAPIInterceptor.js
@@ -43,7 +43,7 @@ define([
         var handleLegacyMutation;
 
         var handleMutation = function (newStyleObject) {
-            var keyString = utils.makeKeyString(newStyleObject.key);
+            var keyString = utils.makeKeyString(newStyleObject.identifier);
             var oldStyleObject = this.instantiate(utils.toOldFormat(newStyleObject), keyString);
 
             // Don't trigger self

--- a/src/api/objects/MutableObject.js
+++ b/src/api/objects/MutableObject.js
@@ -41,7 +41,7 @@ define([
     }
 
     function qualifiedEventName(object, eventName) {
-        return [object.key.identifier, eventName].join(':');
+        return [object.identifier.key, eventName].join(':');
     }
 
     MutableObject.prototype.stopListening = function () {


### PR DESCRIPTION
Fixes some small bugs in the object api where it was using the incorrect key properties.

# Author Checklist

1. Changes address original issue? N/A (as reported here)
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y