### PR TITLE
[Duplicate] Differentiate between user cancellation and other errors

### DIFF
--- a/platform/entanglement/src/actions/AbstractComposeAction.js
+++ b/platform/entanglement/src/actions/AbstractComposeAction.js
@@ -141,6 +141,8 @@ define(
                 currentParent
             ).then(function (newParentObj) {
                 return composeService.perform(object, newParentObj);
+            }, function () {
+                return Promise.reject({ message: "cancelled" });
             });
         };
 

--- a/platform/entanglement/src/actions/AbstractComposeAction.js
+++ b/platform/entanglement/src/actions/AbstractComposeAction.js
@@ -21,7 +21,9 @@
  *****************************************************************************/
 
 define(
-    function () {
+    ['./CancelError'],
+    function (CancelError) {
+        var CANCEL_MESSAGE = "User cancelled location selection.";
 
         /**
          * Common interface exposed by services which support move, copy,
@@ -142,8 +144,8 @@ define(
             ).then(function (newParentObj) {
                 return composeService.perform(object, newParentObj);
             }, function () {
-                return Promise.reject({ message: "cancelled" });
-            });
+                return Promise.reject(new CancelError(CANCEL_MESSAGE));
+            }.bind(this));
         };
 
         AbstractComposeAction.appliesTo = function (context) {

--- a/platform/entanglement/src/actions/CancelError.js
+++ b/platform/entanglement/src/actions/CancelError.js
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(function () {
+    function CancelError() {
+        Error.apply(this, arguments);
+        this.name = CancelError;
+    }
+
+    CancelError.prototype = Object.create(Error.prototype);
+
+    return CancelError;
+});

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -117,6 +117,10 @@ define(
             }
 
             function error(errorDetails) {
+                if (errorDetails && (errorDetails.message === "cancelled")) {
+                    return;
+                }
+
                 var errorDialog,
                     errorMessage = {
                     title: "Error copying objects.",

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -21,8 +21,8 @@
  *****************************************************************************/
 
 define(
-    ['./AbstractComposeAction'],
-    function (AbstractComposeAction) {
+    ['./AbstractComposeAction', './CancelError'],
+    function (AbstractComposeAction, CancelError) {
 
         /**
          * The CopyAction is available from context menus and allows a user to
@@ -117,7 +117,8 @@ define(
             }
 
             function error(errorDetails) {
-                if (errorDetails && (errorDetails.message === "cancelled")) {
+                // No need to notify user of their own cancellation
+                if (errorDetails instanceof CancelError) {
                     return;
                 }
 

--- a/platform/entanglement/test/actions/AbstractComposeActionSpec.js
+++ b/platform/entanglement/test/actions/AbstractComposeActionSpec.js
@@ -157,9 +157,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("copies object to selected location", function () {

--- a/platform/entanglement/test/actions/CopyActionSpec.js
+++ b/platform/entanglement/test/actions/CopyActionSpec.js
@@ -180,9 +180,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("copies object to selected location", function () {

--- a/platform/entanglement/test/actions/LinkActionSpec.js
+++ b/platform/entanglement/test/actions/LinkActionSpec.js
@@ -133,9 +133,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("links object to selected location", function () {

--- a/platform/entanglement/test/actions/MoveActionSpec.js
+++ b/platform/entanglement/test/actions/MoveActionSpec.js
@@ -133,9 +133,9 @@ define(
                             );
                     });
 
-                    it("waits for location from user", function () {
+                    it("waits for location and handles cancellation by user", function () {
                         expect(locationServicePromise.then)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
+                            .toHaveBeenCalledWith(jasmine.any(Function), jasmine.any(Function));
                     });
 
                     it("moves object to selected location", function () {


### PR DESCRIPTION
Small follow-on to @BogdanAlexandru's PR #1457 (uses a subclass of Error instead of an ad hoc object to differentiate errors) addressing #1456 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y