### PR TITLE
[Copy] Diff between user cancellation and failure

### DIFF
--- a/platform/entanglement/src/actions/AbstractComposeAction.js
+++ b/platform/entanglement/src/actions/AbstractComposeAction.js
@@ -141,6 +141,8 @@ define(
                 currentParent
             ).then(function (newParentObj) {
                 return composeService.perform(object, newParentObj);
+            }, function () {
+                return Promise.reject({ message: "cancelled" });
             });
         };
 

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -117,6 +117,10 @@ define(
             }
 
             function error(errorDetails) {
+                if (errorDetails && (errorDetails.message === "cancelled")) {
+                    return;
+                }
+
                 var errorDialog,
                     errorMessage = {
                     title: "Error copying objects.",

--- a/platform/entanglement/test/actions/AbstractComposeActionSpec.js
+++ b/platform/entanglement/test/actions/AbstractComposeActionSpec.js
@@ -157,9 +157,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("copies object to selected location", function () {

--- a/platform/entanglement/test/actions/CopyActionSpec.js
+++ b/platform/entanglement/test/actions/CopyActionSpec.js
@@ -180,9 +180,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("copies object to selected location", function () {

--- a/platform/entanglement/test/actions/LinkActionSpec.js
+++ b/platform/entanglement/test/actions/LinkActionSpec.js
@@ -133,9 +133,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("links object to selected location", function () {

--- a/platform/entanglement/test/actions/MoveActionSpec.js
+++ b/platform/entanglement/test/actions/MoveActionSpec.js
@@ -133,9 +133,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("moves object to selected location", function () {


### PR DESCRIPTION
This fixes #1456 by making `AbstractComposeAction` discern between location dialog cancellation and compose failure. Makes `CopyAction` not attempt to treat cancellations as errors.

## Author Checklist

- Changes address original issue? Y
- Unit tests included and/or updated with changes? Y
- Command line build passes? Y
- Changes have been smoke-tested? Y