### PR TITLE
[Tables] Subscribe to parent if a telemetry object, or children, but not both

### DIFF
--- a/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
@@ -161,7 +161,7 @@ define(
                 });
             });
 
-            describe ('Subscribes to new data', function () {
+            describe ('when getting telemetry', function () {
                 var mockComposition,
                     mockTelemetryObject,
                     mockChildren,
@@ -173,9 +173,7 @@ define(
                         "load"
                     ]);
 
-                    mockTelemetryObject = jasmine.createSpyObj("mockTelemetryObject", [
-                        "something"
-                    ]);
+                    mockTelemetryObject = {};
                     mockTelemetryObject.identifier = {
                         key: "mockTelemetryObject"
                     };
@@ -192,22 +190,12 @@ define(
                     });
 
                     done = false;
-                    controller.getData().then(function () {
-                        done = true;
-                    });
-                });
-
-                it('fetches historical data', function () {
-                    waitsFor(function () {
-                        return done;
-                    }, "getData to return", 100);
-
-                    runs(function () {
-                        expect(mockTelemetryAPI.request).toHaveBeenCalledWith(mockTelemetryObject, jasmine.any(Object));
-                    });
                 });
 
                 it('fetches historical data for the time period specified by the conductor bounds', function () {
+                    controller.getData().then(function () {
+                        done = true;
+                    });
                     waitsFor(function () {
                         return done;
                     }, "getData to return", 100);
@@ -217,17 +205,11 @@ define(
                     });
                 });
 
-                it('subscribes to new data', function () {
-                    waitsFor(function () {
-                        return done;
-                    }, "getData to return", 100);
-
-                    runs(function () {
-                        expect(mockTelemetryAPI.subscribe).toHaveBeenCalledWith(mockTelemetryObject, jasmine.any(Function), {});
+                it('unsubscribes on view destruction', function () {
+                    controller.getData().then(function () {
+                        done = true;
                     });
 
-                });
-                it('and unsubscribes on view destruction', function () {
                     waitsFor(function () {
                         return done;
                     }, "getData to return", 100);
@@ -237,6 +219,87 @@ define(
                         destroy();
 
                         expect(unsubscribe).toHaveBeenCalled();
+                    });
+                });
+                it('fetches historical data for the time period specified by the conductor bounds', function () {
+                    controller.getData().then(function () {
+                        done = true;
+                    });
+                    waitsFor(function () {
+                        return done;
+                    }, "getData to return", 100);
+
+                    runs(function () {
+                        expect(mockTelemetryAPI.request).toHaveBeenCalledWith(mockTelemetryObject, mockBounds);
+                    });
+                });
+
+                it('fetches data for, and subscribes to parent object if it is a telemetry object', function () {
+                    controller.getData().then(function () {
+                        done = true;
+                    });
+                    waitsFor(function () {
+                        return done;
+                    }, "getData to return", 100);
+
+                    runs(function () {
+                        expect(mockTelemetryAPI.subscribe).toHaveBeenCalledWith(mockTelemetryObject, jasmine.any(Function), {});
+                        expect(mockTelemetryAPI.request).toHaveBeenCalledWith(mockTelemetryObject, jasmine.any(Object));
+                    });
+                });
+                it('fetches data for, and subscribes to parent object if it is a telemetry object', function () {
+                    controller.getData().then(function () {
+                        done = true;
+                    });
+                    waitsFor(function () {
+                        return done;
+                    }, "getData to return", 100);
+
+                    runs(function () {
+                        expect(mockTelemetryAPI.subscribe).toHaveBeenCalledWith(mockTelemetryObject, jasmine.any(Function), {});
+                        expect(mockTelemetryAPI.request).toHaveBeenCalledWith(mockTelemetryObject, jasmine.any(Object));
+                    });
+                });
+
+                it('fetches data for, and subscribes to any composees that are telemetry objects if parent is not', function () {
+                    mockChildren = [
+                        {name: "child 1"}
+                    ];
+                    var mockTelemetryChildren = [
+                        {name: "child 2"},
+                        {name: "child 3"},
+                        {name: "child 4"}
+                    ];
+                    mockChildren = mockChildren.concat(mockTelemetryChildren);
+                    mockComposition.load.andReturn(Promise.resolve(mockChildren));
+
+                    mockTelemetryAPI.canProvideTelemetry.andCallFake(function (object) {
+                        if (object === mockTelemetryObject) {
+                            return false;
+                        } else {
+                            return mockTelemetryChildren.indexOf(object) !== -1;
+                        }
+                    });
+
+                    controller.getData().then(function () {
+                        done = true;
+                    });
+
+                    waitsFor(function () {
+                        return done;
+                    }, "getData to return", 100);
+
+                    runs(function () {
+                        mockTelemetryChildren.forEach(function (child) {
+                            expect(mockTelemetryAPI.subscribe).toHaveBeenCalledWith(child, jasmine.any(Function), {});
+                        });
+
+                        mockTelemetryChildren.forEach(function (child) {
+                            expect(mockTelemetryAPI.request).toHaveBeenCalledWith(child, jasmine.any(Object));
+                        });
+
+                        expect(mockTelemetryAPI.subscribe).not.toHaveBeenCalledWith(mockChildren[0], jasmine.any(Function), {});
+                        expect(mockTelemetryAPI.subscribe).not.toHaveBeenCalledWith(mockTelemetryObject[0], jasmine.any(Function), {});
                     });
                 });
             });


### PR DESCRIPTION
* Replaced `getDomainObjects()` with a member function called `getTelemetryObjects()`. Moved `filterForTelemetry` that encapsulates the logic for deciding what to subscribe to / request telemetry for.
* Renamed `newObject` to `domainObject`, 
* Added some tests for specific issue to catch regressions.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y
* Command line build passes? Y
* Changes have been smoke-tested? Y