### PR TITLE
Review and merge no-keyframe-anims branch

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_messages.scss
+++ b/platform/commonUI/general/res/sass/controls/_messages.scss
@@ -368,7 +368,6 @@ body.desktop .t-message-list {
 .s-unsynced {
     $c: $colorPausedBg;
     border: 1px solid $c;
-    @include animTo($animName: pulsePaused, $propName: border-color, $propValStart: rgba($c, 0.8), $propValEnd: rgba($c, 0.5), $dur: $animPausedPulseDur, $dir: alternate, $count: infinite);
 }
 
 .s-status-timeconductor-unsynced {

--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -229,11 +229,11 @@ body.desktop .pane .mini-tab-icon.toggle-pane {
 
 .l-object-wrapper {
     padding: 0;
-    @include trans-prop-nice(padding, 0.25s);
-}
-
-.l-object-wrapper-inner {
-    @include trans-prop-nice-resize(0.25s);
+    @include trans-prop-nice((padding), 0.25s);
+    .l-edit-controls {
+        @include trans-prop-nice((height), 0.5s);
+        height: 0;
+    }
 }
 
 .object-browse-bar .s-button,
@@ -350,48 +350,14 @@ body.desktop {
 
 .s-status-editing {
     .l-object-wrapper {
-        $t2Dur: $browseToEditAnimMs;
-        $t1Dur: $t2Dur / 2;
-        $pulseDur: $editBorderPulseMs;
-        $bC0: rgba($colorEditAreaFg, 0.5);
-        $bC100: rgba($colorEditAreaFg, 1);
-
         background-color: $colorEditAreaBg;
         border-radius: $controlCr;
-        border: 1px dotted $bC0;
-        padding: 5px;
-
-        //// Transition 1
-        //@include keyframes(wrapperIn) {
-        //    from { border: 0px dotted transparent; padding: 0; }
-        //    to { border: 1px dotted $bC0; padding: 5px; }
-        //}
-        //
-        //// Do last
-        //@include keyframes(pulseNew) {
-        //    from  { border-color: $bC0; }
-        //    to { border-color: $bC100; }
-        //}
-
-        //@include animation-name(wrapperIn, pulseNew);
-        //@include animation-duration($t1Dur, $pulseDur);
-        //@include animation-delay(0s, $t1Dur + $t2Dur);
-        //@include animation-direction(normal, alternate);
-        //@include animation-fill-mode(both, none);
-        //@include animation-iteration-count(1, infinite);
-        //@include animation-timing-function(ease-in-out, linear);
-
+        border: 1px dotted $colorEditAreaFg;
+        padding: $interiorMargin;
 
         .l-edit-controls {
-            //height: 0;
             height: $ueEditToolBarH + $interiorMargin; margin-bottom: $interiorMargin;
             border-bottom: 1px solid $colorInteriorBorder;
-            // Transition 2: reveal edit controls
-            //@include keyframes(editIn) {
-            //    from { border-bottom: 0px solid transparent; height: 0; margin-bottom: 0; }
-            //    to { border-bottom: 1px solid $colorInteriorBorder; height: $ueEditToolBarH + $interiorMargin; margin-bottom: $interiorMargin; }
-            //}
-            //@include animToParams(editIn, $dur: $t2Dur, $delay: $t1Dur);
             .tool-bar {
                 right: $interiorMargin;
             }

--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -227,6 +227,11 @@ body.desktop .pane .mini-tab-icon.toggle-pane {
     top: $ueTopBarH + $interiorMarginLg;
 }
 
+.l-object-wrapper {
+    padding: 0;
+    @include trans-prop-nice(padding, 0.25s);
+}
+
 .l-object-wrapper-inner {
     @include trans-prop-nice-resize(0.25s);
 }
@@ -354,37 +359,39 @@ body.desktop {
         background-color: $colorEditAreaBg;
         border-radius: $controlCr;
         border: 1px dotted $bC0;
+        padding: 5px;
 
-        // Transition 1
-        @include keyframes(wrapperIn) {
-            from { border: 0px dotted transparent; padding: 0; }
-            to { border: 1px dotted $bC0; padding: 5px; }
-        }
+        //// Transition 1
+        //@include keyframes(wrapperIn) {
+        //    from { border: 0px dotted transparent; padding: 0; }
+        //    to { border: 1px dotted $bC0; padding: 5px; }
+        //}
+        //
+        //// Do last
+        //@include keyframes(pulseNew) {
+        //    from  { border-color: $bC0; }
+        //    to { border-color: $bC100; }
+        //}
 
-        // Do last
-        @include keyframes(pulseNew) {
-            from  { border-color: $bC0; }
-            to { border-color: $bC100; }
-        }
-
-        @include animation-name(wrapperIn, pulseNew);
-        @include animation-duration($t1Dur, $pulseDur);
-        @include animation-delay(0s, $t1Dur + $t2Dur);
-        @include animation-direction(normal, alternate);
-        @include animation-fill-mode(both, none);
-        @include animation-iteration-count(1, infinite);
-        @include animation-timing-function(ease-in-out, linear);
+        //@include animation-name(wrapperIn, pulseNew);
+        //@include animation-duration($t1Dur, $pulseDur);
+        //@include animation-delay(0s, $t1Dur + $t2Dur);
+        //@include animation-direction(normal, alternate);
+        //@include animation-fill-mode(both, none);
+        //@include animation-iteration-count(1, infinite);
+        //@include animation-timing-function(ease-in-out, linear);
 
 
         .l-edit-controls {
-            height: 0;
+            //height: 0;
+            height: $ueEditToolBarH + $interiorMargin; margin-bottom: $interiorMargin;
             border-bottom: 1px solid $colorInteriorBorder;
             // Transition 2: reveal edit controls
-            @include keyframes(editIn) {
-                from { border-bottom: 0px solid transparent; height: 0; margin-bottom: 0; }
-                to { border-bottom: 1px solid $colorInteriorBorder; height: $ueEditToolBarH + $interiorMargin; margin-bottom: $interiorMargin; }
-            }
-            @include animToParams(editIn, $dur: $t2Dur, $delay: $t1Dur);
+            //@include keyframes(editIn) {
+            //    from { border-bottom: 0px solid transparent; height: 0; margin-bottom: 0; }
+            //    to { border-bottom: 1px solid $colorInteriorBorder; height: $ueEditToolBarH + $interiorMargin; margin-bottom: $interiorMargin; }
+            //}
+            //@include animToParams(editIn, $dur: $t2Dur, $delay: $t1Dur);
             .tool-bar {
                 right: $interiorMargin;
             }


### PR DESCRIPTION
For #1603, removes processor intensive CSS keyframe animations:
- Removed animations associated with transitioning from browse to edit mode.
- Removed border-color animation used during edit mode. Chose not to reimplement animation via other means at this time.
- Other keyframe animations (such as .pulse used in the Play/Pause button) were left alone: they animate opacity of an object and weren't creating any processor issues when inspected via top.

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y, via inspection of Chrome CPU via top running in terminal
 