### PR TITLE
[Time Conductor] Fix link in error message

### DIFF
--- a/src/plugins/timeConductor/plugin.js
+++ b/src/plugins/timeConductor/plugin.js
@@ -26,7 +26,7 @@ define([], function () {
 
         function validateConfiguration() {
             if (config === undefined || config.menuOptions === undefined || config.menuOptions.length === 0) {
-                return "Please provide some configuration for the time conductor. https://github.com/nasa/openmct/blob/master/API.md#time-conductor";
+                return "Please provide some configuration for the time conductor. https://github.com/nasa/openmct/blob/master/API.md#the-time-conductor";
             }
             return undefined;
         }


### PR DESCRIPTION
Anchor tag in the "you need some options" error message for Time Conductor is not quite correct.

### Author Checklist

1. Changes address original issue? N/A (PR documents issue)
2. Unit tests included and/or updated with changes? N/A (changes to link only)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y