### PR TITLE
[Telem] ensure request has minimum fields

### DIFF
--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -197,6 +197,21 @@ define([
     };
 
     /**
+     * @private
+     */
+    TelemetryAPI.prototype.standardizeRequestOptions = function (options) {
+        if (!options.hasOwnProperty('start')) {
+            options.start = this.MCT.time.bounds().start;
+        }
+        if (!options.hasOwnProperty('end')) {
+            options.end = this.MCT.time.bounds().end;
+        }
+        if (!options.hasOwnProperty('domain')) {
+            options.domain = this.MCT.time.timeSystem().key;
+        }
+    };
+
+    /**
      * Request historical telemetry for a domain object.
      * The `options` argument allows you to specify filters
      * (start, end, etc.), sort order, and strategies for retrieving
@@ -212,6 +227,7 @@ define([
      *          telemetry data
      */
     TelemetryAPI.prototype.request = function (domainObject, options) {
+        this.standardizeRequestOptions(options);
         var provider = this.findRequestProvider.apply(this, arguments);
         return provider.request.apply(provider, arguments);
     };


### PR DESCRIPTION
Ensure telemetry request options always have a certain number
of fields-- start, end, and domain.  This allows telemetry providers
to implement necessary filtering for these types of requests.

These properties were not consistently applied, so was running into problems implementing new telemetry adapters with new APIs.  Previously this was added by the conductor compatibility decorator.

@VWoeltjen sending your way for feedback.

# Author Checklist

1. Changes address original issue? As represented here, yes
2. Unit tests included and/or updated with changes? N/A, deferred currently.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y