### PR TITLE
[LADTable] es6 etch LAD table

### DIFF
--- a/example/generator/GeneratorProvider.js
+++ b/example/generator/GeneratorProvider.js
@@ -55,6 +55,10 @@ define([
 
         var workerRequest = {};
 
+        if (!request) {
+            request = {};
+        }
+
         props.forEach(function (prop) {
             if (domainObject.telemetry && domainObject.telemetry.hasOwnProperty(prop)) {
                 workerRequest[prop] = domainObject.telemetry[prop];

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <title></title>
-    <script src="bower_components/requirejs/require.js">
+    <script src="node_modules/cajon/cajon.js">
     </script>
     <script>
         var THIRTY_MINUTES = 30 * 60 * 1000;
@@ -43,6 +43,7 @@
             openmct.install(openmct.plugins.Generator());
             openmct.install(openmct.plugins.ExampleImagery());
             openmct.install(openmct.plugins.UTCTimeSystem());
+            openmct.install(openmct.plugins.LADTable());
             openmct.install(openmct.plugins.Conductor({
                 menuOptions: [
                     {

--- a/openmct.js
+++ b/openmct.js
@@ -48,7 +48,20 @@ requirejs.config({
         "d3-format": "node_modules/d3-format/build/d3-format.min",
         "d3-interpolate": "node_modules/d3-interpolate/build/d3-interpolate.min",
         "d3-time": "node_modules/d3-time/build/d3-time.min",
-        "d3-time-format": "node_modules/d3-time-format/build/d3-time-format.min"
+        "d3-time-format": "node_modules/d3-time-format/build/d3-time-format.min",
+        "es6": "node_modules/requirejs-babel-plugin/es6",
+        "babel": "node_modules/babel-standalone/babel"
+    },
+    map: {
+        "*": {
+            etch: "es6!node_modules/etch/dist/index"
+        }
+    },
+    babel: {
+        presets: ['es2015'],
+        plugins: [
+            'transform-es2015-modules-amd'
+        ]
     },
     "shim": {
         "angular": {
@@ -71,19 +84,6 @@ requirejs.config({
         },
         "zepto": {
             "exports": "Zepto"
-        },
-        "lodash": {
-            "exports": "lodash"
-        },
-        "d3-selection": {
-            "exports": "d3-selection"
-        },
-        "d3-scale": {
-            "deps": ["d3-array", "d3-collection", "d3-color", "d3-format", "d3-interpolate", "d3-time", "d3-time-format"],
-            "exports": "d3-scale"
-        },
-        "d3-axis": {
-            "exports": "d3-axis"
         }
     }
 });

--- a/package.json
+++ b/package.json
@@ -15,10 +15,14 @@
     "d3-time-format": "^2.0.3",
     "express": "^4.13.1",
     "minimist": "^1.1.1",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "requirejs-babel-plugin": "^0.4.0"
   },
   "devDependencies": {
+    "babel-standalone": "^6.25.0",
     "bower": "^1.7.7",
+    "cajon": "^0.4.3",
+    "etch": "^0.12.5",
     "git-rev-sync": "^1.4.0",
     "glob": ">= 3.0.0",
     "gulp": "^3.9.0",

--- a/src/plugins/ladTable/lad-table-item.js
+++ b/src/plugins/ladTable/lad-table-item.js
@@ -1,0 +1,72 @@
+import etch from 'etch';
+
+class LADTableItem {
+    constructor (props, children) {
+        this.props = props;
+        this.props.values = props.values || {
+            'name': props.domainObject.name,
+            'timestamp': '---',
+            'value': '---',
+            'valueClass': ''
+        };
+        etch.initialize(this);
+        this.metadata = props.openmct.telemetry.getMetadata(props.domainObject);
+        this.valueMetadata = this.metadata.valuesForHints(['range'])[0];
+        this.valueFormat = props.openmct.telemetry.getValueFormatter(this.valueMetadata);
+        this.limitEvaluator = props.openmct.telemetry.limitEvaluator(props.domainObject);
+        this.updateTimeSystem(props.openmct.time.timeSystem());
+
+        this.stopWatchingMutation = props
+            .openmct
+            .objects
+            .observe(props.domainObject, 'name', this.onNameChange.bind(this));
+        this.unsubscribe = props
+            .openmct
+            .telemetry
+            .subscribe(props.domainObject, this.onDatum.bind(this));
+        props.openmct
+            .telemetry
+            .request(props.domainObject, {strategy: 'latest'})
+            .then((values) => values.forEach(this.onDatum, this))
+    }
+    updateTimeSystem (timeSystem) {
+        var timeValue = this.metadata.value(timeSystem.key);
+        this.timestampFormat = this.props.openmct.telemetry.getValueFormatter(timeValue);
+        etch.update(this);
+    }
+    onNameChange (name) {
+        this.props.values.name = name;
+        etch.update(this);
+    }
+    updateValues () {
+        this.props.values.timestamp = this.timestampFormat.format(this.datum);
+        this.props.values.value = this.valueFormat.format(this.datum);
+        const limit = this.limitEvaluator.evaluate(this.datum, this.valueMetadata);
+        if (limit) {
+            this.props.values.valueClass = limit.cssClass;
+        } else {
+            this.props.values.valueClass = '';
+        }
+    }
+    onDatum (datum) {
+        this.datum = datum;
+        this.updateValues();
+        etch.update(this);
+    }
+    render () {
+        return etch.dom('tr', null,
+            etch.dom('td', null, `${this.props.values.name}`),
+            etch.dom('td', null, `${this.props.values.timestamp}`),
+            etch.dom('td', {className: this.props.values.valueClass}, `${this.props.values.value}`)
+        );
+    }
+    update (props, children) {
+        return etch.update(this)
+    }
+    destroy () {
+        this.stopWatchingMutation();
+        this.unsubscribe();
+    }
+}
+
+export default LADTableItem

--- a/src/plugins/ladTable/lad-table.js
+++ b/src/plugins/ladTable/lad-table.js
@@ -1,0 +1,63 @@
+import etch from 'etch';
+
+import LADTableItem from 'es6!./lad-table-item';
+
+class LADTable {
+    constructor (properties, children) {
+        this.props = properties;
+        this.props.headers = this.props.headers || [
+            'Name',
+            'Timestamp',
+            'Value'
+        ];
+        this.props.children = this.props.children || [];
+        this.composition = this.props
+            .openmct
+            .composition
+            .get(this.props.domainObject);
+        this.composition.on('add', this.addChild, this);
+        this.composition.on('remove', this.removeChild, this);
+        etch.initialize(this);
+        this.composition.load();
+    }
+    render () {
+        return etch.dom('table', {},
+            etch.dom('thead', null,
+                etch.dom('tr', null,
+                     this.props.headers.map((h) => etch.dom('th', null, h))
+                )
+            ),
+            etch.dom('tbody', null,
+                this.props.children.map((c) => etch.dom(LADTableItem, {
+                    domainObject: c,
+                    key: c.identifier,
+                    headers: this.props.headers,
+                    openmct: this.props.openmct
+                }))
+            )
+        );
+    }
+    destroy () {
+        this.composition.off('add', this.addChild, this);
+        this.composition.off('remove', this.removeChild, this);
+        delete this.composition;
+        etch.destroy(this);
+    }
+    addChild (child) {
+        this.props.children.push(child);
+        etch.update(this);
+    }
+    removeChild (cid) {
+        this.props.children = this.props.children.filter(function (c) {
+            return !(c.identifier.key === cid.key && c.identifier.namespace === cid.namespace)
+        });
+        etch.update(this);
+    }
+    update (props, children) {
+        this.domainObject = properties.domainObject;
+        this.children = properties.children || [];
+        return etch.update(this)
+    }
+}
+
+export default LADTable

--- a/src/plugins/ladTable/plugin.js
+++ b/src/plugins/ladTable/plugin.js
@@ -1,0 +1,44 @@
+
+import LADTable from 'es6!./lad-table';
+
+module.exports = function LADTablePlugin() {
+    return function install(openmct) {
+
+        openmct.types.addType('view.latest-value-table', {
+            name: 'Latest Value Table',
+            description: 'A table that shows the latest values of all telemetry points contained within.',
+            key: 'view.latest-value-table',
+            cssClass: 'icon-tabular-lad',
+            creatable: true,
+            initialize: function (obj) {
+                obj.composition = [];
+            }
+        });
+
+        openmct.mainViews.addProvider({
+            name: 'Latest Value Table',
+            cssClass: 'icon-tabular-lad',
+            canView: function (d) {
+                return d.type === 'view.latest-value-table' && 150;
+            },
+            view: function (domainObject) {
+
+                var listView = new LADTable({
+                    domainObject: domainObject,
+                    openmct: openmct
+                });
+
+                return {
+                    show: function (container) {
+                        container.appendChild(listView.element);
+                    },
+                    destroy: function (container) {
+                        listView.destroy();
+                    }
+                };
+            }
+        });
+    };
+};
+
+

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -26,14 +26,16 @@ define([
     '../../example/generator/plugin',
     '../../platform/features/autoflow/plugin',
     './timeConductor/plugin',
-    '../../example/imagery/plugin'
+    '../../example/imagery/plugin',
+    'es6!./ladTable/plugin'
 ], function (
     _,
     UTCTimeSystem,
     GeneratorPlugin,
     AutoflowPlugin,
     TimeConductorPlugin,
-    ExampleImagery
+    ExampleImagery,
+    LADTable,
 ) {
     var bundleMap = {
         CouchDB: 'platform/persistence/couch',
@@ -116,6 +118,8 @@ define([
     };
 
     plugins.ExampleImagery = ExampleImagery;
+
+    plugins.LADTable = LADTable;
 
     return plugins;
 });


### PR DESCRIPTION
@luisschubert @adoubekk @prestonjcrowe take a look at this.  Looking for general inputs.

This is experimental usage of atom/etch for components.  Here we use etch and have to change multiple parts of the loader tooling to support es6 usage.  I didn't use JSX because I had some trouble getting it working: that could be a further experiment.

Add a basic LAD table, shows all containing telemetry elements in a single
table.  For each point, it shows the latest timestamp and value, and it updates in real time.

Link to the non-es6 implementation: https://github.com/nasa/openmct/pull/1651

