### PR TITLE
[Resize] don't trigger callback after being destroyed

### DIFF
--- a/platform/commonUI/general/src/directives/MCTResize.js
+++ b/platform/commonUI/general/src/directives/MCTResize.js
@@ -83,13 +83,14 @@ define(
                 // Callback to fire after each timeout;
                 // update bounds and schedule another timeout
                 function onInterval() {
+                    if (!active) {
+                        return;
+                    }
                     fireEval({
                         width: element[0].offsetWidth,
                         height: element[0].offsetHeight
                     });
-                    if (active) {
-                        $timeout(onInterval, currentInterval(), false);
-                    }
+                    $timeout(onInterval, currentInterval(), false);
                 }
 
                 // Stop running in the background

--- a/platform/commonUI/general/test/directives/MCTResizeSpec.js
+++ b/platform/commonUI/general/test/directives/MCTResizeSpec.js
@@ -102,11 +102,16 @@ define(
                 // Broadcast a destroy event
                 mockScope.$on.mostRecentCall.args[1]();
 
+                testElement.offsetWidth = 300;
+                testElement.offsetHeight = 350;
+                mockScope.$eval.reset();
+
                 // Fire the timeout
                 mockTimeout.mostRecentCall.args[0]();
 
                 // Should NOT have scheduled another timeout
                 expect(mockTimeout.calls.length).toEqual(2);
+                expect(mockScope.$eval).not.toHaveBeenCalled();
             });
 
             it("triggers a digest cycle when size changes", function () {


### PR DESCRIPTION
Prevent MCTResize from triggering a callback after the scope has been destroyed.

Fixes https://github.com/nasa/openmct/issues/1509

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y

Note that circleci is still broken (#1639), working on a fix, but this does validate locally.  