### PR TITLE
Fixed tabbing in overlay forms

### DIFF
--- a/platform/search/res/templates/search.html
+++ b/platform/search/res/templates/search.html
@@ -26,7 +26,7 @@
              ng-class="{ holder: !(ngModel.input === '' || ngModel.input === undefined) }">
             <div class="holder flex-elem grows">
                 <input class="search-input"
-                       type="text"
+                       type="text" tabindex="10000"
                        ng-model="ngModel.input"
                        ng-keyup="controller.search()"/>
                 <a class="clear-icon clear-input icon-x-in-circle"


### PR DESCRIPTION
Fixes #1569

The fix here involves tabindex. The search input has been set to a very high tabindex value, which will allow it to still be tabbable, but after other elements on screen, most notably form elements in the overlay. 

When Time Conductor is enabled, those form fields will be tabbed into after the elements in the overlay dialog. There does not appear to be any pure CSS way to limit tab indexing to a given container or context; most solutions I saw involve using JavaScript to "redirect" the tab target when leaving a given field. Here's an interesting article: https://bitsofco.de/accessible-modal-dialog/

### Author Checklist
 
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
