### PR TITLE
[Edit] Only persist on mutation if model has actually changed locally

### DIFF
--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -148,13 +148,19 @@ define(
          */
         PersistenceCapability.prototype.refresh = function () {
             var domainObject = this.domainObject;
+            var $q = this.$q;
 
             // Update a domain object's model upon refresh
             function updateModel(model) {
-                var modified = model.modified;
-                return domainObject.useCapability("mutation", function () {
-                    return model;
-                }, modified);
+                if (model === undefined) {
+                    //Get failed, reject promise
+                    return $q.reject('Got empty object model');
+                } else {
+                    var modified = model.modified;
+                    return domainObject.useCapability("mutation", function () {
+                        return model;
+                    }, modified);
+                }
             }
 
             if (domainObject.getModel().persisted === undefined) {


### PR DESCRIPTION
Prevents unnecessary persistence after model refresh.

Also rejects calls to `PersistenceCapability.refresh` if no model is returned.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y
* Command line build passes? Y
* Changes have been smoke-tested? Y