### PR TITLE
Added an app.json and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ instance (e.g. by starting an HTTP server in that directory), including:
 
 Additional `gulp` tasks are defined in [the gulpfile](gulpfile.js).
 
+Or you can deploy to Heroku for free with one click:
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 ## Bundles
 
 A bundle is a group of software components (including source code, declared

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "name": "NASA Open MCT",
+  "description": "Open Mission Control Technologies is a next-generation mission control framework.",
+  "env": {
+    "NPM_CONFIG_PRODUCTION": {
+        "description": "Set to false to install devDependencies",
+        "value": "false"
+    }
+  }
+}


### PR DESCRIPTION
The `app.json` is a general purpose descriptor for an application. I've also updated the README to include a one-click deployment button to easily run the app on Heroku PaaS for free.