### PR TITLE
Example historical imagery

### DIFF
--- a/example/imagery/plugin.js
+++ b/example/imagery/plugin.js
@@ -98,7 +98,7 @@ define([
                             url: IMAGE_SAMPLES[index]
                         });
                         index += 1;
-                    }, 1000);
+                    }, 5000);
 
                     return function (interval) {
                         clearInterval(interval);

--- a/example/imagery/plugin.js
+++ b/example/imagery/plugin.js
@@ -48,6 +48,56 @@ define([
                 "https://www.hq.nasa.gov/alsj/a16/AS16-117-18748.jpg"
             ];
 
+        function pointForTimestamp(timestamp) {
+            return {
+                utc: Math.floor(timestamp / 5000) * 5000,
+                url: IMAGE_SAMPLES[Math.floor(timestamp / 5000) % IMAGE_SAMPLES.length]
+            };
+        }
+
+        var realtimeProvider = {
+            supportsSubscribe: function (domainObject) {
+                return domainObject.type === 'example.imagery';
+            },
+            subscribe: function (domainObject, callback) {
+                var interval = setInterval(function () {
+                    callback(pointForTimestamp(Date.now()));
+                }, 5000);
+
+                return function (interval) {
+                    clearInterval(interval);
+                };
+            }
+        };
+
+        var historicalProvider = {
+            supportsRequest: function (domainObject, options) {
+                return domainObject.type === 'example.imagery'
+                    && options.strategy !== 'latest';
+            },
+            request: function (domainObject, options) {
+                var start = options.start;
+                var end = options.end;
+                var data = [];
+                while (start < end) {
+                    data.push(pointForTimestamp(start));
+                    start += 5000;
+                }
+                return Promise.resolve(data);
+            }
+        };
+
+        var ladProvider = {
+            supportsRequest: function (domainObject, options) {
+                return domainObject.type === 'example.imagery' &&
+                    options.strategy === 'latest';
+            },
+            request: function (domainObject, options) {
+                return Promise.resolve([pointForTimestamp(Date.now())]);
+            }
+        };
+
+
         return function install(openmct) {
             openmct.types.addType('example.imagery', {
                 key: 'example.imagery',
@@ -80,31 +130,9 @@ define([
                 }
             });
 
-            openmct.telemetry.addProvider({
-                supportsSubscribe: function (domainObject) {
-                    return domainObject.type === 'example.imagery';
-                },
-                subscribe: function (domainObject, callback) {
-                    var index = 0,
-                        end = IMAGE_SAMPLES.length,
-                        interval;
-
-                    interval = setInterval(function () {
-                        if (index >= end) {
-                            index = 0;
-                        }
-                        callback({
-                            utc: Date.now(),
-                            url: IMAGE_SAMPLES[index]
-                        });
-                        index += 1;
-                    }, 5000);
-
-                    return function (interval) {
-                        clearInterval(interval);
-                    };
-                }
-            });
+            openmct.telemetry.addProvider(realtimeProvider);
+            openmct.telemetry.addProvider(historicalProvider);
+            openmct.telemetry.addProvider(ladProvider);
         };
     }
 

--- a/platform/features/imagery/src/controllers/ImageryController.js
+++ b/platform/features/imagery/src/controllers/ImageryController.js
@@ -141,4 +141,3 @@ define(
         return ImageryController;
     }
 );
-

--- a/platform/features/imagery/src/controllers/ImageryController.js
+++ b/platform/features/imagery/src/controllers/ImageryController.js
@@ -76,6 +76,14 @@ define(
                         .getValueFormatter(metadata.valuesForHints(['image'])[0]);
                     this.unsubscribe = this.openmct.telemetry
                         .subscribe(this.domainObject, this.updateValues);
+                    this.openmct.telemetry
+                        .request(this.domainObject, {
+                            strategy: 'latest',
+                            size: 1
+                        })
+                        .then(function (values) {
+                            this.updateValues(values[0]);
+                        }.bind(this));
                 }.bind(this));
         };
 


### PR DESCRIPTION
Adds a historical and lad imagery provider to the example imagery source so that @prestonjcrowe can develop his historical view against this provider.

Updates the standard imagery view to request lad telemetry, and updates specs to cover this case.

# Author Checklist

1. Changes address original issue? Y (as reported here)
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

@VWoeltjen your way for integration.