### PR TITLE
Table perf improvements

### DIFF
--- a/platform/features/table/src/TelemetryCollection.js
+++ b/platform/features/table/src/TelemetryCollection.js
@@ -188,6 +188,7 @@ define(
         TelemetryCollection.prototype.add = function (items) {
             var added = items.filter(this.addOne);
             this.emit('added', added);
+            this.dupeCheck = true;
         };
 
         /**

--- a/platform/features/table/src/TelemetryCollection.js
+++ b/platform/features/table/src/TelemetryCollection.js
@@ -32,6 +32,7 @@ define(
          */
         function TelemetryCollection() {
             EventEmitter.call(this, arguments);
+            this.dupeCheck = false;
             this.telemetry = [];
             this.highBuffer = [];
             this.sortField = undefined;
@@ -159,7 +160,7 @@ define(
                 var startIx = _.sortedIndex(array, item, this.sortField);
                 var endIx;
 
-                if (startIx !== array.length) {
+                if (this.dupeCheck && startIx !== array.length) {
                     endIx = _.sortedLastIndex(array, item, this.sortField);
 
                     // Create an array of potential dupes, based on having the

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -435,9 +435,25 @@ define(
          * @param {Object} searchElement Object to find the insertion point for
          */
         MCTTableController.prototype.findInsertionPoint = function (searchArray, searchElement) {
-            //First, use a binary search to find the correct insertion point
-            var index = this.binarySearch(searchArray, searchElement, 0, searchArray.length - 1);
-            var testIndex = index;
+            var index;
+            var textIndex;
+            var first = searchArray[0];
+            var last = searchArray[searchArray.length - 1];
+
+            // Shortcut check for append/prepend
+            if (first && this.sortComparator(first, searchElement) <= 0) {
+                index = testIndex = 0;
+            } else if (last && this.sortComparator(last, searchElement) >= 0) {
+                index = testIndex = searchArray.length - 1;
+            } else {
+                // use a binary search to find the correct insertion point
+                index = testIndex =  this.binarySearch(
+                    searchArray,
+                    searchElement,
+                    0,
+                    searchArray.length - 1
+                );
+            }
 
             //It's possible that the insertion point is a duplicate of the element to be inserted
             var isDupe = function () {

--- a/platform/features/table/src/controllers/MCTTableController.js
+++ b/platform/features/table/src/controllers/MCTTableController.js
@@ -436,15 +436,21 @@ define(
          */
         MCTTableController.prototype.findInsertionPoint = function (searchArray, searchElement) {
             var index;
-            var textIndex;
+            var testIndex;
             var first = searchArray[0];
             var last = searchArray[searchArray.length - 1];
 
+            if (first) {
+                first = first[this.$scope.sortColumn].text;
+            }
+            if (last) {
+                last = last[this.$scope.sortColumn].text;
+            }
             // Shortcut check for append/prepend
-            if (first && this.sortComparator(first, searchElement) <= 0) {
+            if (first && this.sortComparator(first, searchElement) >= 0) {
                 index = testIndex = 0;
-            } else if (last && this.sortComparator(last, searchElement) >= 0) {
-                index = testIndex = searchArray.length - 1;
+            } else if (last && this.sortComparator(last, searchElement) <= 0) {
+                index = testIndex = searchArray.length;
             } else {
                 // use a binary search to find the correct insertion point
                 index = testIndex =  this.binarySearch(

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -291,7 +291,6 @@ define(
                  */
                 function finishProcessing() {
                     telemetryCollection.add(rowData);
-                    telemetryCollection.dupeCheck = true;
                     scope.rows = telemetryCollection.telemetry;
                     scope.loading = false;
 
@@ -377,7 +376,6 @@ define(
             function newData(domainObject, datum) {
                 limitEvaluator = telemetryApi.limitEvaluator(domainObject);
                 added = telemetryCollection.add([table.getRowValues(limitEvaluator, datum)]);
-                this.telemetry.dupeCheck = true;
             }
 
             objects.forEach(function (object) {

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -291,6 +291,7 @@ define(
                  */
                 function finishProcessing() {
                     telemetryCollection.add(rowData);
+                    telemetryCollection.dupeCheck = true;
                     scope.rows = telemetryCollection.telemetry;
                     scope.loading = false;
 
@@ -376,6 +377,7 @@ define(
             function newData(domainObject, datum) {
                 limitEvaluator = telemetryApi.limitEvaluator(domainObject);
                 added = telemetryCollection.add([table.getRowValues(limitEvaluator, datum)]);
+                this.telemetry.dupeCheck = true;
             }
 
             objects.forEach(function (object) {

--- a/src/api/telemetry/TelemetryValueFormatter.js
+++ b/src/api/telemetry/TelemetryValueFormatter.js
@@ -41,8 +41,6 @@ define([
         };
 
         this.valueMetadata = valueMetadata;
-        this.parseCache = new WeakMap();
-        this.formatCache = new WeakMap();
         try {
             this.formatter = formatService
                 .getFormat(valueMetadata.format, valueMetadata);
@@ -72,26 +70,14 @@ define([
 
     TelemetryValueFormatter.prototype.parse = function (datum) {
         if (_.isObject(datum)) {
-            if (!this.parseCache.has(datum)) {
-                this.parseCache.set(
-                    datum,
-                    this.formatter.parse(datum[this.valueMetadata.source])
-                );
-            }
-            return this.parseCache.get(datum);
+            return this.formatter.parse(datum[this.valueMetadata.source]);
         }
         return this.formatter.parse(datum);
     };
 
     TelemetryValueFormatter.prototype.format = function (datum) {
         if (_.isObject(datum)) {
-            if (!this.formatCache.has(datum)) {
-                this.formatCache.set(
-                    datum,
-                    this.formatter.format(datum[this.valueMetadata.source])
-                );
-            }
-            return this.formatCache.get(datum);
+            return this.formatter.format(datum[this.valueMetadata.source]);
         }
         return this.formatter.format(datum);
     };


### PR DESCRIPTION
This includes potential improvements to table performance with large datasets. (~161k rows, many duplicate values in the sort column).

There are three different changes in this PR:

A. defer dupe check
B. shortcut insertion check
C. remove format/parse cache

test case | processData elapsed
 --- | --- 
baseline | 87s 
A | 26s 
A+B | 16s 
A+B+C | 13s 

I'd consider the 3 seconds to maintain the format/parse cache a non-negligible hit; let this be a lesson to myself as to why premature optimization is bad.  The bulk of the remaining performance hit is moment date parsing.

Note that there's also 45-60 seconds of network latency loading this table.

@akhenry would love your insights on these changes before I update tests.
