### PR TITLE
[Open 1641] Change warnings to info messages

### DIFF
--- a/platform/framework/src/register/ServiceCompositor.js
+++ b/platform/framework/src/register/ServiceCompositor.js
@@ -75,6 +75,21 @@ define(
                 ].join(""));
             }
 
+            //Log an info: defaults to "no service provide by"
+            function info(extension, category, message) {
+                var msg = message || "No service provided by";
+                $log.info([
+                    msg,
+                    " ",
+                    category,
+                    " ",
+                    extension.key,
+                    " from bundle ",
+                    (extension.bundle || { path: "unknown bundle" }).path,
+                    "; skipping."
+                ].join(""));
+            }
+
             // Echo arguments; used to represent groups of non-built-in
             // extensions as a single dependency.
             function echoMany() {
@@ -161,13 +176,13 @@ define(
                     name = makeName("aggregator", service, index);
 
                 if (!service) {
-                    return warn(aggregator, "aggregator");
+                    return info(aggregator, "aggregator");
                 }
 
                 // Aggregators need other services to aggregate, otherwise they
                 // do nothing.
                 if (!latest[service]) {
-                    return warn(
+                    return info(
                         aggregator,
                         "aggregator",
                         "No services to aggregate for"

--- a/platform/framework/test/register/ServiceCompositorSpec.js
+++ b/platform/framework/test/register/ServiceCompositorSpec.js
@@ -195,7 +195,8 @@ define(
                 expect(mockApp.service).not.toHaveBeenCalled();
 
                 // Should have gotten one warning for each skipped component
-                expect(mockLog.warn.calls.length).toEqual(3);
+                expect(mockLog.warn.calls.length).toEqual(2);
+                expect(mockLog.info.calls.length).toEqual(1);
             });
 
             it("warns about and skips aggregators with zero providers", function () {
@@ -217,7 +218,7 @@ define(
                 expect(mockApp.service).not.toHaveBeenCalled();
 
                 // Should have gotten a warning
-                expect(mockLog.warn).toHaveBeenCalled();
+                expect(mockLog.info).toHaveBeenCalled();
             });
 
             it("warns about and skips decorators with nothing to decorate", function () {

--- a/platform/telemetry/src/TelemetryCapability.js
+++ b/platform/telemetry/src/TelemetryCapability.js
@@ -117,7 +117,7 @@ define(
                 } catch (e) {
                     // $injector should throw if telemetryService
                     // is unavailable or unsatisfiable.
-                    $log.warn("Telemetry service unavailable");
+                    $log.info("Telemetry service unavailable");
                     return (this.telemetryService = null);
                 }
             };
@@ -314,4 +314,3 @@ define(
         return TelemetryCapability;
     }
 );
-

--- a/platform/telemetry/src/TelemetryCapability.js
+++ b/platform/telemetry/src/TelemetryCapability.js
@@ -115,8 +115,6 @@ define(
                     return (this.telemetryService =
                         $injector.get("telemetryService"));
                 } catch (e) {
-                    // $injector should throw if telemetryService
-                    // is unavailable or unsatisfiable.
                     $log.info("Telemetry service unavailable");
                     return (this.telemetryService = null);
                 }

--- a/platform/telemetry/test/TelemetryCapabilitySpec.js
+++ b/platform/telemetry/test/TelemetryCapabilitySpec.js
@@ -199,7 +199,7 @@ define(
 
                 telemetry.requestData();
 
-                expect(mockLog.warn).toHaveBeenCalled();
+                expect(mockLog.info).toHaveBeenCalled();
             });
 
             it("if a new style telemetry source is available, use it", function () {


### PR DESCRIPTION
Modified the ServiceCompositor and TelemetryCapability to prevent sending warning messages to the console and send information messages instead. [nasa/openmct/issues/1641](https://github.com/nasa/openmct/issues/1641)
@larkin please take a look