### PR TITLE
[CLOCK] Allow clock to set timezone with autocomplete dropdown option.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "eventemitter3": "^1.2.0",
     "lodash": "3.10.1",
     "almond": "~0.3.2",
-    "html2canvas": "^0.4.1"
+    "html2canvas": "^0.4.1",
+    "moment-timezone": "^0.5.13"
   }
 }

--- a/openmct.js
+++ b/openmct.js
@@ -32,6 +32,7 @@ requirejs.config({
         "html2canvas": "bower_components/html2canvas/build/html2canvas.min",
         "moment": "bower_components/moment/moment",
         "moment-duration-format": "bower_components/moment-duration-format/lib/moment-duration-format",
+        "moment-timezone": "bower_components/moment-timezone/builds/moment-timezone-with-data",
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",
         "screenfull": "bower_components/screenfull/dist/screenfull.min",
         "text": "bower_components/text/text",

--- a/platform/commonUI/general/res/sass/controls/_controls.scss
+++ b/platform/commonUI/general/res/sass/controls/_controls.scss
@@ -297,6 +297,39 @@ textarea.lg { position: relative; height: 300px; }
     }
 }
 
+/******************************************************** AUTOCOMPLETE */
+.autocomplete {
+    input {
+        width: 226px;
+        padding: 5px 0px 5px 7px;
+    }
+    .icon-arrow-down {
+        position: absolute;
+        top: 8px;
+        left: 210px;
+        font-size: 10px;
+    }
+    .autocompleteOptions {
+        border: 1px solid $colorFormLines;
+        border-radius: 5px;
+        width: 224px;
+        max-height: 170px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        li {
+            border: 1px solid $colorFormLines;
+            padding: 8px 0px 8px 5px;
+            .optionText {
+                cursor: pointer;
+            }
+        }
+        .optionPreSelected {
+            background-color: $colorInspectorSectionHeaderBg;
+            color: $colorInspectorSectionHeaderFg;
+        }
+    }
+}
+
 /******************************************************** OBJECT-HEADER */
 .object-header {
     font-size: 1em;

--- a/platform/commonUI/general/res/sass/controls/_controls.scss
+++ b/platform/commonUI/general/res/sass/controls/_controls.scss
@@ -329,6 +329,13 @@ textarea.lg { position: relative; height: 300px; }
             color: $colorInspectorSectionHeaderFg;
         }
     }
+    .autocompleteWarning {
+        color: $colorFormInvalid;
+        position: absolute;
+        font-size: 11px;
+        left: 235px;
+        bottom: 7px;
+    }
 }
 
 /******************************************************** OBJECT-HEADER */

--- a/platform/commonUI/general/res/sass/controls/_controls.scss
+++ b/platform/commonUI/general/res/sass/controls/_controls.scss
@@ -329,13 +329,6 @@ textarea.lg { position: relative; height: 300px; }
             color: $colorInspectorSectionHeaderFg;
         }
     }
-    .autocompleteWarning {
-        color: $colorFormInvalid;
-        position: absolute;
-        font-size: 11px;
-        left: 235px;
-        bottom: 7px;
-    }
 }
 
 /******************************************************** OBJECT-HEADER */

--- a/platform/commonUI/general/res/sass/controls/_controls.scss
+++ b/platform/commonUI/general/res/sass/controls/_controls.scss
@@ -308,6 +308,7 @@ textarea.lg { position: relative; height: 300px; }
         top: 8px;
         left: 210px;
         font-size: 10px;
