### PR TITLE
[API] track composition before notifying listeners

### DIFF
--- a/src/api/composition/DefaultCompositionProvider.js
+++ b/src/api/composition/DefaultCompositionProvider.js
@@ -218,6 +218,8 @@ define([
             };
         }
 
+        listeners.composition = newComposition.map(objectUtils.parseKeyString);
+
         added.forEach(function (addedChild) {
             listeners.add.forEach(notify(addedChild));
         });
@@ -226,7 +228,7 @@ define([
             listeners.remove.forEach(notify(removedChild));
         });
 
-        listeners.composition = newComposition.map(objectUtils.parseKeyString);
+
     };
 
     return DefaultCompositionProvider;


### PR DESCRIPTION
Track the updated composition of an object before notifying any
listeners.  Otherwise, any composition listener that mutates the
object would cause an infinite loop.

Detected in implementation of the new plot.

# Author Checklist

1. Changes address original issue? Y (as reported here)
2. Unit tests included and/or updated with changes? N, new API tests deferred.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y