### PR TITLE
[Search] Use new composition in search

### DIFF
--- a/platform/search/bundle.js
+++ b/platform/search/bundle.js
@@ -100,7 +100,8 @@ define([
                         "modelService",
                         "workerService",
                         "topic",
-                        "GENERIC_SEARCH_ROOTS"
+                        "GENERIC_SEARCH_ROOTS",
+                        "openmct"
                     ]
                 },
                 {


### PR DESCRIPTION
Use private parts of new composition API for generic search indexer
so that all objects are properly accessible in search results.

Also prevent ROOT object from getting indexed but still traverse
composition.  That way, "The root object" no longer shows in search
results.

Updated tests to cover changes.

Fixes #1579

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y