### PR TITLE
[Search] Allow navigation from results

### DIFF
--- a/platform/search/res/templates/search-item.html
+++ b/platform/search/res/templates/search-item.html
@@ -18,14 +18,14 @@
  licenses. See the Open Source Licenses file (LICENSES.md) included with
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
---> 
+-->
 
 <div class="search-result-item l-flex-row flex-elem grows"
      ng-class="{selected: ngModel.selectedObject.getId() === domainObject.getId()}">
     <mct-representation key="'label'"
                         mct-object="domainObject"
                         ng-model="ngModel"
-                        ng-click="ngModel.selectedObject = domainObject"
+                        ng-click="ngModel.allowSelection(domainObject) && ngModel.onSelection(domainObject)"
                         class="l-flex-row flex-elem grows">
     </mct-representation>
 </div>


### PR DESCRIPTION
Fix search item so that navigation occurs after clicking on
a search result, while still properly preventing navigation
when required.

Related to #1366

# Author Checklist

1. Changes address original issue? (as reported here)
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y