### PR TITLE
[Duplicate] Allow custom properties when duplicating an object

### DIFF
--- a/platform/entanglement/bundle.js
+++ b/platform/entanglement/bundle.js
@@ -85,7 +85,6 @@ define([
                     "depends": [
                         "$log",
                         "policyService",
-                        "locationService",
                         "copyService",
                         "dialogService",
                         "notificationService"

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -140,7 +140,8 @@ define(
                 wizard.getFormStructure(),
                 wizard.getInitialFormValue()
             ).then(function (userInput) {
-                return copyService.perform(object, userInput.location, undefined, userInput);
+                var customModel = wizard.createModel(userInput);
+                return copyService.perform(object, userInput.location, undefined, customModel);
             }, function () {
                 return Promise.reject(new CancelError(CANCEL_MESSAGE));
             }.bind(this));

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -21,6 +21,8 @@
  *****************************************************************************/
 
 define(
+    // AbstractComposeAction used to be extended by CopyAction.
+    // Now used only for the few common parts left.
     ['./AbstractComposeAction', './CopyActionWizard', './CancelError',],
     function (AbstractComposeAction, CopyActionWizard, CancelError) {
 
@@ -148,9 +150,9 @@ define(
         };
 
         /**
-         * Executes the CopyAction. The CopyAction uses the default behaviour of
-         * the AbstractComposeAction, but extends it to support notification
-         * updates of progress on copy.
+         * Executes the CopyAction. The actual copy logic is contained within
+         * performBase, and perform extends it with notifications on overall
+         * progress.
          */
         CopyAction.prototype.perform = function () {
             var self = this;

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -140,7 +140,7 @@ define(
                 wizard.getFormStructure(),
                 wizard.getInitialFormValue()
             ).then(function (userInput) {
-                return copyService.perform(object, userInput.location);
+                return copyService.perform(object, userInput.location, undefined, userInput);
             }, function () {
                 return Promise.reject(new CancelError(CANCEL_MESSAGE));
             }.bind(this));

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -110,8 +110,6 @@ define(
 
         CopyAction.prototype.createWizard = function () {
             var self = this,
-                title = "Duplicate " + this.object.getModel().name + " To a Location",
-                label = "Duplicate To",
                 object = this.object,
                 copyService = this.copyService,
                 policyService = this.policyService;
@@ -124,12 +122,7 @@ define(
                     policyService.allow("action", self, newContext);
             };
 
-            return new CopyActionWizard(
-                this.object,
-                undefined,
-                validateLocation,
-                title,
-                label);
+            return new CopyActionWizard(this.object, undefined, validateLocation);
         };
 
         CopyAction.prototype.performBase = function () {

--- a/platform/entanglement/src/actions/CopyAction.js
+++ b/platform/entanglement/src/actions/CopyAction.js
@@ -35,7 +35,6 @@ define(
         function CopyAction(
             $log,
             policyService,
-            locationService,
             copyService,
             dialogService,
             notificationService,

--- a/platform/entanglement/src/actions/CopyActionWizard.js
+++ b/platform/entanglement/src/actions/CopyActionWizard.js
@@ -37,7 +37,6 @@ define(
         function CopyActionWizard(domainObject, parent, locationValidator) {
             this.type = domainObject.getCapability('type');
             this.model = domainObject.getModel();
-            this.domainObject = domainObject;
             this.properties = this.type.getProperties();
             this.parent = parent;
             this.locationValidator = locationValidator;
@@ -100,8 +99,7 @@ define(
                     return property.getValue(model);
                 });
 
-            // Include the createParent
-            formValue.createParent = this.parent;
+            formValue.location = this.parent;
 
             return formValue;
         };

--- a/platform/entanglement/src/actions/CopyActionWizard.js
+++ b/platform/entanglement/src/actions/CopyActionWizard.js
@@ -1,0 +1,111 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define(
+    function () {
+
+        /**
+         * A class for capturing user input data from an object creation
+         * dialog, and populating a domain object with that data.
+         *
+         * @param {DomainObject} domainObject the newly created object to
+         * populate with user input
+         * @param {DomainObject} parent the domain object to serve as
+         *        the initial parent for the created object, in the dialog
+         * @memberof platform/commonUI/browse
+         * @constructor
+         */
+        function CopyActionWizard(domainObject, parent, locationValidator, title, label) {
+            this.type = domainObject.getCapability('type');
+            this.model = domainObject.getModel();
+            this.domainObject = domainObject;
+            this.properties = this.type.getProperties();
+            this.parent = parent;
+            this.locationValidator = locationValidator;
+            this.title = title;
+            this.label = label;
+        }
+
+        /**
+         * Get the form model for this wizard; this is a description
+         * that will be rendered to an HTML form. See the
+         * platform/forms bundle
+         * @param {boolean} includeLocation if true, a 'location' section
+         * will be included that will allow the user to select the location
+         * of the newly created object, otherwise the .location property of
+         * the model will be used.
+         * @return {FormModel} formModel the form model to
+         *         show in the create dialog
+         */
+        CopyActionWizard.prototype.getFormStructure = function () {
+            return {
+                sections: [
+                    {
+                        name: 'Properties',
+                        rows: this.properties.map(function (property, index) {
+                            var row = Object.create(property.getDefinition());
+                            row.key = index;
+                            return row;
+                        }).filter(function (row) {
+                            return row && row.control;
+                        })
+                    },
+                    {
+                        name: 'Location',
+                        cssClass: 'grows',
+                        rows: [
+                            {
+                                name: this.label,
+                                control: 'locator',
+                                validate: this.locationValidator,
+                                key: 'location'
+                            }
+                        ]
+                    }
+                ],
+                name: this.title
+            };
+        };
+
+        /**
+         * Get the initial value for the form being described.
+         * This will include the values for all properties described
+         * in the structure.
+         *
+         * @returns {object} the initial value of the form
+         */
+        CopyActionWizard.prototype.getInitialFormValue = function () {
+            // Start with initial values for properties
+            var model = this.model,
+                formValue = this.properties.map(function (property) {
+                    return property.getValue(model);
+                });
+
+            // Include the createParent
+            formValue.createParent = this.parent;
+
+            return formValue;
+        };
+
+        return CopyActionWizard;
+    }
+);

--- a/platform/entanglement/src/actions/CopyActionWizard.js
+++ b/platform/entanglement/src/actions/CopyActionWizard.js
@@ -34,15 +34,15 @@ define(
          * @memberof platform/commonUI/browse
          * @constructor
          */
-        function CopyActionWizard(domainObject, parent, locationValidator, title, label) {
+        function CopyActionWizard(domainObject, parent, locationValidator) {
             this.type = domainObject.getCapability('type');
             this.model = domainObject.getModel();
             this.domainObject = domainObject;
             this.properties = this.type.getProperties();
             this.parent = parent;
             this.locationValidator = locationValidator;
-            this.title = title;
-            this.label = label;
+            this.title = "Duplicate " + this.model.name + " To a Location";
+            this.label = "Duplicate To";
         }
 
         /**

--- a/platform/entanglement/src/actions/CopyActionWizard.js
+++ b/platform/entanglement/src/actions/CopyActionWizard.js
@@ -22,18 +22,6 @@
 
 define(
     function () {
-
-        /**
-         * A class for capturing user input data from an object creation
-         * dialog, and populating a domain object with that data.
-         *
-         * @param {DomainObject} domainObject the newly created object to
-         * populate with user input
-         * @param {DomainObject} parent the domain object to serve as
-         *        the initial parent for the created object, in the dialog
-         * @memberof platform/commonUI/browse
-         * @constructor
-         */
         function CopyActionWizard(domainObject, parent, locationValidator) {
             this.type = domainObject.getCapability('type');
             this.model = domainObject.getModel();
@@ -44,17 +32,6 @@ define(
             this.label = "Duplicate To";
         }
 
-        /**
-         * Get the form model for this wizard; this is a description
-         * that will be rendered to an HTML form. See the
-         * platform/forms bundle
-         * @param {boolean} includeLocation if true, a 'location' section
-         * will be included that will allow the user to select the location
-         * of the newly created object, otherwise the .location property of
-         * the model will be used.
-         * @return {FormModel} formModel the form model to
-         *         show in the create dialog
-         */
         CopyActionWizard.prototype.getFormStructure = function () {
             return {
                 sections: [
@@ -85,13 +62,6 @@ define(
             };
         };
 
-        /**
-         * Get the initial value for the form being described.
-         * This will include the values for all properties described
-         * in the structure.
-         *
-         * @returns {object} the initial value of the form
-         */
         CopyActionWizard.prototype.getInitialFormValue = function () {
             // Start with initial values for properties
             var model = this.model,
@@ -100,8 +70,16 @@ define(
                 });
 
             formValue.location = this.parent;
-
             return formValue;
+        };
+
+        CopyActionWizard.prototype.createModel = function (formValue) {
+            var newModel = JSON.parse(JSON.stringify(this.model));
+            newModel.type = this.type.getKey();
+            this.properties.forEach(function (property, index) {
+                property.setValue(newModel, formValue[index]);
+            });
+            return newModel;
         };
 
         return CopyActionWizard;

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -78,7 +78,7 @@ define(
          * @returns a promise that will be completed with the clone of
          * domainObject when the duplication is successful.
          */
-        CopyService.prototype.perform = function (domainObject, parent, filter, cloneProperties) {
+        CopyService.prototype.perform = function (domainObject, parent, filter, cloneModel) {
             var policyService = this.policyService;
 
             // Combines caller-provided filter (if any) with the
@@ -96,7 +96,7 @@ define(
                     domainObject,
                     parent,
                     filterWithPolicy,
-                    cloneProperties,
+                    cloneModel,
                     this.$q
                 ).perform();
             } else {

--- a/platform/entanglement/src/services/CopyService.js
+++ b/platform/entanglement/src/services/CopyService.js
@@ -78,7 +78,7 @@ define(
          * @returns a promise that will be completed with the clone of
          * domainObject when the duplication is successful.
          */
-        CopyService.prototype.perform = function (domainObject, parent, filter) {
+        CopyService.prototype.perform = function (domainObject, parent, filter, cloneProperties) {
             var policyService = this.policyService;
 
             // Combines caller-provided filter (if any) with the
@@ -96,6 +96,7 @@ define(
                     domainObject,
                     parent,
                     filterWithPolicy,
+                    cloneProperties,
                     this.$q
                 ).perform();
             } else {

--- a/platform/entanglement/src/services/CopyTask.js
+++ b/platform/entanglement/src/services/CopyTask.js
@@ -37,9 +37,10 @@ define(
          * @param $q Angular's $q, for promises
          * @constructor
          */
-        function CopyTask(domainObject, parent, filter, $q) {
+        function CopyTask(domainObject, parent, filter, cloneProperties, $q) {
             this.domainObject = domainObject;
             this.parent = parent;
+            this.cloneProperties = cloneProperties;
             this.firstClone = undefined;
             this.$q = $q;
             this.deferred = undefined;

--- a/platform/entanglement/test/actions/CopyActionSpec.js
+++ b/platform/entanglement/test/actions/CopyActionSpec.js
@@ -152,7 +152,6 @@ define(
                     copyAction = new CopyAction(
                         mockLog,
                         policyService,
-                        locationService,
                         copyService,
                         dialogService,
                         notificationService,
@@ -212,7 +211,6 @@ define(
                     copyAction = new CopyAction(
                         mockLog,
                         policyService,
-                        locationService,
                         copyService,
                         dialogService,
                         notificationService,

--- a/platform/entanglement/test/actions/CopyActionSpec.js
+++ b/platform/entanglement/test/actions/CopyActionSpec.js
@@ -222,11 +222,11 @@ define(
                     expect(copyAction).toBeDefined();
                 });
 
-
                 it("performs copy immediately", function () {
                     copyAction.perform();
                     expect(copyService.perform)
                         .toHaveBeenCalledWith(selectedObject, newParent);
+                    expect(copyAction.createWizard).not.toHaveBeenCalled();
                 });
             });
         });

--- a/platform/entanglement/test/actions/CopyActionSpec.js
+++ b/platform/entanglement/test/actions/CopyActionSpec.js
@@ -48,9 +48,10 @@ define(
                 mockWizard,
                 mockFormStructure = "form_structure",
                 mockFormInitialValue = "initial_form_value",
+                mockFormUserInput,
                 mockLog,
                 abstractComposePromise,
-                progress = {phase: "copying", totalObjects: 10, processed: 1};
+                progress = { phase: "copying", totalObjects: 10, processed: 1 };
 
             beforeEach(function () {
                 policyService = jasmine.createSpyObj(
@@ -108,8 +109,12 @@ define(
                     success();
                 });
 
+                mockFormUserInput = {
+                    location: newParentLocation
+                };
+
                 userInputPromise.then.andCallFake(function (callback) {
-                    callback({ location: newParentLocation });
+                    callback(mockFormUserInput);
                     return abstractComposePromise;
                 });
 
@@ -122,7 +127,7 @@ define(
                 mockDialog = jasmine.createSpyObj("dialog", ["dismiss"]);
                 dialogService.showBlockingMessage.andReturn(mockDialog);
 
-                mockWizard = jasmine.createSpyObj('wizard', 
+                mockWizard = jasmine.createSpyObj('wizard',
                     ['getFormStructure', 'getInitialFormValue']);
                 mockWizard.getFormStructure.andReturn(mockFormStructure);
                 mockWizard.getInitialFormValue.andReturn(mockFormInitialValue);
@@ -190,7 +195,11 @@ define(
                             .args[0](newParent);
 
                         expect(copyService.perform)
-                            .toHaveBeenCalledWith(selectedObject, newParentLocation);
+                            .toHaveBeenCalledWith(
+                                selectedObject, 
+                                newParentLocation,
+                                undefined,
+                                mockFormUserInput);
                     });
 
                     it("notifies the user of progress", function () {

--- a/platform/entanglement/test/actions/CopyActionWizardSpec.js
+++ b/platform/entanglement/test/actions/CopyActionWizardSpec.js
@@ -19,7 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-// TODO: Check for validator in the CopyActionSpec
+
 define(
     [
         '../../src/actions/CopyActionWizard',

--- a/platform/entanglement/test/actions/CopyActionWizardSpec.js
+++ b/platform/entanglement/test/actions/CopyActionWizardSpec.js
@@ -1,0 +1,125 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+// TODO: Check for validator in the CopyActionSpec
+define(
+    [
+        '../../src/actions/CopyActionWizard',
+    ],
+    function (CopyActionWizard) {
+
+        describe("Copy Action Wizard", function () {
+            var copyActionWizard,
+                mockDomainObject,
+                mockParent,
+                mockValidator,
+                mockType,
+                mockProperties,
+                mockModel;
+
+            beforeEach(function () {
+                mockParent = {
+                    name: "mock parent"
+                };
+
+                mockModel = {
+                    name: "mock model"
+                };
+
+                mockProperties = [
+                    {
+                        getDefinition: function () {
+                            return { name: "property 1 definition", control: undefined };
+                        },
+
+                        getValue: function (model) {
+                            return "property 1 value";
+                        }
+                    },
+                    {
+                        getDefinition: function () {
+                            return { name: "property 2 definition", control: {} };
+                        },
+
+                        getValue: function (model) {
+                            return "property 2 value";
+                        }
+                    }
+                ];
+
+                mockType = jasmine.createSpyObj("mockType", ["getProperties"]);
+                mockType.getProperties.andReturn(mockProperties);
+
+                mockDomainObject = jasmine.createSpyObj('mockDomainObject',
+                    ["getCapability", "getModel"]);
+
+                mockDomainObject.getCapability.andCallFake(function (capability) {
+                    if (capability === "type") {
+                        return mockType;
+                    }
+                    return undefined;
+                });
+
+                mockDomainObject.getModel.andReturn(mockModel);
+
+                mockValidator = function () {
+                    return true;
+                };
+
+                copyActionWizard = new CopyActionWizard(
+                    mockDomainObject,
+                    mockParent,
+                    mockValidator
+                );
+            });
+
+            it("initializes successfully", function () {
+                expect(copyActionWizard).toBeDefined();
+            });
+
+            it("creates the expected form structure", function () {
+                var form = copyActionWizard.getFormStructure();
+                expect(form.sections).toBeDefined();
+                expect(form.sections.length).toBe(2);
+
+                expect(form.sections[0].name).toBe("Properties");
+                expect(form.sections[0].rows.length).toBe(1);
+                expect(form.sections[0].rows[0].name).toBe("property 2 definition");
+
+                expect(form.sections[1].name).toBe("Location");
+                expect(form.sections[1].rows.length).toBe(1);
+                expect(form.sections[1].rows[0].name).toBe("Duplicate To");
+                expect(form.sections[1].rows[0].validate).toBe(mockValidator);
+                expect(form.sections[1].rows[0].control).toBe("locator");
+                expect(form.sections[1].rows[0].key).toBe("location");
+
+                expect(form.name).toBe("Duplicate " + mockModel.name + " To a Location");
+            });
+
+            it("populates initial data accordingly", function () {
+                var value = copyActionWizard.getInitialFormValue();
+                expect(value[0]).toBe("property 1 value");
+                expect(value[1]).toBe("property 2 value");
+                expect(value.location).toBe(mockParent);
+            });
+        });
+    }
+);

--- a/platform/entanglement/test/services/CopyTaskSpec.js
+++ b/platform/entanglement/test/services/CopyTaskSpec.js
@@ -140,10 +140,7 @@ define(
                 mockDeferred.resolve.andCallFake(function (value) {
                     mockDeferred.promise = synchronousPromise(value);
                 });
-
-
             });
-
 
             describe("produces models which", function () {
                 var model;
@@ -153,6 +150,7 @@ define(
                         mockDomainObject,
                         mockParentObject,
                         mockFilter,
+                        undefined,
                         mockQ
                     );
 
@@ -214,6 +212,7 @@ define(
                         mockComposingObject,
                         mockParentObject,
                         mockFilter,
+                        undefined,
                         mockQ
                     );
 


### PR DESCRIPTION
This almost solves #604. Custom properties are settable, but it lacks proper test coverage, some cleanup is needed, comments need adding/changing and any other changes that come up during this review. 
It can be seen in action in [**this gif**](https://gfycat.com/DifferentRipeLadybird).

Since I had most of the changes available locally, I went ahead and got this out of the way so as to not hold the issue any longer.

See the original issue for the reasoning behind my decisions. There are some things I want to ask about especially:

1) I added a separate CopyActionWizard to keep custom properties input simple. This wizard is almost 100% identical to the CreateWizard. The two have different purposes (in that they're used for different purposes, but both create a model), but finding a way to merge them together would get rid of that extra Spec file. Any thoughts on what the best approach here would be?
A `ModelBuildingWizard` maybe, with the sole purpose of taking user input and building a model with it? That could cover both cases successfully I think.

2) Duplicate always points to the root of the tree initially when picking a location (and I think it always did this). Do we want to point to the current parent instead?