### PR TITLE
Open1280

### DIFF
--- a/platform/commonUI/browse/bundle.js
+++ b/platform/commonUI/browse/bundle.js
@@ -40,6 +40,7 @@ define([
     "text!./res/templates/back-arrow.html",
     "text!./res/templates/items/items.html",
     "text!./res/templates/browse/object-properties.html",
+    "text!./res/templates/browse/object-notes.html",
     "text!./res/templates/browse/inspector-region.html",
     'legacyRegistry'
 ], function (
@@ -62,6 +63,7 @@ define([
     backArrowTemplate,
     itemsTemplate,
     objectPropertiesTemplate,
+    objectNotesTemplate,
     inspectorRegionTemplate,
     legacyRegistry
 ) {
@@ -191,6 +193,10 @@ define([
                     "template": objectPropertiesTemplate
                 },
                 {
+                    "key": "object-notes",
+                    "template": objectNotesTemplate
+                },
+                {
                     "key": "inspector-region",
                     "template": inspectorRegionTemplate
                 }
@@ -226,7 +232,7 @@ define([
                         "$window"
                     ],
                     "group": "windowing",
-                    "cssClass": "icon-new-window",
+                    "cssclass": "icon-new-window",
                     "priority": "preferred"
                 },
                 {
@@ -241,7 +247,7 @@ define([
                 {
                     "key": "items",
                     "name": "Items",
-                    "cssClass": "icon-thumbs-strip",
+                    "cssclass": "icon-thumbs-strip",
                     "description": "Grid of available items",
                     "template": itemsTemplate,
                     "uses": [

--- a/platform/commonUI/browse/res/templates/browse/object-notes.html
+++ b/platform/commonUI/browse/res/templates/browse/object-notes.html
@@ -1,0 +1,33 @@
+<!--
+ Open MCT, Copyright (c) 2014-2016, United States Government
+ as represented by the Administrator of the National Aeronautics and Space
+ Administration. All rights reserved.
+
+ Open MCT is licensed under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+
+ Open MCT includes source code licensed under additional open source
+ licenses. See the Open Source Licenses file (LICENSES.md) included with
+ this source code distribution or the Licensing information page available
+ at runtime from the About dialog for additional information.
+-->
+<div ng-controller="ObjectInspectorController as controller">
+    <ul class="flex-elem grows l-inspector-part">
+        <li>
+            <em class="t-inspector-part-header" title="Notes.">Notes</em>
+            <div class="value"
+                 ng-repeat="data in metadata"
+                 ng-if="data.name === 'Notes'">
+                {{ data.value }}
+            </div>
+        </li>
+    </ul>
+</div>

--- a/platform/commonUI/browse/res/templates/browse/object-properties.html
+++ b/platform/commonUI/browse/res/templates/browse/object-properties.html
@@ -25,7 +25,8 @@
             <em class="t-inspector-part-header">Properties</em>
             <div class="inspector-properties"
                  ng-repeat="data in metadata"
-                 ng-class="{ first:$index === 0 }">
+                 ng-class="{ first:$index === 0 }"
+                 ng-if="data.name !== 'Notes'">
                 <div class="label">{{ data.name }}</div>
                 <div class="value">{{ data.value }}</div>
             </div>

--- a/platform/commonUI/browse/src/InspectorRegion.js
+++ b/platform/commonUI/browse/src/InspectorRegion.js
@@ -59,7 +59,25 @@ define(
                     key: 'object-properties'
                 }
             };
+            var notesRegion = {
+                name: 'notes',
+                title: 'Notes Region',
+                modes: ['browse'],
+                content: {
+                    key: 'object-notes'
+                }
+            };
+            var editNotesRegion = {
+                name: 'editNotes',
+                title: 'Edit Notes Region',
+                modes: ['edit'],
+                content: {
+                    key: 'edit-notes'
+                }
+            };
             this.addRegion(new Region(metadataRegion), 0);
+            this.addRegion(new Region(notesRegion), 1);
+            this.addRegion(new Region(editNotesRegion), 1);
         };
 
         return InspectorRegion;

--- a/platform/commonUI/browse/test/InspectorRegionSpec.js
+++ b/platform/commonUI/browse/test/InspectorRegionSpec.js
@@ -35,7 +35,7 @@ define(
             });
 
             it("creates default region parts", function () {
-                expect(inspectorRegion.regions.length).toBe(1);
+                expect(inspectorRegion.regions.length).toBe(3);
             });
 
         });

--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -23,6 +23,7 @@
 define([
     "./src/controllers/EditActionController",
     "./src/controllers/EditPanesController",
+    "./src/controllers/EditNotesController",
     "./src/controllers/ElementsController",
     "./src/controllers/EditObjectController",
     "./src/actions/EditAndComposeAction",
@@ -41,6 +42,7 @@ define([
     "./src/representers/EditToolbarRepresenter",
     "./src/capabilities/EditorCapability",
     "./src/capabilities/TransactionCapabilityDecorator",
+    "./src/services/EditNotesService",
     "./src/services/TransactionManager",
     "./src/services/TransactionService",
     "./src/creation/CreateMenuController",
@@ -55,12 +57,14 @@ define([
     "text!./res/templates/library.html",
     "text!./res/templates/edit-object.html",
     "text!./res/templates/edit-action-buttons.html",
+    "text!./res/templates/edit-notes.html",
     "text!./res/templates/elements.html",
     "text!./res/templates/topbar-edit.html",
     'legacyRegistry'
 ], function (
     EditActionController,
     EditPanesController,
+    EditNotesController,
     ElementsController,
     EditObjectController,
     EditAndComposeAction,
@@ -79,6 +83,7 @@ define([
     EditToolbarRepresenter,
     EditorCapability,
     TransactionCapabilityDecorator,
+    EditNotesService,
     TransactionManager,
     TransactionService,
     CreateMenuController,
@@ -93,6 +98,7 @@ define([
     libraryTemplate,
     editObjectTemplate,
     editActionButtonsTemplate,
+    editNotesTemplate,
     elementsTemplate,
     topbarEditTemplate,
     legacyRegistry
@@ -113,6 +119,14 @@ define([
                     "implementation": EditPanesController,
                     "depends": [
                         "$scope"
+                    ]
+                },
+                {
+                    "key": "EditNotesController",
+                    "implementation": EditNotesController,
+                    "depends": [
+                        "$scope",
+                        "editNotesService"
                     ]
                 },
                 {
@@ -199,7 +213,8 @@ define([
                     "description": "Save changes made to these objects.",
                     "depends": [
                         "dialogService",
-                        "notificationService"
+                        "notificationService",
+                        "editNotesService"
                     ]
                 },
                 {
@@ -211,7 +226,8 @@ define([
                     "description": "Save changes made to these objects.",
                     "depends": [
                         "dialogService",
-                        "notificationService"
+                        "notificationService",
+                        "editNotesService"
                     ]
                 },
                 {
@@ -288,6 +304,10 @@ define([
                     "uses": [
                         "action"
                     ]
+                },
+                {
+                    "key": "edit-notes",
+                    "template": editNotesTemplate
                 },
                 {
                     "key": "edit-elements",
@@ -415,6 +435,10 @@ define([
                     "depends": [
                         "transactionService"
                     ]
+                },
+                {
+                    "key": "editNotesService",
+                    "implementation": EditNotesService
                 }
             ]
         }

--- a/platform/commonUI/edit/res/templates/edit-notes.html
+++ b/platform/commonUI/edit/res/templates/edit-notes.html
@@ -1,0 +1,27 @@
+<!--
+ Open MCT, Copyright (c) 2014-2016, United States Government
+ as represented by the Administrator of the National Aeronautics and Space
+ Administration. All rights reserved.
+
+ Open MCT is licensed under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+
+ Open MCT includes source code licensed under additional open source
+ licenses. See the Open Source Licenses file (LICENSES.md) included with
+ this source code distribution or the Licensing information page available
+ at runtime from the About dialog for additional information.
+-->
+<div ng-controller="EditNotesController" class="flex-elem l-flex-col holder grows">
+    <em class="t-inspector-part-header" title="Notes.">Notes</em>
+    <span class="field control l-textarea-sm">
+        <textarea ng-model="notes"></textarea>
+    </span>
+</div>

--- a/platform/commonUI/edit/src/actions/SaveAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAction.js
@@ -34,11 +34,13 @@ define(
         function SaveAction(
             dialogService,
             notificationService,
+            editNotesService,
             context
         ) {
             this.domainObject = (context || {}).domainObject;
             this.dialogService = dialogService;
             this.notificationService = notificationService;
+            this.editNotesService = editNotesService;
         }
 
         /**
@@ -58,6 +60,8 @@ define(
             // used to insulate underlying objects from changes made
             // during editing.
             function doSave() {
+                //First save the notes
+                self.editNotesService.saveNotes(domainObject);
                 return domainObject.getCapability("editor").save();
             }
 

--- a/platform/commonUI/edit/src/actions/SaveAndStopEditingAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAndStopEditingAction.js
@@ -34,12 +34,14 @@ define(
         function SaveAndStopEditingAction(
             dialogService,
             notificationService,
+            editNotesService,
             context
         ) {
             this.context = context;
             this.domainObject = (context || {}).domainObject;
             this.dialogService = dialogService;
             this.notificationService = notificationService;
+            this.editNotesService = editNotesService;
         }
 
         /**
@@ -51,7 +53,7 @@ define(
          */
         SaveAndStopEditingAction.prototype.perform = function () {
             var domainObject = this.domainObject,
-                saveAction = new SaveAction(this.dialogService, this.notificationService, this.context);
+                saveAction = new SaveAction(this.dialogService, this.notificationService, this.editNotesService, this.context);
 
             function closeEditor() {
                 return domainObject.getCapability("editor").finish();

--- a/platform/commonUI/edit/src/controllers/EditNotesController.js
+++ b/platform/commonUI/edit/src/controllers/EditNotesController.js
@@ -1,0 +1,52 @@
+/**
+ * Created by EvansDesktop on 2/15/2017.
+ */
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    [],
+    function () {
+
+        /**
+         * The EditNotesController prepares the edit-notes view for display
+         * @constructor
+         */
+        function EditNotesController($scope) {
+            this.properties = $scope.domainObject.useCapability('metadata');
+
+            function locateNotesValueInDomainObject(properties) {
+                var notesValue;
+                properties.forEach(function(property){
+                    if (property.name === 'Notes'){
+                        notesValue = property.value;
+                    }
+                });
+                return notesValue;
+            }
+
+            $scope.notes = locateNotesValueInDomainObject(this.properties);
+        }
+
+        return EditNotesController;
+    }
+);

--- a/platform/commonUI/edit/src/controllers/EditNotesController.js
+++ b/platform/commonUI/edit/src/controllers/EditNotesController.js
@@ -29,9 +29,11 @@ define(
 
         /**
          * The EditNotesController prepares the edit-notes view for display
+         * and keeps the editNotesService updated with user input.
          * @constructor
          */
-        function EditNotesController($scope) {
+        function EditNotesController($scope, editNotesService) {
+            this.editNotesService = editNotesService;
             this.properties = $scope.domainObject.useCapability('metadata');
 
             function locateNotesValueInDomainObject(properties) {
@@ -44,7 +46,13 @@ define(
                 return notesValue;
             }
 
+            function sendNotesToController(value){
+                editNotesService.updateNotesFromController(value);
+            }
+
             $scope.notes = locateNotesValueInDomainObject(this.properties);
+
+            $scope.$watch('notes', sendNotesToController);
         }
 
         return EditNotesController;

--- a/platform/commonUI/edit/src/services/EditNotesService.js
+++ b/platform/commonUI/edit/src/services/EditNotesService.js
@@ -1,0 +1,79 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([],
+    function () {
+        /**
+         * The EditNotesService is responsible for handling communication
+         * between SaveAction and the EditNotesController as well as persisting
+         * the notes when a SaveAction is called
+         *
+         * @memberof platform/commonUI/edit
+         * @constructor
+         */
+        function EditNotesService() {
+        }
+
+        /**
+         * Keeps the EditNotesService in sync with the EditNotesController
+         * @param (string) value passed in by the EditNotesController
+         */
+        EditNotesService.prototype.updateNotesFromController = function (value) {
+            this.notes = value;
+        };
+
+        /**
+         * Updates the notes property in a domain object model based on
+         * a value given by the edit notes controller.
+         * @param (DomainObject) The active domainObject that we want to
+         *         mutate
+         */
+        EditNotesService.prototype.saveNotes = function (domainObject) {
+            if (this.notes != null) {
+                var type = domainObject.getCapability('type'),
+                    properties = type.getProperties(),
+                    notes = this.notes;
+
+                function getNotesIndex() {
+                    var notesIndex;
+                    properties.forEach(function (property, index) {
+                        if (property.getDefinition().key === 'notes') {
+                            notesIndex = index;
+                        }
+                    });
+
+                    return notesIndex;
+                }
+
+                var notesIndex = getNotesIndex();
+
+                // Make sure the object has a notes property before mutation
+                if (notesIndex != null)
+                    return domainObject.useCapability('mutation', function (model) {
+                        properties[notesIndex].setValue(model, notes);
+                    });
+            }
+        };
+
+        return EditNotesService;
+    }
+);

--- a/platform/commonUI/edit/test/actions/SaveActionSpec.js
+++ b/platform/commonUI/edit/test/actions/SaveActionSpec.js
@@ -31,6 +31,7 @@ define(
                 actionContext,
                 mockDialogService,
                 mockNotificationService,
+                mockEditNotesService,
                 mockActionCapability,
                 capabilities = {},
                 action;
@@ -81,6 +82,11 @@ define(
                     ["info", "error"]
                 );
 
+                mockEditNotesService = jasmine.createSpyObj(
+                    "editNotesService",
+                    ["saveNotes"]
+                );
+
                 mockDomainObject.hasCapability.andReturn(true);
                 mockDomainObject.getCapability.andCallFake(function (capability) {
                     return capabilities[capability];
@@ -89,7 +95,7 @@ define(
                 mockEditorCapability.save.andReturn(mockPromise(true));
                 mockEditorCapability.isEditContextRoot.andReturn(true);
 
-                action = new SaveAction(mockDialogService, mockNotificationService, actionContext);
+                action = new SaveAction(mockDialogService, mockNotificationService, mockEditNotesService, actionContext);
             });
 
             it("only applies to domain object with an editor capability", function () {

--- a/platform/commonUI/edit/test/actions/SaveAndStopEditingActionSpec.js
+++ b/platform/commonUI/edit/test/actions/SaveAndStopEditingActionSpec.js
@@ -37,6 +37,7 @@ define(
                 actionContext,
                 dialogService,
                 notificationService,
+                editNotesService,
                 mockActionCapability,
                 capabilities = {},
                 action;
@@ -86,6 +87,11 @@ define(
                     ["info", "error"]
                 );
 
+                editNotesService = jasmine.createSpyObj(
+                    "editNotesService",
+                    ["saveNotes"]
+                );
+
                 mockDomainObject.hasCapability.andReturn(true);
                 mockDomainObject.getCapability.andCallFake(function (capability) {
                     return capabilities[capability];
@@ -94,7 +100,7 @@ define(
                 mockEditorCapability.save.andReturn(mockPromise(true));
                 mockEditorCapability.isEditContextRoot.andReturn(true);
 
-                action = new SaveAndStopEditingAction(dialogService, notificationService, actionContext);
+                action = new SaveAndStopEditingAction(dialogService, notificationService, editNotesService, actionContext);
             });
 
 

--- a/platform/commonUI/edit/test/controllers/EditNotesControllerSpec.js
+++ b/platform/commonUI/edit/test/controllers/EditNotesControllerSpec.js
@@ -1,0 +1,78 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    ["../../src/controllers/EditNotesController"],
+    function (EditNotesController) {
+        describe("The Edit Notes controller", function () {
+            var mockScope,
+                mockDomainObject,
+                mockEditNotesService,
+                controller;
+
+            // Utility function; look for a $watch on scope and fire it
+            function fireWatch(expr, value) {
+                mockScope.$watch.calls.forEach(function (call) {
+                    if (call.args[0] === expr) {
+                        call.args[1](value);
+                    }
+                });
+            }
+
+            beforeEach(function () {
+                mockScope = jasmine.createSpyObj(
+                    "$scope",
+                    ["$watch"]
+                );
+
+                mockDomainObject = jasmine.createSpyObj(
+                    "domainObject",
+                    ["useCapability"]
+                );
+
+                mockEditNotesService = jasmine.createSpyObj(
+                    "editNotesService",
+                    ["updateNotesFromController"]
+                );
+
+                mockScope.domainObject = mockDomainObject;
+                mockDomainObject.useCapability.andReturn([{
+                    name: "Notes",
+                    value: "Initial Notes"
+                }]);
+
+                controller = new EditNotesController(
+                    mockScope,
+                    mockEditNotesService
+                );
+            });
+
+            it("keeps the edit notes service updated on the user input", function () {
+                var newNotes = "Updated Notes";
+                mockScope.notes = newNotes;
+                fireWatch("notes", newNotes);
+                expect(mockEditNotesService.updateNotesFromController).toHaveBeenCalledWith(newNotes);
+            });
+
+        });
+    }
+);

--- a/platform/commonUI/edit/test/services/EditNotesServiceSpec.js
+++ b/platform/commonUI/edit/test/services/EditNotesServiceSpec.js
@@ -1,0 +1,100 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2016, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    ['../../src/services/EditNotesService'],
+    function (EditNotesService) {
+        describe("The Edit Notes Service", function () {
+            var editNotesService,
+                mockProperties,
+                mockDomainObject,
+                mockType;
+
+            beforeEach(function () {
+                mockDomainObject = jasmine.createSpyObj(
+                    'domainObject',
+                    [
+                        'getCapability',
+                        'useCapability'
+                    ]
+                );
+
+                mockType = jasmine.createSpyObj(
+                    'type',
+                    ['getProperties']
+                );
+
+                mockDomainObject.getCapability.andReturn(mockType);
+                editNotesService = new EditNotesService();
+            });
+
+            describe("With a valid domain object", function () {
+
+                beforeEach(function() {
+                    mockProperties = [
+                        {key: "x", value: "xyz"},
+                        {key: "y", value: "xyz"},
+                        {key: "notes", value: "xyz"}
+                    ].map(function (k) {
+                            return {
+                                getDefinition: function () {
+                                    return k;
+                                }
+                            };
+                        });
+
+                    mockType.getProperties.andReturn(mockProperties);
+                });
+
+                it("mutates an object when saved", function () {
+                    var updatedNotes = "updated notes";
+                    editNotesService.updateNotesFromController(updatedNotes);
+                    editNotesService.saveNotes(mockDomainObject);
+                    expect(mockDomainObject.useCapability).toHaveBeenCalled();
+                });
+            });
+
+            describe("With an invalid domain object", function () {
+                beforeEach(function() {
+                    mockProperties = [
+                        {key: "x", value: "xyz"},
+                        {key: "y", value: "xyz"}
+                    ].map(function (k) {
+                            return {
+                                getDefinition: function () {
+                                    return k.key;
+                                }
+                            };
+                        });
+
+                    mockType.getProperties.andReturn(mockProperties);
+                });
+
+                it("does not perform a mutation if the domainObject has no notes field", function () {
+                    var updatedNotes = "updated notes";
+                    editNotesService.updateNotesFromController(updatedNotes);
+                    editNotesService.saveNotes(mockDomainObject);
+                    expect(mockDomainObject.useCapability).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });


### PR DESCRIPTION
Here is my initial pull request for this issue.  The main problem I had to solve was how to save the notes property when SaveAction.perform() is called.  It was a little tricky because SaveAction originally has nothing to do with saving the properties in the domain object.

I idea is to remove the notes property from the rest of the properties to have it stand on its own.  After that I had to make a browse and editable template for the notes.  After that I created a generic service to allow SaveAction to communicate with the new editable notes region in order to make the save.

If there is something a bit off with the methodology let me know and I can redo it.  Most of the time spent was just learning the architecture and learning angular/git/unit-testing.
 
## Author Checklist
- [x] Changes address original issue? 
- [x] Unit tests included and/or updated with changes? 
- [x] Command line build passes? 
- [x] Changes have been smoke-tested?

As a note, I just learned about rebase in order to clean up my commits.  Hopefully they still seem logical.  Thanks!