### PR TITLE
[Browse] Handle missing path and nav to root

### DIFF
--- a/platform/commonUI/browse/src/BrowseController.js
+++ b/platform/commonUI/browse/src/BrowseController.js
@@ -113,11 +113,22 @@ define(
                 $location.path('/browse/' + currentIds);
             }
 
+            function getLastChildIfRoot(object) {
+                if (object.getId() !== 'ROOT') {
+                    return object;
+                }
+                return object.useCapability('composition')
+                    .then(function (composees) {
+                        return composees[composees.length - 1];
+                    });
+            }
+
             function navigateToPath(path) {
                 return getObject('ROOT')
                     .then(function (root) {
                         return findViaComposition(root, path);
                     })
+                    .then(getLastChildIfRoot)
                     .then(function (object) {
                         navigationService.setNavigation(object);
                     });
@@ -147,10 +158,14 @@ define(
             // navigate to the path ourselves, which results in it being
             // properly set.
             $scope.$on('$routeChangeStart', function (event, route) {
-                if (route.$$route === $route.current.$$route &&
-                    route.pathParams.ids !== $route.current.pathParams.ids) {
-                    event.preventDefault();
-                    navigateToPath(route.pathParams.ids.split('/'));
+                if (route.$$route === $route.current.$$route) {
+                    if (route.pathParams.ids &&
+                        route.pathParams.ids !== $route.current.pathParams.ids) {
+                        event.preventDefault();
+                        navigateToPath(route.pathParams.ids.split('/'));
+                    } else {
+                        navigateToPath([]);
+                    }
                 }
             });
 


### PR DESCRIPTION
When no path is specified, don't throw error.  Navigate
to default, as expected.

When navigating to root, navigate to the last child
of root instead.  This handles cases where DEFAULT_PATH
is not found (e.g. deployments without "mine").

@akhenry small change to reduce console errors.

# Reviewer Checklist

1. Changes appear to address issue? Y (as reported here)
2. Appropriate unit tests included? Y
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y
