### PR TITLE
persist user preference width for MCTSplitPanes issue #1646

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ protractor/logs
 
 # npm-debug log
 npm-debug.log
+
+package-lock.json

--- a/platform/commonUI/browse/res/templates/browse.html
+++ b/platform/commonUI/browse/res/templates/browse.html
@@ -26,7 +26,7 @@
          ng-controller="PaneController as modelPaneTree"
          ng-class="modelPaneTree.visible() ? 'pane-tree-showing' : 'pane-tree-hidden'">
         <mct-split-pane class='abs contents'
-                        anchor='left'>
+                        anchor='left' alias="leftSide">
             <div class='split-pane-component treeview pane left'>
                 <div class="abs holder l-flex-col holder-treeview-elements">
                     <mct-representation key="'create-button'"
@@ -60,7 +60,7 @@
                      ng-controller="InspectorPaneController as modelPaneInspect"
                      ng-class="modelPaneInspect.visible() ? 'pane-inspect-showing' : 'pane-inspect-hidden'">
 
-                    <mct-split-pane class='l-object-and-inspector contents abs' anchor='right'>
+                    <mct-split-pane class='l-object-and-inspector contents abs' anchor='right' alias="rightSide">
                         <div class='split-pane-component t-object pane primary-pane left'>
                             <mct-representation mct-object="navigatedObject"
                                                 key="navigatedObject.getCapability('status').get('editing') ? 'edit-object' : 'browse-object'"
@@ -87,4 +87,3 @@
     </div>
     <mct-include key="'bottombar'"></mct-include>
 </div>
-