+        cursor: pointer;
     }
     .autocompleteOptions {
         border: 1px solid $colorFormLines;

--- a/platform/features/clock/bundle.js
+++ b/platform/features/clock/bundle.js
@@ -21,6 +21,7 @@
  *****************************************************************************/
 
 define([
+    "moment-timezone",
     "./src/indicators/ClockIndicator",
     "./src/services/TickerService",
     "./src/controllers/ClockController",
@@ -32,6 +33,7 @@ define([
     "text!./res/templates/timer.html",
     'legacyRegistry'
 ], function (
+    MomentTimezone,
     ClockIndicator,
     TickerService,
     ClockController,
@@ -200,13 +202,20 @@ define([
                                     "cssClass": "l-inline"
                                 }
                             ]
+                        },
+                        {
+                            "key": "timezone",
+                            "name": "Timezone",
+                            "control": "autocomplete",
+                            "options": MomentTimezone.tz.names()
                         }
                     ],
                     "model": {
                         "clockFormat": [
                             "YYYY/MM/DD hh:mm:ss",
                             "clock12"
-                        ]
+                        ],
+                        "timezone": "UTC"
                     }
                 },
                 {

--- a/platform/features/clock/src/controllers/ClockController.js
+++ b/platform/features/clock/src/controllers/ClockController.js
@@ -67,7 +67,7 @@ define([
                     timeFormat = self.use24 ?
                             baseFormat.replace('hh', "HH") : baseFormat;
                     // If wrong timezone is provided, the UTC will be used
-                    zoneName = momentTimezone.tz.names().includes(model.timezone) ? 
+                    zoneName = momentTimezone.tz.names().includes(model.timezone) ?
                         model.timezone : "UTC";
                     update();
                 }

--- a/platform/features/clock/src/controllers/ClockController.js
+++ b/platform/features/clock/src/controllers/ClockController.js
@@ -20,9 +20,14 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-define(
-    ['moment'],
-    function (moment) {
+define([
+    'moment',
+    'moment-timezone'
+    ],
+    function (
+        moment,
+        momentTimezone
+    ) {
 
         /**
          * Controller for views of a Clock domain object.
@@ -37,10 +42,13 @@ define(
             var lastTimestamp,
                 unlisten,
                 timeFormat,
+                zoneName,
                 self = this;
 
             function update() {
-                var m = moment.utc(lastTimestamp);
+                var m = zoneName ?
+                    moment.utc(lastTimestamp).tz(zoneName) : moment.utc(lastTimestamp);
+                self.zoneAbbr = zoneName ? m.zoneAbbr() : "UTC";
                 self.textValue = timeFormat && m.format(timeFormat);
                 self.ampmValue = m.format("A"); // Just the AM or PM part
             }
@@ -50,21 +58,23 @@ define(
                 update();
             }
 
-            function updateFormat(clockFormat) {
+            function updateModel(model) {
                 var baseFormat;
+                if (model !== undefined) {
+                    baseFormat = model.clockFormat[0];
 
-                if (clockFormat !== undefined) {
-                    baseFormat = clockFormat[0];
-
-                    self.use24 = clockFormat[1] === 'clock24';
+                    self.use24 = model.clockFormat[1] === 'clock24';
                     timeFormat = self.use24 ?
                             baseFormat.replace('hh', "HH") : baseFormat;
-
-                    update();
+                    // If wrong timezone is provided, the UTC will be used
+                    zoneName = momentTimezone.tz.names().includes(model.timezone) ? 
+                        model.timezone : "UTC";
                 }
+                update();
             }
-            // Pull in the clock format from the domain object model
-            $scope.$watch('model.clockFormat', updateFormat);
+
+            // Pull in the model (clockFormat and timezone) from the domain object model
+            $scope.$watch('model', updateModel);
 
             // Listen for clock ticks ... and stop listening on destroy
             unlisten = tickerService.listen(tick);
@@ -76,7 +86,7 @@ define(
          * @returns {string}
          */
         ClockController.prototype.zone = function () {
-            return "UTC";
+            return this.zoneAbbr;
         };
 
         /**

--- a/platform/features/clock/src/controllers/ClockController.js
+++ b/platform/features/clock/src/controllers/ClockController.js
@@ -48,7 +48,7 @@ define([
             function update() {
                 var m = zoneName ?
                     moment.utc(lastTimestamp).tz(zoneName) : moment.utc(lastTimestamp);
-                self.zoneAbbr = zoneName ? m.zoneAbbr() : "UTC";
+                self.zoneAbbr = m.zoneAbbr();
                 self.textValue = timeFormat && m.format(timeFormat);
                 self.ampmValue = m.format("A"); // Just the AM or PM part
             }
@@ -69,8 +69,8 @@ define([
                     // If wrong timezone is provided, the UTC will be used
                     zoneName = momentTimezone.tz.names().includes(model.timezone) ? 
                         model.timezone : "UTC";
+                    update();
                 }
-                update();
             }
 
             // Pull in the model (clockFormat and timezone) from the domain object model

--- a/platform/features/clock/test/controllers/ClockControllerSpec.js
+++ b/platform/features/clock/test/controllers/ClockControllerSpec.js
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Open MCT, Copyright (c) 2009-2016, United States Government
+ * Open MCT, Copyright (c) 2009-2017, United States Government
  * as represented by the Administrator of the National Aeronautics and Space
  * Administration. All rights reserved.
  *
@@ -43,9 +43,9 @@ define(
                 controller = new ClockController(mockScope, mockTicker);
             });
 
-            it("watches for clock format from the domain object model", function () {
+            it("watches for model (clockFormat and timezone) from the domain object model", function () {
                 expect(mockScope.$watch).toHaveBeenCalledWith(
-                    "model.clockFormat",
+                    "model",
                     jasmine.any(Function)
                 );
             });
@@ -67,29 +67,35 @@ define(
 
             it("formats using the format string from the model", function () {
                 mockTicker.listen.mostRecentCall.args[0](TEST_TIMESTAMP);
-                mockScope.$watch.mostRecentCall.args[1]([
-                    "YYYY-DDD hh:mm:ss",
-                    "clock24"
-                ]);
+                mockScope.$watch.mostRecentCall.args[1]({
+                    "clockFormat": [
+                        "YYYY-DDD hh:mm:ss",
+                        "clock24"
+                    ],
+                    "timezone": "Canada/Eastern"
+                });
 
-                expect(controller.zone()).toEqual("UTC");
-                expect(controller.text()).toEqual("2015-154 17:56:14");
+                expect(controller.zone()).toEqual("EDT");
+                expect(controller.text()).toEqual("2015-154 13:56:14");
                 expect(controller.ampm()).toEqual("");
             });
 
             it("formats 12-hour time", function () {
                 mockTicker.listen.mostRecentCall.args[0](TEST_TIMESTAMP);
-                mockScope.$watch.mostRecentCall.args[1]([
-                    "YYYY-DDD hh:mm:ss",
-                    "clock12"
-                ]);
+                mockScope.$watch.mostRecentCall.args[1]({
+                    "clockFormat": [
+                        "YYYY-DDD hh:mm:ss",
+                        "clock12"
+                    ],
+                    "timezone": ""
+                });
 
                 expect(controller.zone()).toEqual("UTC");
                 expect(controller.text()).toEqual("2015-154 05:56:14");
                 expect(controller.ampm()).toEqual("PM");
             });
 
-            it("does not throw exceptions when clockFormat is undefined", function () {
+            it("does not throw exceptions when model is undefined", function () {
                 mockTicker.listen.mostRecentCall.args[0](TEST_TIMESTAMP);
                 expect(function () {
                     mockScope.$watch.mostRecentCall.args[1](undefined);

--- a/platform/forms/bundle.js
+++ b/platform/forms/bundle.js
@@ -24,10 +24,12 @@ define([
     "./src/MCTForm",
     "./src/MCTToolbar",
     "./src/MCTControl",
+    "./src/controllers/AutocompleteController",
     "./src/controllers/DateTimeController",
     "./src/controllers/CompositeController",
     "./src/controllers/ColorController",
     "./src/controllers/DialogButtonController",
+    "text!./res/templates/controls/autocomplete.html",
     "text!./res/templates/controls/checkbox.html",
     "text!./res/templates/controls/datetime.html",
     "text!./res/templates/controls/select.html",
@@ -44,10 +46,12 @@ define([
     MCTForm,
     MCTToolbar,
     MCTControl,
+    AutocompleteController,
     DateTimeController,
     CompositeController,
     ColorController,
     DialogButtonController,
+    autocompleteTemplate,
     checkboxTemplate,
     datetimeTemplate,
     selectTemplate,
@@ -85,6 +89,10 @@ define([
                 }
             ],
             "controls": [
+                {
+                    "key": "autocomplete",
+                    "template": autocompleteTemplate
+                },
                 {
                     "key": "checkbox",
                     "template": checkboxTemplate
@@ -131,6 +139,13 @@ define([
                 }
             ],
             "controllers": [
+                {
+                    "key": "AutocompleteController",
+                    "implementation": AutocompleteController,
+                    "depends": [
+                        "$scope"
+                    ]
+                },
                 {
                     "key": "DateTimeController",
                     "implementation": DateTimeController,

--- a/platform/forms/bundle.js
+++ b/platform/forms/bundle.js
@@ -152,7 +152,8 @@ define([
                     "key": "AutocompleteController",
                     "implementation": AutocompleteController,
                     "depends": [
-                        "$scope"
+                        "$scope",
+                        "$element"
                     ]
                 },
                 {

--- a/platform/forms/bundle.js
+++ b/platform/forms/bundle.js
@@ -24,7 +24,6 @@ define([
     "./src/MCTForm",
     "./src/MCTToolbar",
     "./src/MCTControl",
-    "../commonUI/general/src/directives/MCTClickElsewhere",
     "./src/controllers/AutocompleteController",
     "./src/controllers/DateTimeController",
     "./src/controllers/CompositeController",
@@ -47,7 +46,6 @@ define([
     MCTForm,
     MCTToolbar,
     MCTControl,
-    MCTClickElsewhere,
     AutocompleteController,
     DateTimeController,
     CompositeController,
@@ -87,13 +85,6 @@ define([
                     "depends": [
                         "templateLinker",
                         "controls[]"
-                    ]
-                },
-                {
-                    "key": "mctClickElsewhere",
-                    "implementation": MCTClickElsewhere,
-                    "depends": [
-                        "$document"
                     ]
                 }
             ],
@@ -177,13 +168,6 @@ define([
                     "depends": [
                         "$scope",
                         "dialogService"
-                    ]
-                },
-                {
-                    "key": "mctClickElsewhere",
-                    "implementation": MCTClickElsewhere,
-                    "depends": [
-                        "$document"
                     ]
                 }
             ]

--- a/platform/forms/bundle.js
+++ b/platform/forms/bundle.js
@@ -24,6 +24,7 @@ define([
     "./src/MCTForm",
     "./src/MCTToolbar",
     "./src/MCTControl",
+    "../commonUI/general/src/directives/MCTClickElsewhere",
     "./src/controllers/AutocompleteController",
     "./src/controllers/DateTimeController",
     "./src/controllers/CompositeController",
@@ -46,6 +47,7 @@ define([
     MCTForm,
     MCTToolbar,
     MCTControl,
+    MCTClickElsewhere,
     AutocompleteController,
     DateTimeController,
     CompositeController,
@@ -85,6 +87,13 @@ define([
                     "depends": [
                         "templateLinker",
                         "controls[]"
+                    ]
+                },
+                {
+                    "key": "mctClickElsewhere",
+                    "implementation": MCTClickElsewhere,
+                    "depends": [
+                        "$document"
                     ]
                 }
             ],
@@ -167,6 +176,13 @@ define([
                     "depends": [
                         "$scope",
                         "dialogService"
+                    ]
+                },
+                {
+                    "key": "mctClickElsewhere",
+                    "implementation": MCTClickElsewhere,
+                    "depends": [
+                        "$document"
                     ]
                 }
             ]

--- a/platform/forms/res/templates/controls/autocomplete.html
+++ b/platform/forms/res/templates/controls/autocomplete.html
@@ -21,13 +21,15 @@
 -->
 
 <div ng-controller="AutocompleteController"
-     class='form-control autocomplete' >  
-    <input type="text"
+     class='form-control autocomplete'>
+    <input class="autocompleteInput"
+           type="text"
            ng-model="ngModel[field]"
            ng-change="filterOptions(ngModel[field])"
            ng-click="inputClicked($event)"
            ng-keydown="keyDown($event)"/>
-    <span class="icon-arrow-down"></span>
+    <span class="icon-arrow-down"
+          ng-click="arrowClicked()"></span>
     <div class="autocompleteOptions"
          onload="hideOptions = false"
          ng-hide="hideOptions"

--- a/platform/forms/res/templates/controls/autocomplete.html
+++ b/platform/forms/res/templates/controls/autocomplete.html
@@ -30,7 +30,8 @@
     <span class="icon-arrow-down"></span>
     <div class="autocompleteOptions"
          onload="hideOptions = false"
-         ng-hide="hideOptions">
+         ng-hide="hideOptions"
+         mct-click-elsewhere="hideOptions = true">
         <ul>  
             <li ng-repeat="opt in filteredOptions"
                 ng-click="fillInput(opt.name)"

--- a/platform/forms/res/templates/controls/autocomplete.html
+++ b/platform/forms/res/templates/controls/autocomplete.html
@@ -26,12 +26,12 @@
            type="text"
            ng-model="ngModel[field]"
            ng-change="filterOptions(ngModel[field])"
-           ng-click="inputClicked($event)"
+           ng-click="inputClicked()"
            ng-keydown="keyDown($event)"/>
     <span class="icon-arrow-down"
           ng-click="arrowClicked()"></span>
     <div class="autocompleteOptions"
-         onload="hideOptions = false"
+         ng-init="hideOptions = true"
          ng-hide="hideOptions"
          mct-click-elsewhere="hideOptions = true">
         <ul>  

--- a/platform/forms/res/templates/controls/autocomplete.html
+++ b/platform/forms/res/templates/controls/autocomplete.html
@@ -1,0 +1,43 @@
+<!--
+ Open MCT, Copyright (c) 2014-2017, United States Government
+ as represented by the Administrator of the National Aeronautics and Space
+ Administration. All rights reserved.
+
+ Open MCT is licensed under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+
+ Open MCT includes source code licensed under additional open source
+ licenses. See the Open Source Licenses file (LICENSES.md) included with
+ this source code distribution or the Licensing information page available
+ at runtime from the About dialog for additional information.
+-->
+
+<div ng-controller="AutocompleteController"
+     class='form-control autocomplete' >  
+    <input type="text"
+           ng-model="ngModel[field]"
+           ng-change="filterOptions(ngModel[field])"
+           ng-click="inputClicked($event)"
+           ng-keydown="keyDown($event)"/>
+    <span class="icon-arrow-down"></span>
+    <div class="autocompleteOptions"
+         onload="hideOptions = false"
+         ng-hide="hideOptions">
+        <ul>  
+            <li ng-repeat="opt in filteredOptions"
+                ng-click="fillInput(opt.name)"
+                ng-mouseover="optionMouseover(opt.optionId)"
+                ng-class="optionIndex === opt.optionId ? 'optionPreSelected' : ''">
+                <span class="optionText">{{opt.name}}</span>
+            </li>
+        </ul>  
+    </div>
+</div>

--- a/platform/forms/res/templates/controls/autocomplete.html
+++ b/platform/forms/res/templates/controls/autocomplete.html
@@ -26,7 +26,6 @@
            type="text"
            ng-model="ngModel[field]"
            ng-change="filterOptions(ngModel[field])"
-           ng-init="filterOptions(ngModel[field])"
            ng-click="inputClicked()"
            ng-keydown="keyDown($event)"/>
     <span class="icon-arrow-down"
@@ -44,7 +43,4 @@
             </li>
         </ul>  
     </div>
-    <span class="icon-x autocompleteWarning"
-          ng-show="invalidOption">
-    </span>
 </div>

--- a/platform/forms/res/templates/controls/autocomplete.html
+++ b/platform/forms/res/templates/controls/autocomplete.html
@@ -26,6 +26,7 @@
            type="text"
            ng-model="ngModel[field]"
            ng-change="filterOptions(ngModel[field])"
+           ng-init="filterOptions(ngModel[field])"
            ng-click="inputClicked()"
            ng-keydown="keyDown($event)"/>
     <span class="icon-arrow-down"
@@ -43,4 +44,7 @@
             </li>
         </ul>  
     </div>
+    <span class="icon-x autocompleteWarning"
+          ng-show="invalidOption">
+    </span>
 </div>

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -39,18 +39,24 @@ define(
                     },
                 autocompleteInputElement = $element[0].getElementsByClassName('autocompleteInput')[0];
 
-            if($scope.options[0].name) {
+            if ($scope.options[0].name) {
                 // If "options" include name, value pair
-                $scope.optionNames = $scope.options.map(function(opt) {
+                $scope.optionNames = $scope.options.map(function (opt) {
                     return opt.name;
-                })
+                });
             } else {
                 // If options is only an array of string.
                 $scope.optionNames = $scope.options;
             }
 
+            function fillInputWithIndexedOption() {
+                if ($scope.filteredOptions[$scope.optionIndex]) {
+                    $scope.ngModel[$scope.field] = $scope.filteredOptions[$scope.optionIndex].name;
+                }
+            }
+
             function decrementOptionIndex() {
-                if($scope.optionIndex === 0) {
+                if ($scope.optionIndex === 0) {
                     $scope.optionIndex = $scope.filteredOptions.length;
                 }
                 $scope.optionIndex--;
@@ -58,7 +64,7 @@ define(
             }
 
             function incrementOptionIndex() {
-                if($scope.optionIndex === $scope.filteredOptions.length-1) {
+                if ($scope.optionIndex === $scope.filteredOptions.length - 1) {
                     $scope.optionIndex = -1;
                 }
                 $scope.optionIndex++;
@@ -70,22 +76,16 @@ define(
                 $scope.ngModel[$scope.field] = string;
             }
 
-            function fillInputWithIndexedOption() {
-                if($scope.filteredOptions[$scope.optionIndex]) {
-                    $scope.ngModel[$scope.field] = $scope.filteredOptions[$scope.optionIndex].name;
-                }
-            }
-
             function showOptions(string) {
                 $scope.hideOptions = false;
                 $scope.filterOptions(string);
                 $scope.optionIndex = 0;
             }
 
-            $scope.keyDown = function($event) {
-                if($scope.filteredOptions) {
+            $scope.keyDown = function ($event) {
+                if ($scope.filteredOptions) {
                     var keyCode = $event.keyCode;
-                    switch(keyCode) {
+                    switch (keyCode) {
                         case key.down:
                             incrementOptionIndex();
                             break;
@@ -94,42 +94,42 @@ define(
                             decrementOptionIndex();
                             break;
                         case key.enter:
-                            if($scope.filteredOptions[$scope.optionIndex]) {
+                            if ($scope.filteredOptions[$scope.optionIndex]) {
                                 fillInputWithString($scope.filteredOptions[$scope.optionIndex].name);
                             }
                     }
                 }
-            }
+            };
 
-            $scope.filterOptions = function(string) {
+            $scope.filterOptions = function (string) {
                 $scope.hideOptions = false;
-                $scope.filteredOptions = $scope.optionNames.filter(function(option) {
+                $scope.filteredOptions = $scope.optionNames.filter(function (option) {
                     return option.toLowerCase().indexOf(string.toLowerCase()) >= 0;
-                }).map(function(option, index) {
+                }).map(function (option, index) {
                     return {
                         optionId: index,
                         name: option
-                    }
+                    };
                 });
-            }
+            };
 
-            $scope.inputClicked = function() {
+            $scope.inputClicked = function () {
                 autocompleteInputElement.select();
                 showOptions(autocompleteInputElement.value);
-            }
+            };
 
-            $scope.arrowClicked = function() {
+            $scope.arrowClicked = function () {
                 autocompleteInputElement.select();
                 showOptions('');
-            }
-            
-            $scope.fillInput = function(string) {
-                fillInputWithString(string);
-            }
+            };
 
-            $scope.optionMouseover = function(optionId) {
+            $scope.fillInput = function (string) {
+                fillInputWithString(string);
+            };
+
+            $scope.optionMouseover = function (optionId) {
                 $scope.optionIndex = optionId;
-            }
+            };
         }
 
         return AutocompleteController;

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -64,12 +64,11 @@ define(
 
             function fillInputWithString(string) {
                 $scope.hideOptions = true;
-                // Hard coded!!
-                $scope.ngModel[4] = string;
+                $scope.ngModel[$scope.field] = string;
             }
 
             function fillInputWithIndexedOption() {
-                $scope.ngModel[4] = $scope.filteredOptions[$scope.optionIndex].name;
+                $scope.ngModel[$scope.field] = $scope.filteredOptions[$scope.optionIndex].name;
             }
 
             $scope.keyDown = function($event) {

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -111,7 +111,6 @@ define(
                         name: option
                     };
                 });
-                $scope.invalidOption = $scope.filteredOptions.length === 0;
             };
 
             $scope.inputClicked = function () {

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -1,0 +1,128 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    [],
+    function () {
+
+        /**
+         * Controller for the `autocomplete` form control.
+         *
+         * @memberof platform/forms
+         * @constructor
+         */
+        function AutocompleteController($scope) {
+
+            var key = {
+                down: 40,
+                up: 38,
+                enter: 13
+            }
+
+            if($scope.options[0].name) {
+                // If "options" include name, value pair
+                $scope.optionNames = $scope.options.map(function(opt) {
+                    return opt.name;
+                })
+            } else {
+                // If options is only an array of string.
+                $scope.optionNames = $scope.options;
+            }
+
+            function decrementOptionIndex() {
+                if($scope.optionIndex === 0) {
+                    $scope.optionIndex = $scope.filteredOptions.length;
+                }
+                $scope.optionIndex--;
+            }
+
+            function incrementOptionIndex() {
+                if($scope.optionIndex === $scope.filteredOptions.length-1) {
+                    $scope.optionIndex = -1;
+                }
+                $scope.optionIndex++;
+            }
+
+            function fillInputWithString(string) {
+                $scope.hideOptions = true;
+                // Hard coded!!
+                $scope.ngModel[4] = string;
+            }
+
+            function fillInputWithIndexedOption() {
+                $scope.ngModel[4] = $scope.filteredOptions[$scope.optionIndex].name;
+            }
+
+            $scope.keyDown = function($event) {
+                if($scope.filteredOptions) {
+                    var keyCode = $event.keyCode;
+                    switch(keyCode) {
+                        case key.down:
+                            incrementOptionIndex();
+                            fillInputWithIndexedOption();
+                            break;
+                        case key.up:
+                            $event.preventDefault();    // Prevents cursor jumping back and forth
+                            decrementOptionIndex();
+                            fillInputWithIndexedOption();
+                            break;
+                        case key.enter:
+                            if($scope.filteredOptions[$scope.optionIndex]) {
+                                fillInputWithString($scope.filteredOptions[$scope.optionIndex].name);
+                            }
+                    }
+                }
+            }
+
+            $scope.filterOptions = function(string) {
+                $scope.hideOptions = false;
+                $scope.filteredOptions = $scope.optionNames.filter(function(option) {
+                    return option.toLowerCase().indexOf(string.toLowerCase()) >= 0;
+                }).map(function(option, index) {
+                    return {
+                        optionId: index,
+                        name: option
+                    }
+                });
+            }
+
+            $scope.inputClicked = function($event) {
+                var target = $event.target;
+                target.select();
+                $scope.hideOptions = false;
+                $scope.filterOptions(target.value);
+                $scope.optionIndex = 0;
+            }
+            
+            $scope.fillInput = function(string) {
+                fillInputWithString(string);
+            }
+
+            $scope.optionMouseover = function(optionId) {
+                $scope.optionIndex = optionId;
+            }
+        }
+
+        return AutocompleteController;
+
+    }
+);

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -33,10 +33,11 @@ define(
         function AutocompleteController($scope, $element) {
 
             var key = {
-                    down: 40,
-                    up: 38,
-                    enter: 13
-                }
+                        down: 40,
+                        up: 38,
+                        enter: 13
+                    },
+                autocompleteInputElement = $element[0].getElementsByClassName('autocompleteInput')[0];
 
             if($scope.options[0].name) {
                 // If "options" include name, value pair
@@ -53,6 +54,7 @@ define(
                     $scope.optionIndex = $scope.filteredOptions.length;
                 }
                 $scope.optionIndex--;
+                fillInputWithIndexedOption();
             }
 
             function incrementOptionIndex() {
@@ -60,6 +62,7 @@ define(
                     $scope.optionIndex = -1;
                 }
                 $scope.optionIndex++;
+                fillInputWithIndexedOption();
             }
 
             function fillInputWithString(string) {
@@ -85,12 +88,10 @@ define(
                     switch(keyCode) {
                         case key.down:
                             incrementOptionIndex();
-                            fillInputWithIndexedOption();
                             break;
                         case key.up:
                             $event.preventDefault();    // Prevents cursor jumping back and forth
                             decrementOptionIndex();
-                            fillInputWithIndexedOption();
                             break;
                         case key.enter:
                             if($scope.filteredOptions[$scope.optionIndex]) {
@@ -112,14 +113,12 @@ define(
                 });
             }
 
-            $scope.inputClicked = function($event) {
-                var target = $event.target;
-                target.select();
-                showOptions(target.value);
+            $scope.inputClicked = function() {
+                autocompleteInputElement.select();
+                showOptions(autocompleteInputElement.value);
             }
 
             $scope.arrowClicked = function() {
-                var autocompleteInputElement = $element[0].getElementsByClassName('autocompleteInput')[0];
                 autocompleteInputElement.select();
                 showOptions('');
             }

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -30,13 +30,13 @@ define(
          * @memberof platform/forms
          * @constructor
          */
-        function AutocompleteController($scope) {
+        function AutocompleteController($scope, $element) {
 
             var key = {
-                down: 40,
-                up: 38,
-                enter: 13
-            }
+                    down: 40,
+                    up: 38,
+                    enter: 13
+                }
 
             if($scope.options[0].name) {
                 // If "options" include name, value pair
@@ -71,6 +71,12 @@ define(
                 if($scope.filteredOptions[$scope.optionIndex]) {
                     $scope.ngModel[$scope.field] = $scope.filteredOptions[$scope.optionIndex].name;
                 }
+            }
+
+            function showOptions(string) {
+                $scope.hideOptions = false;
+                $scope.filterOptions(string);
+                $scope.optionIndex = 0;
             }
 
             $scope.keyDown = function($event) {
@@ -109,9 +115,13 @@ define(
             $scope.inputClicked = function($event) {
                 var target = $event.target;
                 target.select();
-                $scope.hideOptions = false;
-                $scope.filterOptions(target.value);
-                $scope.optionIndex = 0;
+                showOptions(target.value);
+            }
+
+            $scope.arrowClicked = function() {
+                var autocompleteInputElement = $element[0].getElementsByClassName('autocompleteInput')[0];
+                autocompleteInputElement.select();
+                showOptions('');
             }
             
             $scope.fillInput = function(string) {

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -68,7 +68,9 @@ define(
             }
 
             function fillInputWithIndexedOption() {
-                $scope.ngModel[$scope.field] = $scope.filteredOptions[$scope.optionIndex].name;
+                if($scope.filteredOptions[$scope.optionIndex]) {
+                    $scope.ngModel[$scope.field] = $scope.filteredOptions[$scope.optionIndex].name;
+                }
             }
 
             $scope.keyDown = function($event) {

--- a/platform/forms/src/controllers/AutocompleteController.js
+++ b/platform/forms/src/controllers/AutocompleteController.js
@@ -111,6 +111,7 @@ define(
                         name: option
                     };
                 });
+                $scope.invalidOption = $scope.filteredOptions.length === 0;
             };
 
             $scope.inputClicked = function () {

--- a/platform/forms/test/controllers/AutocompleteControllerSpec.js
+++ b/platform/forms/test/controllers/AutocompleteControllerSpec.js
@@ -1,0 +1,63 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    ["../../src/controllers/AutocompleteController"],
+    function (AutocompleteController) {
+
+        describe("The autocomplete controller", function () {
+            var mockScope,
+                controller;
+
+            beforeEach(function () {
+                mockScope = jasmine.createSpyObj("$scope", ["$watch"]);
+                mockScope.options = ['Asia/Dhaka', 'UTC', 'Toronto', 'Asia/Shanghai', 'Hotel California'];
+                mockScope.ngModel = [null, null, null, null, null];
+                controller = new AutocompleteController(mockScope);
+            });
+
+            it("makes optionNames array equal to options if options is an array of string", function () {
+                expect(mockScope.optionNames).toEqual(mockScope.options);
+            });
+
+            it("filters options by returning array containing optionId and name", function () {
+                mockScope.filterOptions('Asia');
+                var filteredOptions = [ { optionId : 0, name : 'Asia/Dhaka' },
+                                        { optionId : 1, name : 'Asia/Shanghai' } ];
+                expect(mockScope.filteredOptions).toEqual(filteredOptions);
+            });
+            
+            it("fills input with given string", function () {
+                var str = "UTC";
+                mockScope.fillInput(str);
+                expect(mockScope.hideOptions).toEqual(true);
+                expect(mockScope.ngModel[4]).toEqual(str);
+            });
+            
+            it("sets a new optionIndex on mouse hover", function () {
+                mockScope.optionMouseover(1);
+                expect(mockScope.optionIndex).toEqual(1);
+            });
+
+        });
+    }
+);

--- a/platform/forms/test/controllers/AutocompleteControllerSpec.js
+++ b/platform/forms/test/controllers/AutocompleteControllerSpec.js
@@ -53,11 +53,6 @@ define([
             expect(mockScope.filteredOptions).toEqual(filteredOptions);
         });
 
-        it("checks if invalid option was typed", function () {
-            mockScope.filterOptions('openmct');
-            expect(mockScope.invalidOption).toEqual(true);
-        });
-
         it("fills input with given string", function () {
             var str = "UTC";
             mockScope.fillInput(str);

--- a/platform/forms/test/controllers/AutocompleteControllerSpec.js
+++ b/platform/forms/test/controllers/AutocompleteControllerSpec.js
@@ -53,6 +53,11 @@ define([
             expect(mockScope.filteredOptions).toEqual(filteredOptions);
         });
 
+        it("checks if invalid option was typed", function () {
+            mockScope.filterOptions('openmct');
+            expect(mockScope.invalidOption).toEqual(true);
+        });
+
         it("fills input with given string", function () {
             var str = "UTC";
             mockScope.fillInput(str);

--- a/platform/forms/test/controllers/AutocompleteControllerSpec.js
+++ b/platform/forms/test/controllers/AutocompleteControllerSpec.js
@@ -41,18 +41,18 @@ define(
 
             it("filters options by returning array containing optionId and name", function () {
                 mockScope.filterOptions('Asia');
-                var filteredOptions = [ { optionId : 0, name : 'Asia/Dhaka' },
-                                        { optionId : 1, name : 'Asia/Shanghai' } ];
+                var filteredOptions = [{ optionId : 0, name : 'Asia/Dhaka' },
+                                        { optionId : 1, name : 'Asia/Shanghai' }];
                 expect(mockScope.filteredOptions).toEqual(filteredOptions);
             });
-            
+
             it("fills input with given string", function () {
                 var str = "UTC";
                 mockScope.fillInput(str);
                 expect(mockScope.hideOptions).toEqual(true);
                 expect(mockScope.ngModel[4]).toEqual(str);
             });
-            
+
             it("sets a new optionIndex on mouse hover", function () {
                 mockScope.optionMouseover(1);
                 expect(mockScope.optionIndex).toEqual(1);

--- a/platform/forms/test/controllers/AutocompleteControllerSpec.js
+++ b/platform/forms/test/controllers/AutocompleteControllerSpec.js
@@ -20,44 +20,50 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-define(
-    ["../../src/controllers/AutocompleteController"],
-    function (AutocompleteController) {
+define([
+    "../../src/controllers/AutocompleteController",
+    "angular"
+], function (
+    AutocompleteController,
+    angular
+) {
 
-        describe("The autocomplete controller", function () {
-            var mockScope,
-                controller;
+    describe("The autocomplete controller", function () {
+        var mockScope,
+            mockElement,
+            controller;
 
-            beforeEach(function () {
-                mockScope = jasmine.createSpyObj("$scope", ["$watch"]);
-                mockScope.options = ['Asia/Dhaka', 'UTC', 'Toronto', 'Asia/Shanghai', 'Hotel California'];
-                mockScope.ngModel = [null, null, null, null, null];
-                controller = new AutocompleteController(mockScope);
-            });
-
-            it("makes optionNames array equal to options if options is an array of string", function () {
-                expect(mockScope.optionNames).toEqual(mockScope.options);
-            });
-
-            it("filters options by returning array containing optionId and name", function () {
-                mockScope.filterOptions('Asia');
-                var filteredOptions = [{ optionId : 0, name : 'Asia/Dhaka' },
-                                        { optionId : 1, name : 'Asia/Shanghai' }];
-                expect(mockScope.filteredOptions).toEqual(filteredOptions);
-            });
-
-            it("fills input with given string", function () {
-                var str = "UTC";
-                mockScope.fillInput(str);
-                expect(mockScope.hideOptions).toEqual(true);
-                expect(mockScope.ngModel[4]).toEqual(str);
-            });
-
-            it("sets a new optionIndex on mouse hover", function () {
-                mockScope.optionMouseover(1);
-                expect(mockScope.optionIndex).toEqual(1);
-            });
-
+        beforeEach(function () {
+            mockScope = jasmine.createSpyObj("$scope", ["$watch"]);
+            mockScope.options = ['Asia/Dhaka', 'UTC', 'Toronto', 'Asia/Shanghai', 'Hotel California'];
+            mockScope.ngModel = [null, null, null, null, null];
+            mockScope.field = 4;
+            mockElement = angular.element("<div></div>");
+            controller = new AutocompleteController(mockScope, mockElement);
         });
-    }
-);
+
+        it("makes optionNames array equal to options if options is an array of string", function () {
+            expect(mockScope.optionNames).toEqual(mockScope.options);
+        });
+
+        it("filters options by returning array containing optionId and name", function () {
+            mockScope.filterOptions('Asia');
+            var filteredOptions = [{ optionId : 0, name : 'Asia/Dhaka' },
+                                    { optionId : 1, name : 'Asia/Shanghai' }];
+            expect(mockScope.filteredOptions).toEqual(filteredOptions);
+        });
+
+        it("fills input with given string", function () {
+            var str = "UTC";
+            mockScope.fillInput(str);
+            expect(mockScope.hideOptions).toEqual(true);
+            expect(mockScope.ngModel[mockScope.field]).toEqual(str);
+        });
+
+        it("sets a new optionIndex on mouse hover", function () {
+            mockScope.optionMouseover(1);
+            expect(mockScope.optionIndex).toEqual(1);
+        });
+
+    });
+});

--- a/test-main.js
+++ b/test-main.js
@@ -58,6 +58,7 @@ requirejs.config({
         "html2canvas": "bower_components/html2canvas/build/html2canvas.min",
         "moment": "bower_components/moment/moment",
         "moment-duration-format": "bower_components/moment-duration-format/lib/moment-duration-format",
+        "moment-timezone": "bower_components/moment-timezone/builds/moment-timezone-with-data",
         "saveAs": "bower_components/FileSaver.js/FileSaver.min",
         "screenfull": "bower_components/screenfull/dist/screenfull.min",
         "text": "bower_components/text/text",


### PR DESCRIPTION
Addresses #1273 
- Added `autocomplete` control. To use it just need to pass `options` as either an array of strings or an object with `name` and `value`.
- User will be able to set timezone via autocomplete control. Default timezone is UTC.

## Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y