### PR TITLE
[Table] parse/format with datum

### DIFF
--- a/platform/features/table/src/TableConfiguration.js
+++ b/platform/features/table/src/TableConfiguration.js
@@ -65,9 +65,8 @@ define(
                                         limitEvaluator &&
                                         limitEvaluator.evaluate(telemetryDatum, metadatum);
                             var value = {
-                                text: formatter ? formatter.format(telemetryDatum[metadatum.key])
-                                    : telemetryDatum[metadatum.key],
-                                value: telemetryDatum[metadatum.key]
+                                text: formatter.format(telemetryDatum),
+                                value: formatter.parse(telemetryDatum)
                             };
 
                             if (alarm) {

--- a/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
@@ -101,7 +101,21 @@ define(
                 ]);
                 mockTelemetryAPI.commonValuesForHints.andReturn([]);
                 mockTelemetryAPI.request.andReturn(Promise.resolve([]));
-
+                mockTelemetryAPI.getValueFormatter.andCallFake(function (metadata) {
+                    var formatter = jasmine.createSpyObj(
+                        'telemetryFormatter:' + metadata.key,
+                        [
+                            'format',
+                            'parse'
+                        ]
+                    );
+                    var getter = function (datum) {
+                        return datum[metadata.key];
+                    };
+                    formatter.format.andCallFake(getter);
+                    formatter.parse.andCallFake(getter);
+                    return formatter;
+                });
 
                 mockTelemetryAPI.canProvideTelemetry.andReturn(false);
 


### PR DESCRIPTION
Use formatter to parse format datum such that source remapping
is properly handled.  Otherwise, tables would read incorrect fields and in the case of the tutorial, a lot of data would be removed as duplicate when it wasn't duplicate.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

To andrew for review and integrate.

