### PR TITLE
[Telemetry API] many subscribes -> one provider subscribe

### DIFF
--- a/platform/telemetry/src/TelemetryCapability.js
+++ b/platform/telemetry/src/TelemetryCapability.js
@@ -213,7 +213,8 @@ define(
 
             var metadata = telemetryAPI.getMetadata(domainObject);
             var defaultDomain = metadata.valuesForHints(['domain'])[0].source;
-            var defaultRange = metadata.valuesForHints(['range'])[0].source;
+            var defaultRange = metadata.valuesForHints(['range'])[0];
+            defaultRange = defaultRange ? defaultRange.source : undefined;
 
             var isLegacyProvider = telemetryAPI.findRequestProvider(domainObject) ===
                 telemetryAPI.legacyProvider;
@@ -275,7 +276,8 @@ define(
 
             var metadata = telemetryAPI.getMetadata(domainObject);
             var defaultDomain = metadata.valuesForHints(['domain'])[0].source;
-            var defaultRange = metadata.valuesForHints(['range'])[0].source;
+            var defaultRange = metadata.valuesForHints(['range'])[0];
+            defaultRange = defaultRange ? defaultRange.source : undefined;
 
             var isLegacyProvider = telemetryAPI.findSubscriptionProvider(domainObject) ===
                 telemetryAPI.legacyProvider;

--- a/src/api/telemetry/TelemetryAPISpec.js
+++ b/src/api/telemetry/TelemetryAPISpec.js
@@ -1,0 +1,281 @@
+define([
+    './TelemetryAPI'
+], function (
+    TelemetryAPI
+) {
+    describe('Telemetry API', function () {
+        var openmct;
+        var telemetryAPI;
+
+        beforeEach(function () {
+            openmct = {
+                time: jasmine.createSpyObj('timeAPI', [
+                    'timeSystem',
+                    'bounds'
+                ])
+            };
+            openmct.time.timeSystem.andReturn({key: 'system'});
+            openmct.time.bounds.andReturn({start: 0, end: 1});
+            telemetryAPI = new TelemetryAPI(openmct);
+
+        });
+
+        describe('telemetry providers', function () {
+            var telemetryProvider,
+                domainObject;
+
+            beforeEach(function () {
+                telemetryProvider = jasmine.createSpyObj('telemetryProvider', [
+                    'supportsSubscribe',
+                    'subscribe',
+                    'supportsRequest',
+                    'request'
+                ]);
+                domainObject = {
+                    identifier: {
+                        key: 'a',
+                        namespace: 'b'
+                    },
+                    type: 'sample-type'
+                };
+            });
+
+            it('provides consistent results without providers', function () {
+                var unsubscribe = telemetryAPI.subscribe(domainObject);
+                expect(unsubscribe).toEqual(jasmine.any(Function));
+
+                var response = telemetryAPI.request(domainObject);
+                expect(response).toEqual(jasmine.any(Promise));
+            });
+
+            it('skips providers that do not match', function () {
+                telemetryProvider.supportsSubscribe.andReturn(false);
+                telemetryProvider.supportsRequest.andReturn(false);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                var callback = jasmine.createSpy('callback');
+                var unsubscribe = telemetryAPI.subscribe(domainObject, callback);
+                expect(telemetryProvider.supportsSubscribe)
+                    .toHaveBeenCalledWith(domainObject);
+                expect(telemetryProvider.subscribe).not.toHaveBeenCalled();
+                expect(unsubscribe).toEqual(jasmine.any(Function));
+
+                var response = telemetryAPI.request(domainObject);
+                expect(telemetryProvider.supportsRequest)
+                    .toHaveBeenCalledWith(domainObject, jasmine.any(Object));
+                expect(telemetryProvider.request).not.toHaveBeenCalled();
+                expect(response).toEqual(jasmine.any(Promise));
+            });
+
+            it('sends subscribe calls to matching providers', function () {
+                var unsubFunc = jasmine.createSpy('unsubscribe');
+                telemetryProvider.subscribe.andReturn(unsubFunc);
+                telemetryProvider.supportsSubscribe.andReturn(true);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                var callback = jasmine.createSpy('callback');
+                var unsubscribe = telemetryAPI.subscribe(domainObject, callback);
+                expect(telemetryProvider.supportsSubscribe.calls.length).toBe(1);
+                expect(telemetryProvider.supportsSubscribe)
+                    .toHaveBeenCalledWith(domainObject);
+                expect(telemetryProvider.subscribe.calls.length).toBe(1);
+                expect(telemetryProvider.subscribe)
+                    .toHaveBeenCalledWith(domainObject, jasmine.any(Function));
+
+                // can notify values
+                var notify = telemetryProvider.subscribe.mostRecentCall.args[1];
+                notify('someValue');
+                expect(callback).toHaveBeenCalledWith('someValue');
+
+                // unsubscribes
+                expect(unsubscribe).toEqual(jasmine.any(Function));
+                expect(unsubFunc).not.toHaveBeenCalled();
+                unsubscribe();
+                expect(unsubFunc).toHaveBeenCalled();
+
+                // doesn't notify after unsubscribe
+                notify('otherValue');
+                expect(callback).not.toHaveBeenCalledWith('otherValue');
+            });
+
+            it('subscribes once per object', function () {
+                var unsubFunc = jasmine.createSpy('unsubscribe');
+                telemetryProvider.subscribe.andReturn(unsubFunc);
+                telemetryProvider.supportsSubscribe.andReturn(true);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                var callback = jasmine.createSpy('callback');
+                var callbacktwo = jasmine.createSpy('callback two');
+                var unsubscribe = telemetryAPI.subscribe(domainObject, callback);
+                var unsubscribetwo = telemetryAPI.subscribe(domainObject, callbacktwo);
+
+                expect(telemetryProvider.subscribe.calls.length).toBe(1);
+
+                var notify = telemetryProvider.subscribe.mostRecentCall.args[1];
+                notify('someValue');
+                expect(callback).toHaveBeenCalledWith('someValue');
+                expect(callbacktwo).toHaveBeenCalledWith('someValue');
+
+                unsubscribe();
+                expect(unsubFunc).not.toHaveBeenCalled();
+                notify('otherValue');
+                expect(callback).not.toHaveBeenCalledWith('otherValue');
+                expect(callbacktwo).toHaveBeenCalledWith('otherValue');
+
+                unsubscribetwo();
+                expect(unsubFunc).toHaveBeenCalled();
+                notify('anotherValue');
+                expect(callback).not.toHaveBeenCalledWith('anotherValue');
+                expect(callbacktwo).not.toHaveBeenCalledWith('anotherValue');
+            });
+
+            it('does subscribe/unsubscribe', function () {
+                var unsubFunc = jasmine.createSpy('unsubscribe');
+                telemetryProvider.subscribe.andReturn(unsubFunc);
+                telemetryProvider.supportsSubscribe.andReturn(true);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                var callback = jasmine.createSpy('callback');
+                var unsubscribe = telemetryAPI.subscribe(domainObject, callback);
+                expect(telemetryProvider.subscribe.calls.length).toBe(1);
+                unsubscribe();
+
+                unsubscribe = telemetryAPI.subscribe(domainObject, callback);
+                expect(telemetryProvider.subscribe.calls.length).toBe(2);
+                unsubscribe();
+            });
+
+            it('subscribes for different object', function () {
+                var unsubFuncs = [];
+                var notifiers = [];
+                telemetryProvider.supportsSubscribe.andReturn(true);
+                telemetryProvider.subscribe.andCallFake(function (obj, cb) {
+                    var unsubFunc = jasmine.createSpy('unsubscribe ' + unsubFuncs.length);
+                    unsubFuncs.push(unsubFunc);
+                    notifiers.push(cb);
+                    return unsubFunc;
+                });
+                telemetryAPI.addProvider(telemetryProvider);
+
+                var otherDomainObject = JSON.parse(JSON.stringify(domainObject));
+                otherDomainObject.identifier.namespace = 'other';
+
+                var callback = jasmine.createSpy('callback');
+                var callbacktwo = jasmine.createSpy('callback two');
+
+                var unsubscribe = telemetryAPI.subscribe(domainObject, callback);
+                var unsubscribetwo = telemetryAPI.subscribe(otherDomainObject, callbacktwo);
+
+                expect(telemetryProvider.subscribe.calls.length).toBe(2);
+
+                notifiers[0]('someValue');
+                expect(callback).toHaveBeenCalledWith('someValue');
+                expect(callbacktwo).not.toHaveBeenCalledWith('someValue');
+
+                notifiers[1]('anotherValue');
+                expect(callback).not.toHaveBeenCalledWith('anotherValue');
+                expect(callbacktwo).toHaveBeenCalledWith('anotherValue');
+
+                unsubscribe();
+                expect(unsubFuncs[0]).toHaveBeenCalled();
+                expect(unsubFuncs[1]).not.toHaveBeenCalled();
+
+                unsubscribetwo();
+                expect(unsubFuncs[1]).toHaveBeenCalled();
+            });
+
+            it('sends requests to matching providers', function () {
+                var telemPromise = Promise.resolve([]);
+                telemetryProvider.supportsRequest.andReturn(true);
+                telemetryProvider.request.andReturn(telemPromise);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                var result = telemetryAPI.request(domainObject);
+                expect(result).toBe(telemPromise);
+                expect(telemetryProvider.supportsRequest).toHaveBeenCalledWith(
+                    domainObject,
+                    jasmine.any(Object)
+                );
+                expect(telemetryProvider.request).toHaveBeenCalledWith(
+                    domainObject,
+                    jasmine.any(Object)
+                );
+            });
+
+            it('generates default request options', function () {
+                telemetryProvider.supportsRequest.andReturn(true);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                telemetryAPI.request(domainObject);
+                expect(telemetryProvider.supportsRequest).toHaveBeenCalledWith(
+                    jasmine.any(Object),
+                    {
+                        start: 0,
+                        end: 1,
+                        domain: 'system'
+                    }
+                );
+
+                expect(telemetryProvider.request).toHaveBeenCalledWith(
+                    jasmine.any(Object),
+                    {
+                        start: 0,
+                        end: 1,
+                        domain: 'system'
+                    }
+                );
+
+                telemetryProvider.supportsRequest.reset();
+                telemetryProvider.request.reset();
+
+                telemetryAPI.request(domainObject, {});
+                expect(telemetryProvider.supportsRequest).toHaveBeenCalledWith(
+                    jasmine.any(Object),
+                    {
+                        start: 0,
+                        end: 1,
+                        domain: 'system'
+                    }
+                );
+
+                expect(telemetryProvider.request).toHaveBeenCalledWith(
+                    jasmine.any(Object),
+                    {
+                        start: 0,
+                        end: 1,
+                        domain: 'system'
+                    }
+                );
+            });
+
+            it('does not overwrite existing request options', function () {
+                telemetryProvider.supportsRequest.andReturn(true);
+                telemetryAPI.addProvider(telemetryProvider);
+
+                telemetryAPI.request(domainObject, {
+                    start: 20,
+                    end: 30,
+                    domain: 'someDomain'
+                });
+
+                expect(telemetryProvider.supportsRequest).toHaveBeenCalledWith(
+                    jasmine.any(Object),
+                    {
+                        start: 20,
+                        end: 30,
+                        domain: 'someDomain'
+                    }
+                );
+
+                expect(telemetryProvider.request).toHaveBeenCalledWith(
+                    jasmine.any(Object),
+                    {
+                        start: 20,
+                        end: 30,
+                        domain: 'someDomain'
+                    }
+                );
+            });
+        });
+    });
+});

--- a/src/api/telemetry/TelemetryAPISpec.js
+++ b/src/api/telemetry/TelemetryAPISpec.js
@@ -82,18 +82,15 @@ define([
                 expect(telemetryProvider.subscribe)
                     .toHaveBeenCalledWith(domainObject, jasmine.any(Function));
 
-                // can notify values
                 var notify = telemetryProvider.subscribe.mostRecentCall.args[1];
                 notify('someValue');
                 expect(callback).toHaveBeenCalledWith('someValue');
 
-                // unsubscribes
                 expect(unsubscribe).toEqual(jasmine.any(Function));
                 expect(unsubFunc).not.toHaveBeenCalled();
                 unsubscribe();
                 expect(unsubFunc).toHaveBeenCalled();
 
-                // doesn't notify after unsubscribe
                 notify('otherValue');
                 expect(callback).not.toHaveBeenCalledWith('otherValue');
             });


### PR DESCRIPTION
Updates the subscription interface to combine subscriptions for the same point-- by implementing this behavior in one place, we prevent every plugin author from having to implement it.

Add some improvements for various telemetry types and ensure that telemetry requests always have reasonable defaults applied.

Also adds some tests to the telem api (where previously there were none).

Fixes #1594.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y