### PR TITLE
[Time Conductor] Removed caching of UTC Time System defaults

### DIFF
--- a/platform/features/conductor/utcTimeSystem/src/UTCTimeSystem.js
+++ b/platform/features/conductor/utcTimeSystem/src/UTCTimeSystem.js
@@ -48,7 +48,6 @@ define([
 
         this.fmts = ['utc'];
         this.sources = [new LocalClock($timeout, DEFAULT_PERIOD)];
-        this.defaultValues = undefined;
     }
 
     UTCTimeSystem.prototype = Object.create(TimeSystem.prototype);
@@ -65,25 +64,18 @@ define([
         return this.sources;
     };
 
-    UTCTimeSystem.prototype.defaults = function (defaults) {
-        if (arguments.length > 0) {
-            this.defaultValues = defaults;
-        }
+    UTCTimeSystem.prototype.defaults = function () {
+        var now = Math.ceil(Date.now() / 1000) * 1000;
+        var ONE_MINUTE = 60 * 1 * 1000;
+        var FIFTY_YEARS = 50 * 365 * 24 * 60 * 60 * 1000;
 
-        if (this.defaultValues === undefined) {
-            var now = Math.ceil(Date.now() / 1000) * 1000;
-            var ONE_MINUTE = 60 * 1 * 1000;
-            var FIFTY_YEARS = 50 * 365 * 24 * 60 * 60 * 1000;
-
-            this.defaultValues = {
-                key: 'utc-default',
-                name: 'UTC time system defaults',
-                deltas: {start: FIFTEEN_MINUTES, end: 0},
-                bounds: {start: now - FIFTEEN_MINUTES, end: now},
-                zoom: {min: FIFTY_YEARS, max: ONE_MINUTE}
-            };
-        }
-        return this.defaultValues;
+        return {
+            key: 'utc-default',
+            name: 'UTC time system defaults',
+            deltas: {start: FIFTEEN_MINUTES, end: 0},
+            bounds: {start: now - FIFTEEN_MINUTES, end: now},
+            zoom: {min: FIFTY_YEARS, max: ONE_MINUTE}
+        };
     };
 
     return UTCTimeSystem;

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -68,14 +68,6 @@ define([
                 return ts.metadata.key === options.defaultTimeSystem;
             });
             if (timeSystem !== undefined) {
-                defaults = timeSystem.defaults();
-
-                if (options.defaultTimespan !== undefined) {
-                    defaults.deltas.start = options.defaultTimespan;
-                    defaults.bounds.start = defaults.bounds.end - options.defaultTimespan;
-                    timeSystem.defaults(defaults);
-                }
-
                 openmct.conductor.timeSystem(timeSystem, defaults.bounds);
             }
         }


### PR DESCRIPTION
This addresses the weirdness seen in #1434 which was due to default bounds being cached and not re-calculated based on 'now()'. There are a number of other issues at play, which have been added to the original issue and will be addressed subsequently.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A
* Command line build passes? Y
* Changes have been smoke-tested? Y