### PR TITLE
[Time Conductor] Enable time conductor in dev environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,27 @@
             openmct.install(openmct.plugins.Generator());
             openmct.install(openmct.plugins.ExampleImagery());
             openmct.install(openmct.plugins.UTCTimeSystem());
+            openmct.install(openmct.plugins.Conductor({
+                menuOptions: [
+                    {
+                        name: "Fixed",
+                        timeSystem: 'utc',
+                        bounds: {
+                            start: Date.now() - 30 * 60 * 1000,
+                            end: Date.now()
+                        }
+                    },
+                    {
+                        name: "Realtime",
+                        timeSystem: 'utc',
+                        clock: 'local',
+                        clockOffsets: {
+                            start: -25 * 60 * 1000,
+                            end: 5 * 60 * 1000
+                        }
+                    }
+                ]
+            }));
             openmct.time.clock('local', {start: -THIRTY_MINUTES, end: 0});
             openmct.time.timeSystem('utc');
             openmct.start();


### PR DESCRIPTION
Supports #1550 (using this change for debugging there)

Now that Time Conductor is more consistently in use, I think it would be useful to have it enabled by default in dev environments - it's the more common case.

### Author Checklist

1. Changes address original issue? N (but supports various Time-related issues)
2. Unit tests included and/or updated with changes? N (changes out of scope for unit tests)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

