### PR TITLE
[API] Removed API classes from Open MCT prototype. Fixes #1293

### DIFF
--- a/src/MCT.js
+++ b/src/MCT.js
@@ -194,15 +194,13 @@ define([
          */
         this.telemetry = new api.TelemetryAPI(this);
 
-        this.TimeConductor = this.conductor; // compatibility for prototype
+        this.Dialog = api.Dialog;
+
         this.on('navigation', this.selection.clear.bind(this.selection));
     }
 
     MCT.prototype = Object.create(EventEmitter.prototype);
 
-    Object.keys(api).forEach(function (k) {
-        MCT.prototype[k] = api[k];
-    });
     MCT.prototype.MCT = MCT;
 
     MCT.prototype.legacyExtension = function (category, extension) {


### PR DESCRIPTION
Removed exposed API classes from the public API. Question mark about whether we should be exposing API that doesn't work / isn't final right now though?