--- a/platform/commonUI/general/bundle.js
+++ b/platform/commonUI/general/bundle.js
@@ -374,7 +374,8 @@ define([
                     "depends": [
                         "$parse",
                         "$log",
-                        "$interval"
+                        "$interval",
+                        "$window"
                     ]
                 },
                 {

--- a/platform/commonUI/general/src/directives/MCTSplitPane.js
+++ b/platform/commonUI/general/src/directives/MCTSplitPane.js
@@ -93,13 +93,21 @@ define(
          * @memberof platform/commonUI/general
          * @constructor
          */
-        function MCTSplitPane($parse, $log, $interval) {
+        function MCTSplitPane($parse, $log, $interval, $window) {
             function controller($scope, $element, $attrs) {
                 var anchorKey = $attrs.anchor || DEFAULT_ANCHOR,
+                    positionParsed = $parse($attrs.position),
                     anchor,
                     activeInterval,
-                    positionParsed = $parse($attrs.position),
-                    position; // Start undefined, until explicitly set
+                    position,
+                    splitterSize,
+
+                    alias = $attrs.alias !== undefined ?
+                      "mctSplitPane-" + $attrs.alias : undefined,
+
+                    //convert string to number from localStorage
+                    userWidthPreference = $window.localStorage.getItem(alias) === null ?
+                      undefined : Number($window.localStorage.getItem(alias));
 
                 // Get relevant size (height or width) of DOM element
                 function getSize(domElement) {
@@ -114,11 +122,11 @@ define(
                     var first = children.eq(anchor.reversed ? 2 : 0),
                         splitter = children.eq(1),
                         last = children.eq(anchor.reversed ? 0 : 2),
-                        splitterSize = getSize(splitter[0]),
                         firstSize;
 
+                    splitterSize = getSize(splitter[0]);
                     first.css(anchor.edge, "0px");
-                    first.css(anchor.dimension, (position - splitterSize) + 'px');
+                    first.css(anchor.dimension, (userWidthPreference || position) + 'px');
 
                     // Get actual size (to obey min-width etc.)
                     firstSize = getSize(first[0]);
@@ -126,9 +134,8 @@ define(
                     splitter.css(anchor.edge, firstSize + 'px');
                     splitter.css(anchor.opposite, "auto");
 
-                    last.css(anchor.edge, (firstSize + splitterSize) + 'px');
+                    last.css(anchor.edge, firstSize + splitterSize + 'px');
                     last.css(anchor.opposite, "0px");
-
                     position = firstSize + splitterSize;
                 }
 
@@ -169,6 +176,17 @@ define(
                     return position;
                 }
 
+                function setUserWidthPreference(value) {
+                    userWidthPreference = value - splitterSize;
+                }
+
+                function persistToLocalStorage(value) {
+                    if (alias) {
+                        userWidthPreference = value - splitterSize;
+                        $window.localStorage.setItem(alias, userWidthPreference);
+                    }
+                }
+
                 // Dynamically apply a CSS class to elements when the user
                 // is actively resizing
                 function toggleClass(classToToggle) {
@@ -196,18 +214,31 @@ define(
                 activeInterval = $interval(function () {
                     getSetPosition(getSetPosition());
                 }, POLLING_INTERVAL, 0, false);
-
                 // ...and stop polling when we're destroyed.
                 $scope.$on('$destroy', function () {
                     $interval.cancel(activeInterval);
                 });
 
+
                 // Interface exposed by controller, for mct-splitter to user
                 return {
-                    position: getSetPosition,
-                    toggleClass: toggleClass,
                     anchor: function () {
                         return anchor;
+                    },
+                    position: function (value) {
+                        if (arguments.length > 0) {
+                            setUserWidthPreference(value);
+                            return getSetPosition(value);
+                        } else {
+                            return getSetPosition();
+                        }
+                    },
+                    startResizing: function () {
+                        toggleClass('resizing');
+                    },
+                    endResizing: function (finalPosition) {
+                        persistToLocalStorage(finalPosition);
+                        toggleClass('resizing');
                     }
                 };
             }
@@ -219,9 +250,7 @@ define(
                 controller: ['$scope', '$element', '$attrs', controller]
             };
         }
-
         return MCTSplitPane;
 
     }
 );
-

--- a/platform/commonUI/general/src/directives/MCTSplitter.js
+++ b/platform/commonUI/general/src/directives/MCTSplitter.js
@@ -37,15 +37,16 @@ define(
          */
         function MCTSplitter() {
             function link(scope, element, attrs, mctSplitPane) {
-                var initialPosition;
+                var initialPosition,
+                    newPosition;
 
                 element.addClass("splitter");
 
                 scope.splitter = {
                     // Begin moving this splitter
                     startMove: function () {
+                        mctSplitPane.startResizing();
                         initialPosition = mctSplitPane.position();
-                        mctSplitPane.toggleClass('resizing');
                     },
                     // Handle user changes to splitter position
                     move: function (delta) {
@@ -55,12 +56,13 @@ define(
                                 (anchor.reversed ? -1 : 1);
 
                         // Update the position of this splitter
-                        mctSplitPane.position(initialPosition + pixelDelta);
+                        newPosition =  initialPosition + pixelDelta;
+                        mctSplitPane.position(newPosition);
                     },
                     // Grab the event when the user is done moving
                     // the splitter and pass it on
                     endMove: function () {
-                        mctSplitPane.toggleClass('resizing');
+                        mctSplitPane.endResizing(newPosition);
                     }
                 };
             }
@@ -83,4 +85,3 @@ define(
 
     }
 );
-

--- a/platform/commonUI/general/test/directives/MCTSplitterSpec.js
+++ b/platform/commonUI/general/test/directives/MCTSplitterSpec.js
@@ -57,7 +57,7 @@ define(
                     testAttrs = {};
                     mockSplitPane = jasmine.createSpyObj(
                         'mctSplitPane',
-                        ['position', 'toggleClass', 'anchor']
+                        ['position', 'startResizing', 'endResizing', 'anchor']
                     );
 
                     mctSplitter.link(
@@ -86,9 +86,9 @@ define(
                         mockScope.splitter.startMove();
                     });
 
-                    it("adds a 'resizing' class", function () {
-                        expect(mockSplitPane.toggleClass)
-                            .toHaveBeenCalledWith('resizing');
+                    it("tell's the splitter when it is resizing", function () {
+                        expect(mockSplitPane.startResizing)
+                            .toHaveBeenCalled();
                     });
 
                     it("repositions during drag", function () {
@@ -97,11 +97,10 @@ define(
                             .toHaveBeenCalledWith(testPosition + 10);
                     });
 
-                    it("removes the 'resizing' class when finished", function () {
-                        mockSplitPane.toggleClass.reset();
+                    it("tell's the splitter when it is done resizing", function () {
+                        mockScope.splitter.move([10,0]);
                         mockScope.splitter.endMove();
-                        expect(mockSplitPane.toggleClass)
-                            .toHaveBeenCalledWith('resizing');
+                        expect(mockSplitPane.endResizing).toHaveBeenCalledWith(testPosition + 10);
                     });
 
                 });


### PR DESCRIPTION
Made changes as requested. Kept all logic regarding localStorage on MCTSplitPane, update localStorage when user drags MCTSplitter to new position. 
