### PR TITLE
[LADTable] Add basic LAD table

### DIFF
--- a/example/generator/GeneratorProvider.js
+++ b/example/generator/GeneratorProvider.js
@@ -55,6 +55,10 @@ define([
 
         var workerRequest = {};
 
+        if (!request) {
+            request = {};
+        }
+
         props.forEach(function (prop) {
             if (domainObject.telemetry && domainObject.telemetry.hasOwnProperty(prop)) {
                 workerRequest[prop] = domainObject.telemetry[prop];

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
             openmct.install(openmct.plugins.AutoflowView({
                 type: "telemetry.panel"
             }));
+            openmct.install(openmct.plugins.LADTable());
             openmct.install(openmct.plugins.Conductor({
                 menuOptions: [
                     {

--- a/openmct.js
+++ b/openmct.js
@@ -49,7 +49,8 @@ requirejs.config({
         "d3-format": "node_modules/d3-format/build/d3-format.min",
         "d3-interpolate": "node_modules/d3-interpolate/build/d3-interpolate.min",
         "d3-time": "node_modules/d3-time/build/d3-time.min",
-        "d3-time-format": "node_modules/d3-time-format/build/d3-time-format.min"
+        "d3-time-format": "node_modules/d3-time-format/build/d3-time-format.min",
+        "etch": "node_modules/etch-standalone/dist/etch-standalone.min"
     },
     "shim": {
         "angular": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "bower": "^1.7.7",
+    "etch-standalone": "^0.12.5",
     "git-rev-sync": "^1.4.0",
     "glob": ">= 3.0.0",
     "gulp": "^3.9.1",

--- a/src/api/telemetry/LegacyTelemetryProvider.js
+++ b/src/api/telemetry/LegacyTelemetryProvider.js
@@ -148,7 +148,9 @@ define([
         var limitEvaluator = oldObject.getCapability("limit");
 
         if (!limitEvaluator) {
-            return;
+            return {
+                evaluate: function () {}
+            };
         }
 
         return {

--- a/src/plugins/ladTable/LADTable.js
+++ b/src/plugins/ladTable/LADTable.js
@@ -1,0 +1,75 @@
+define([
+    './LADTableItem',
+    'etch'
+], function (
+    LADTableItem,
+    etch
+) {
+
+    function LADTable(properties, children) {
+        this.props = properties;
+        this.props.headers = this.props.headers || [
+            'Name',
+            'Timestamp',
+            'Value'
+        ];
+        this.props.children = this.props.children || [];
+        this.composition = this.props
+            .openmct
+            .composition
+            .get(this.props.domainObject);
+        this.composition.on('add', this.addChild, this);
+        this.composition.on('remove', this.removeChild, this);
+        etch.initialize(this);
+        this.composition.load();
+    }
+
+
+    LADTable.prototype.render = function () {
+        return etch.dom('table', {},
+            etch.dom('thead', null,
+                etch.dom('tr', null, this.props.headers.map(function (h) {
+                    return etch.dom('th', null, h);
+                }, this))
+            ),
+            etch.dom('tbody', null, this.props.children.map(function (c) {
+                return etch.dom(LADTableItem, {
+                    domainObject: c,
+                    key: c.identifier,
+                    headers: this.props.headers,
+                    openmct: this.props.openmct
+                });
+            }, this))
+        );
+    };
+
+    LADTable.prototype.destroy = function () {
+        this.composition.off('add', this.addChild, this);
+        this.composition.off('remove', this.removeChild, this);
+        delete this.composition;
+        etch.destroy(this);
+    };
+
+    LADTable.prototype.addChild = function (child) {
+        this.props.children.push(child);
+        etch.update(this);
+    };
+
+    LADTable.prototype.removeChild = function (cid) {
+        this.props.children = this.props.children.filter(function (c) {
+            return !(c.identifier.key === cid.key &&
+                     c.identifier.namespace === cid.namespace);
+        });
+        etch.update(this);
+    };
+
+    LADTable.prototype.update = function (props, children) {
+        this.domainObject = properties.domainObject;
+        this.children = properties.children || [];
+        return etch.update(this);
+    };
+
+    return LADTable;
+});
+
+

--- a/src/plugins/ladTable/LADTableItem.js
+++ b/src/plugins/ladTable/LADTableItem.js
@@ -1,0 +1,81 @@
+define([
+    'etch'
+], function (
+    etch
+) {
+    function LADTableItem(props, children) {
+        this.props = props;
+        this.props.values = props.values || {
+            'name': props.domainObject.name,
+            'timestamp': '---',
+            'value': '---',
+            'valueClass': ''
+        };
+        etch.initialize(this);
+        this.metadata = props.openmct.telemetry.getMetadata(props.domainObject);
+        this.valueMetadata = this.metadata.valuesForHints(['range'])[0];
+        this.valueFormat = props.openmct.telemetry.getValueFormatter(this.valueMetadata);
+        this.limitEvaluator = props.openmct.telemetry.limitEvaluator(props.domainObject);
+        this.updateTimeSystem(props.openmct.time.timeSystem());
+
+        this.stopWatchingMutation = props
+            .openmct
+            .objects
+            .observe(props.domainObject, 'name', this.onNameChange.bind(this));
+        this.unsubscribe = props
+            .openmct
+            .telemetry
+            .subscribe(props.domainObject, this.onDatum.bind(this));
+        props.openmct
+            .telemetry
+            .request(props.domainObject, {strategy: 'latest'})
+            .then((values) => values.forEach(this.onDatum, this))
+    }
+
+    LADTableItem.prototype.updateTimeSystem = function (timeSystem) {
+        var timeValue = this.metadata.value(timeSystem.key);
+        this.timestampFormat = this.props.openmct.telemetry.getValueFormatter(timeValue);
+        etch.update(this);
+    };
+
+    LADTableItem.prototype.onNameChange = function (name) {
+        this.props.values.name = name;
+        etch.update(this);
+    };
+
+    LADTableItem.prototype.updateValues = function () {
+        this.props.values.timestamp = this.timestampFormat.format(this.datum);
+        this.props.values.value = this.valueFormat.format(this.datum);
+        const limit = this.limitEvaluator.evaluate(this.datum, this.valueMetadata);
+        if (limit) {
+            this.props.values.valueClass = limit.cssClass;
+        } else {
+            this.props.values.valueClass = '';
+        }
+    };
+
+    LADTableItem.prototype.onDatum = function (datum) {
+        this.datum = datum;
+        this.updateValues();
+        etch.update(this);
+    };
+
+    LADTableItem.prototype.render = function () {
+        return etch.dom('tr', null,
+            etch.dom('td', null, `${this.props.values.name}`),
+            etch.dom('td', null, `${this.props.values.timestamp}`),
+            etch.dom('td', {className: this.props.values.valueClass}, `${this.props.values.value}`)
+        );
+    };
+
+    LADTableItem.prototype.update = function (props, children) {
+        return etch.update(this)
+    };
+
+    LADTableItem.prototype.destroy = function () {
+        this.stopWatchingMutation();
+        this.unsubscribe();
+    };
+
+    return LADTableItem;
+});

--- a/src/plugins/ladTable/LADTableItem.js
+++ b/src/plugins/ladTable/LADTableItem.js
@@ -21,7 +21,7 @@ define([
         this.stopWatchingMutation = props
             .openmct
             .objects
-            .observe(props.domainObject, 'name', this.onNameChange.bind(this));
+            .observe(props.domainObject, '*', this.onNameChange.bind(this));
         this.unsubscribe = props
             .openmct
             .telemetry
@@ -38,8 +38,8 @@ define([
         etch.update(this);
     };
 
-    LADTableItem.prototype.onNameChange = function (name) {
-        this.props.values.name = name;
+    LADTableItem.prototype.onNameChange = function (domainObject) {
+        this.props.values.name = domainObject.name;
         etch.update(this);
     };
 

--- a/src/plugins/ladTable/LADTableItem.js
+++ b/src/plugins/ladTable/LADTableItem.js
@@ -29,7 +29,9 @@ define([
         props.openmct
             .telemetry
             .request(props.domainObject, {strategy: 'latest'})
-            .then((values) => values.forEach(this.onDatum, this))
+            .then(function (values) {
+                values.forEach(this.onDatum, this)
+            }.bind(this));
     }
 
     LADTableItem.prototype.updateTimeSystem = function (timeSystem) {
@@ -62,9 +64,9 @@ define([
 
     LADTableItem.prototype.render = function () {
         return etch.dom('tr', null,
-            etch.dom('td', null, `${this.props.values.name}`),
-            etch.dom('td', null, `${this.props.values.timestamp}`),
-            etch.dom('td', {className: this.props.values.valueClass}, `${this.props.values.value}`)
+            etch.dom('td', null, "" + this.props.values.name),
+            etch.dom('td', null, "" + this.props.values.timestamp),
+            etch.dom('td', {className: this.props.values.valueClass}, "" + this.props.values.value)
         );
     };
 

--- a/src/plugins/ladTable/plugin.js
+++ b/src/plugins/ladTable/plugin.js
@@ -1,0 +1,51 @@
+define([
+    './LADTable'
+], function (
+    LADTable
+) {
+
+    function LADTablePlugin() {
+
+
+        return function install(openmct) {
+
+            openmct.types.addType('view.latest-value-table', {
+                name: 'Latest Value Table',
+                description: 'A table that shows the latest values of all telemetry points contained within.',
+                key: 'view.latest-value-table',
+                cssClass: 'icon-tabular-lad',
+                creatable: true,
+                initialize: function (obj) {
+                    obj.composition = [];
+                }
+            });
+
+            openmct.mainViews.addProvider({
+                name: 'Latest Value Table',
+                cssClass: 'icon-tabular-lad',
+                canView: function (d) {
+                    return d.type === 'view.latest-value-table' && 150;
+                },
+                view: function (domainObject) {
+
+                    var listView = new LADTable({
+                        domainObject: domainObject,
+                        openmct: openmct
+                    });
+
+                    return {
+                        show: function (container) {
+                            container.appendChild(listView.element);
+                        },
+                        destroy: function (container) {
+                            listView.destroy();
+                        }
+                    };
+                }
+            });
+        };
+    }
+
+    return LADTablePlugin;
+});
+

--- a/src/plugins/ladTable/plugin.js
+++ b/src/plugins/ladTable/plugin.js
@@ -20,11 +20,15 @@ define([
                 }
             });
 
-            openmct.mainViews.addProvider({
+            openmct.objectViews.addProvider({
                 name: 'Latest Value Table',
+                key:'latest-value-table',
                 cssClass: 'icon-tabular-lad',
                 canView: function (d) {
-                    return d.type === 'view.latest-value-table' && 150;
+                    return d.type === 'view.latest-value-table';
+                },
+                priority: function () {
+                    return 150;
                 },
                 view: function (domainObject) {
 

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -30,7 +30,8 @@ define([
     '../../platform/import-export/bundle',
     './summaryWidget/plugin',
     './URLIndicatorPlugin/URLIndicatorPlugin',
-    './telemetryMean/plugin'
+    './telemetryMean/plugin',
+    './ladTable/plugin'
 ], function (
     _,
     UTCTimeSystem,
@@ -41,7 +42,8 @@ define([
     ImportExport,
     SummaryWidget,
     URLIndicatorPlugin,
-    TelemetryMean
+    TelemetryMean,
+    LADTable
 ) {
     var bundleMap = {
         CouchDB: 'platform/persistence/couch',
@@ -129,6 +131,8 @@ define([
     plugins.SummaryWidget = SummaryWidget;
     plugins.TelemetryMean = TelemetryMean;
     plugins.URLIndicatorPlugin = URLIndicatorPlugin;
+
+    plugins.LADTable = LADTable;
 
     return plugins;
 });


### PR DESCRIPTION
@luisschubert @adoubekk @prestonjcrowe take a look, looking for general inputs.  Looking for general inputs.

This is experimental usage of atom/etch for components.  Here we use etch-standalone so that we aren't forced to use babel, and we skip JSX for simplicity.

Add a basic lad table, shows all containing telemetry elements in a single table that automatically resizes to fit.  For each point, it shows the latest timestamp and value, and it updates in real time.

Link to the ES6 implementation: https://github.com/nasa/openmct/pull/1650

