### PR TITLE
[Build] Remove/reorganize version headers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,7 +85,7 @@ gulp.task('scripts', function () {
       ' * Built: ${timestamp}',
       ' * Revision: ${revision}',
       ' * Branch: ${branch}',
-      '*/\n'
+      ' */\n'
     ].join('\n');
 
     return gulp.src(paths.main)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,15 +78,7 @@ gulp.task('scripts', function () {
     var requirejsOptimize = require('gulp-requirejs-optimize');
     var replace = require('gulp-replace-task');
     var header = require('gulp-header');
-    var comment = [
-      '/**',
-      ' * Open MCT https://nasa.github.io/openmct/',
-      ' * Version: ${version}',
-      ' * Built: ${timestamp}',
-      ' * Revision: ${revision}',
-      ' * Branch: ${branch}',
-      ' */\n'
-    ].join('\n');
+    var comment = fs.readFileSync('src/about.frag');
 
     return gulp.src(paths.main)
         .pipe(sourcemaps.init())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,10 +81,10 @@ gulp.task('scripts', function () {
     var comment = [
       '/**',
       ' * Open MCT https://nasa.github.io/openmct/',
-      ' * Version: ${pkg.version}',
-      ' * Built: ${pkg.timestamp}',
-      ' * Revision: ${pkg.revision}',
-      ' * Branch: ${pkg.branch}',
+      ' * Version: ${version}',
+      ' * Built: ${timestamp}',
+      ' * Revision: ${revision}',
+      ' * Branch: ${branch}',
       '*/\n'
     ].join('\n');
 
@@ -93,7 +93,7 @@ gulp.task('scripts', function () {
         .pipe(requirejsOptimize(options.requirejsOptimize))
         .pipe(sourcemaps.write('.'))
         .pipe(replace(options.replace))
-        .pipe(header(comment, { pkg: options.replace.variables}))
+        .pipe(header(comment, options.replace.variables))
         .pipe(gulp.dest(paths.dist));
 });
 

--- a/src/about.frag
+++ b/src/about.frag
@@ -1,0 +1,7 @@
+/**
+ * Open MCT https://nasa.github.io/openmct/
+ * Version: ${version}
+ * Built: ${timestamp}
+ * Revision: ${revision}
+ * Branch: ${branch}
+ */

--- a/src/start.frag
+++ b/src/start.frag
@@ -20,14 +20,6 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-/**
- * Open MCT https://nasa.github.io/openmct/
- * Version @@version
- * Built @@timestamp
- * Revision @@revision
- * Branch @@branch
- */
-
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         define([], factory);


### PR DESCRIPTION
Small follow-on to #1598; removes obsolete comment from `start.frag`, moves version header into a separate file.

### Author Checklist

1. Changes address original issue? Y (completes work on #1541)
2. Unit tests included and/or updated with changes? N/A (changes to build only)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y