### PR TITLE
chore: Remove unsed variables from codebase

### DIFF
--- a/platform/commonUI/formats/src/UTCTimeFormat.js
+++ b/platform/commonUI/formats/src/UTCTimeFormat.js
@@ -112,7 +112,7 @@ define([
      * formatted values will be returned. Where a value could not be formatted, `undefined` will be returned at its position
      * in the array.
      */
-    UTCTimeFormat.prototype.format = function (value, minValue, maxValue, count) {
+    UTCTimeFormat.prototype.format = function (value) {
         if (arguments.length > 1) {
             return getScaledFormat(value);
         } else {

--- a/src/adapter/actions/ActionDialogDecorator.js
+++ b/src/adapter/actions/ActionDialogDecorator.js
@@ -41,7 +41,7 @@ define([
 
                 if (providers.length > 0) {
                     action.dialogService = Object.create(action.dialogService);
-                    action.dialogService.getUserInput = function (form, value) {
+                    action.dialogService.getUserInput = function (form) {
                         return new mct.Dialog(
                             providers[0].view(context.domainObject),
                             form.title

--- a/src/adapter/capabilities/AlternateCompositionCapability.js
+++ b/src/adapter/capabilities/AlternateCompositionCapability.js
@@ -96,7 +96,7 @@ define([
                 }.bind(this));
         };
 
-        AlternateCompositionCapability.appliesTo = function (model) {
+        AlternateCompositionCapability.appliesTo = function () {
             // Will get replaced by a runs exception to properly
             // bind to running openmct instance
             return false;

--- a/src/adapter/directives/MCTView.js
+++ b/src/adapter/directives/MCTView.js
@@ -23,11 +23,9 @@
 define([
     'angular',
     './Region',
-    '../../api/objects/object-utils'
 ], function (
     angular,
-    Region,
-    objectUtils
+    Region
 ) {
     function MCTView() {
         return {

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -22,10 +22,8 @@
 
 define([
     'lodash',
-    '../objects/object-utils'
 ], function (
-    _,
-    objectUtils
+    _
 ) {
 
     /**

--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -24,12 +24,10 @@ define([
     './TelemetryMetadataManager',
     './TelemetryValueFormatter',
     'lodash',
-    'EventEmitter'
 ], function (
     TelemetryMetadataManager,
     TelemetryValueFormatter,
-    _,
-    EventEmitter
+    _
 ) {
     /**
      * A LimitEvaluator may be used to detect when telemetry values
@@ -175,7 +173,7 @@ define([
     /**
      * @private
      */
-    TelemetryAPI.prototype.findSubscriptionProvider = function (domainObject) {
+    TelemetryAPI.prototype.findSubscriptionProvider = function () {
         var args = Array.prototype.slice.apply(arguments);
         function supportsDomainObject(provider) {
             return provider.supportsSubscribe.apply(provider, args);
@@ -187,7 +185,7 @@ define([
     /**
      * @private
      */
-    TelemetryAPI.prototype.findRequestProvider = function (domainObject, options) {
+    TelemetryAPI.prototype.findRequestProvider = function (domainObject) {
         var args = Array.prototype.slice.apply(arguments);
         function supportsDomainObject(provider) {
             return provider.supportsRequest.apply(provider, args);
@@ -226,8 +224,7 @@ define([
      * @returns {Promise.<object[]>} a promise for an array of
      *          telemetry data
      */
-    TelemetryAPI.prototype.request = function (domainObject, options) {
-        this.standardizeRequestOptions(options);
+    TelemetryAPI.prototype.request = function (domainObject) {
         var provider = this.findRequestProvider.apply(this, arguments);
         return provider.request.apply(provider, arguments);
     };
@@ -248,7 +245,7 @@ define([
      * @returns {Function} a function which may be called to terminate
      *          the subscription
      */
-    TelemetryAPI.prototype.subscribe = function (domainObject, callback, options) {
+    TelemetryAPI.prototype.subscribe = function (domainObject, callback) {
         var provider = this.findSubscriptionProvider.apply(this, arguments);
         return provider.subscribe.apply(provider, arguments);
     };

--- a/src/plugins/utcTimeSystem/LocalClock.js
+++ b/src/plugins/utcTimeSystem/LocalClock.js
@@ -81,7 +81,7 @@ define(['EventEmitter'], function (EventEmitter) {
      * @param listener
      * @returns {function} a function for deregistering the provided listener
      */
-    LocalClock.prototype.on = function (event, listener) {
+    LocalClock.prototype.on = function (event) {
         var result = EventEmitter.prototype.on.apply(this, arguments);
 
         if (this.listeners(event).length === 1) {
@@ -97,7 +97,7 @@ define(['EventEmitter'], function (EventEmitter) {
      * @param listener
      * @returns {function} a function for deregistering the provided listener
      */
-    LocalClock.prototype.off = function (event, listener) {
+    LocalClock.prototype.off = function (event) {
         var result = EventEmitter.prototype.off.apply(this, arguments);
 
         if (this.listeners(event).length === 0) {


### PR DESCRIPTION
Hey, I was trying to understand the code base. I feel instead of `jshint` we can use [`eslint`](http://eslint.org) or [`standardjs`](https://standardjs.com/). And have a pre-commit hook that can fix linting issues automatically whenever possible (including spaces, etc).

I tried both eslint and standard and found a bunch of errors. With this PR I am intending to remove unused variables from the codebase, with two exceptions, because I wasn't sure, should I do that or not? If yes, the I will incorporate that as well in the PR.

```
DefautlComposotionProvider.js
Line 154: 'childId'
Line 171: 'child'
```
``` 
LegacyObjectAPIInterceptor.js
Line 82: 'object'
```
Also, I saw that `four spaces` is defined in `CONTRIBUTING.md`. And as I understand, generally `two spaces` is a convention instead. So, can we do that? 