### PR TITLE
[Time] Handle missing time system gracefully

### DIFF
--- a/src/adapter/runs/TimeSettingsURLHandler.js
+++ b/src/adapter/runs/TimeSettingsURLHandler.js
@@ -107,7 +107,9 @@ define([
         }
         this.last = params;
 
-        if (params.clock === 'fixed' && params.bounds) {
+        if (!params.timeSystem) {
+            this.updateQueryParams();
+        } else if (params.clock === 'fixed' && params.bounds) {
             if (!this.time.timeSystem() ||
                 this.time.timeSystem().key !== params.timeSystem) {
 

--- a/src/adapter/runs/TimeSettingsURLHandlerSpec.js
+++ b/src/adapter/runs/TimeSettingsURLHandlerSpec.js
@@ -132,6 +132,20 @@ define([
             };
         });
 
+        it("initializes with missing time system", function () {
+            // This handles an odd transitory case where a url does not include
+            // a timeSystem.  It's generally only experienced by those who
+            // based their code on the tutorial before it specified a time
+            // system.
+            search['tc.mode'] = 'clockA';
+            search['tc.timeSystem'] = undefined;
+            search['tc.startDelta'] = '123';
+            search['tc.endDelta'] = '456';
+
+            // We don't specify behavior right now other than "don't break."
+            expect(initialize).not.toThrow();
+        });
+
         it("can initalize fixed mode from location", function () {
             search['tc.mode'] = 'fixed';
             search['tc.timeSystem'] = 'timeSystemA';


### PR DESCRIPTION
When loading the application and no time system is set,
the url handler should not cause multiple errors to be
logged, and the url fragment for the time system would 
have no time system set.  Reloading the application with
this broken url would cause problems, particularly if the 
time conductor was installed.

This adds a test for the case and then fixes the issue.

Fixes bugs as reported here.