### PR TITLE
Save As clears transaction while undirtying

### DIFF
--- a/platform/core/bundle.js
+++ b/platform/core/bundle.js
@@ -365,7 +365,7 @@ define([
             "runs": [
                 {
                     "implementation": TransactingMutationListener,
-                    "depends": ["topic", "transactionService", "cacheService"]
+                    "depends": ["topic", "transactionService", "cacheService", "transactionManager"]
                 }
             ],
             "constants": [

--- a/platform/core/bundle.js
+++ b/platform/core/bundle.js
@@ -365,7 +365,7 @@ define([
             "runs": [
                 {
                     "implementation": TransactingMutationListener,
-                    "depends": ["topic", "transactionService", "cacheService", "transactionManager"]
+                    "depends": ["topic", "transactionService", "cacheService"]
                 }
             ],
             "constants": [

--- a/platform/core/src/runs/TransactingMutationListener.js
+++ b/platform/core/src/runs/TransactingMutationListener.js
@@ -32,7 +32,8 @@ define([], function () {
     function TransactingMutationListener(
         topic,
         transactionService,
-        cacheService
+        cacheService,
+        transactionManager
     ) {
 
         function hasChanged(domainObject) {
@@ -52,7 +53,8 @@ define([], function () {
                     transactionService.startTransaction();
                 }
 
-                transactionService.addToTransaction(
+                transactionManager.addToTransaction(
+                    domainObject.getId(),
                     persistence.persist.bind(persistence),
                     persistence.refresh.bind(persistence)
                 );

--- a/platform/core/src/runs/TransactingMutationListener.js
+++ b/platform/core/src/runs/TransactingMutationListener.js
@@ -32,8 +32,7 @@ define([], function () {
     function TransactingMutationListener(
         topic,
         transactionService,
-        cacheService,
-        transactionManager
+        cacheService
     ) {
 
         function hasChanged(domainObject) {
@@ -53,11 +52,7 @@ define([], function () {
                     transactionService.startTransaction();
                 }
 
-                transactionManager.addToTransaction(
-                    domainObject.getId(),
-                    persistence.persist.bind(persistence),
-                    persistence.refresh.bind(persistence)
-                );
+                persistence.persist();
 
                 if (!wasActive) {
                     transactionService.commit();

--- a/platform/core/test/runs/TransactingMutationListenerSpec.js
+++ b/platform/core/test/runs/TransactingMutationListenerSpec.js
@@ -48,10 +48,6 @@ define(
                         'startTransaction',
                         'commit'
                     ]);
-                mockTransactionManager =
-                    jasmine.createSpyObj('transactionManager', [
-                        'addToTransaction'
-                    ]);
                 mockDomainObject = jasmine.createSpyObj(
                     'domainObject',
                     ['getId', 'getCapability', 'getModel']
@@ -62,12 +58,14 @@ define(
                 );
 
                 mockTopic.and.callFake(function (t) {
-                    return (t === 'mutation') && mockMutationTopic;
+                    expect(t).toBe('mutation');
+                    return mockMutationTopic;
                 });
 
                 mockDomainObject.getId.and.returnValue('mockId');
                 mockDomainObject.getCapability.and.callFake(function (c) {
-                    return (c === 'persistence') && mockPersistence;
+                    expect(c).toBe('persistence');
+                    return mockPersistence;
                 });
                 mockModel = {};
                 mockDomainObject.getModel.and.returnValue(mockModel);
@@ -77,8 +75,7 @@ define(
                 return new TransactingMutationListener(
                     mockTopic,
                     mockTransactionService,
-                    mockCacheService,
-                    mockTransactionManager
+                    mockCacheService
                 );
             });
 
@@ -114,13 +111,8 @@ define(
                             ).toHaveBeenCalled();
                         });
 
-                        it("adds to the active transaction", function () {
-                            expect(mockTransactionManager.addToTransaction)
-                                .toHaveBeenCalledWith(
-                                'mockId',
-                                jasmine.any(Function),
-                                jasmine.any(Function)
-                            );
+                        it("calls persist", function () {
+                            expect(mockPersistence.persist).toHaveBeenCalled();
                         });
 
                         it(innerVerb + " immediately commit", function () {

--- a/platform/core/test/runs/TransactingMutationListenerSpec.js
+++ b/platform/core/test/runs/TransactingMutationListenerSpec.js
@@ -29,7 +29,6 @@ define(
                 mockMutationTopic,
                 mockCacheService,
                 mockTransactionService,
-                mockTransactionManager,
                 mockDomainObject,
                 mockModel,
                 mockPersistence;


### PR DESCRIPTION
This is the fix for #1468.  The mutationTransactionListener needs to be using the transactionManager for addToTransaction so that the persistence refresh properly clears transactions for any temporary objects.  Prevents openmct creating extraneous objects on the back end.

TODO:
* [x] Update tests


