### PR TITLE
Fix for Pane controller issue#1670

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ protractor/logs
 
 # npm-debug log
 npm-debug.log
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bower": "^1.7.7",
     "git-rev-sync": "^1.4.0",
     "glob": ">= 3.0.0",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-header": "^1.8.8",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",

--- a/platform/commonUI/browse/bundle.js
+++ b/platform/commonUI/browse/bundle.js
@@ -107,7 +107,9 @@ define([
                     "depends": [
                         "$scope",
                         "agentService",
-                        "$window"
+                        "$window",
+                        "$location",
+                        "$attrs"
                     ]
                 },
                 {
@@ -134,7 +136,9 @@ define([
                         "$scope",
                         "agentService",
                         "$window",
-                        "navigationService"
+                        "navigationService",
+                        "$location",
+                        "$attrs"
                     ]
                 }
             ],

--- a/platform/commonUI/browse/res/templates/browse.html
+++ b/platform/commonUI/browse/res/templates/browse.html
@@ -24,7 +24,7 @@
     <mct-include key="'topbar-browse'"></mct-include>
     <div class="abs holder holder-main browse-area s-browse-area browse-wrapper"
          ng-controller="PaneController as modelPaneTree"
-         ng-class="modelPaneTree.visible() ? 'pane-tree-showing' : 'pane-tree-hidden'">
+         ng-class="modelPaneTree.visible() ? 'pane-tree-showing' : 'pane-tree-hidden'" hide-parameter="hideTree">
         <mct-split-pane class='abs contents'
                         anchor='left'>
             <div class='split-pane-component treeview pane left'>
@@ -58,7 +58,8 @@
 
                 <div class='holder holder-object-and-inspector abs' id='content-area'
                      ng-controller="InspectorPaneController as modelPaneInspect"
-                     ng-class="modelPaneInspect.visible() ? 'pane-inspect-showing' : 'pane-inspect-hidden'">
+                     ng-class="modelPaneInspect.visible() ? 'pane-inspect-showing' : 'pane-inspect-hidden'" 
+                     hide-parameter="hideInspector">
 
                     <mct-split-pane class='l-object-and-inspector contents abs' anchor='right'>
                         <div class='split-pane-component t-object pane primary-pane left'>
@@ -87,4 +88,3 @@
     </div>
     <mct-include key="'bottombar'"></mct-include>
 </div>
-

--- a/platform/commonUI/browse/src/InspectorPaneController.js
+++ b/platform/commonUI/browse/src/InspectorPaneController.js
@@ -35,9 +35,8 @@ define(
          * @param navigationService
          * @constructor
          */
-        function InspectorPaneController($scope, agentService, $window, navigationService) {
-            PaneController.call(this, $scope, agentService, $window);
-
+        function InspectorPaneController($scope, agentService, $window, navigationService, $location, $attrs) {
+            PaneController.call(this, $scope, agentService, $window, $location, $attrs);
             var statusListener,
                 self = this;
 

--- a/platform/commonUI/browse/src/PaneController.js
+++ b/platform/commonUI/browse/src/PaneController.js
@@ -31,12 +31,17 @@ define(
          * @constructor
          * @memberof platform/commonUI/browse
          */
-        function PaneController($scope, agentService, $window) {
+        function PaneController($scope, agentService, $window, $location, $attrs) {
             var self = this;
             this.agentService = agentService;
+            var hideParameterPresent = $location.search().hasOwnProperty($attrs.hideParameter);
 
-            // Fast and cheap: if this has been opened in a new window, hide panes by default
-            this.state = !$window.opener;
+            if ($attrs.hideParameter && hideParameterPresent) {
+                this.state = false;
+                $location.search($attrs.hideParameter, undefined);
+            } else {
+                this.state = true;
+            }
 
             /**
              * Callback to invoke when any selection occurs in the tree.
@@ -70,7 +75,7 @@ define(
          * @returns {boolean} true when visible
          */
         PaneController.prototype.visible = function () {
-            return this.state;
+            return !!this.state;
         };
 
         return PaneController;

--- a/platform/commonUI/browse/src/windowing/NewTabAction.js
+++ b/platform/commonUI/browse/src/windowing/NewTabAction.js
@@ -38,6 +38,7 @@ define(
 
             this.urlService = urlService;
             this.open = function () {
+                arguments[0] += "&hideTree=true&hideInspector=true";
                 $window.open.apply($window, arguments);
             };
 

--- a/platform/commonUI/browse/test/InspectorPaneControllerSpec.js
+++ b/platform/commonUI/browse/test/InspectorPaneControllerSpec.js
@@ -33,7 +33,9 @@ define(
                 mockNavigationService,
                 mockNavigationUnlistener,
                 mockStatusUnlistener,
-                controller;
+                controller,
+                mockLocation,
+                mockAttrs;
 
             beforeEach(function () {
                 mockScope = jasmine.createSpyObj("$scope", ["$on"]);
@@ -71,7 +73,12 @@ define(
                 mockDomainObject.hasCapability.andReturn(true);
                 mockDomainObject.getCapability.andReturn(mockStatusCapability);
 
-                controller = new InspectorPaneController(mockScope, mockAgentService, mockWindow, mockNavigationService);
+                mockLocation = jasmine.createSpyObj('location', ['search']);
+                mockLocation.search.andReturn({});
+
+                mockAttrs = {};
+
+                controller = new InspectorPaneController(mockScope, mockAgentService, mockWindow, mockNavigationService, mockLocation, mockAttrs);
             });
 
             it("listens for changes to navigation and attaches a status" +

--- a/platform/commonUI/browse/test/PaneControllerSpec.js
+++ b/platform/commonUI/browse/test/PaneControllerSpec.js
@@ -29,7 +29,9 @@ define(
                 mockAgentService,
                 mockDomainObjects,
                 mockWindow,
-                controller;
+                controller,
+                mockLocation,
+                mockAttrs;
 
             // We want to reinstantiate for each test case
             // because device state can influence constructor-time behavior
@@ -37,7 +39,9 @@ define(
                 return new PaneController(
                     mockScope,
                     mockAgentService,
-                    mockWindow
+                    mockWindow,
+                    mockLocation,
+                    mockAttrs
                 );
             }
 
@@ -59,6 +63,11 @@ define(
                     ["isMobile", "isPhone", "isTablet", "isPortrait", "isLandscape"]
                 );
                 mockWindow = jasmine.createSpyObj("$window", ["open"]);
+
+                mockLocation = jasmine.createSpyObj('location', ['search']);
+                mockLocation.search.andReturn({});
+
+                mockAttrs = {};
             });
 
             it("is initially visible", function () {
@@ -85,6 +94,24 @@ define(
 
                 // Tree should have collapsed
                 expect(controller.visible()).toBeFalsy();
+            });
+
+            describe("specifying hideParameter", function () {
+                beforeEach(function () {
+                    mockAttrs = {hideParameter: 'hideTree'};
+                });
+
+                it("sets pane state to false when in location.search", function () {
+                    mockLocation.search.andReturn({'hideTree': true});
+                    expect(instantiateController().visible()).toBe(false);
+                    expect(mockLocation.search).toHaveBeenCalledWith('hideTree', undefined);
+                });
+
+                it("sets state to true when not found in location.search", function () {
+                    mockLocation.search.andReturn({});
+                    expect(instantiateController().visible()).toBe(true);
+                    expect(mockLocation.search).not.toHaveBeenCalledWith('hideTree', undefined);
+                });
             });
         });
     }


### PR DESCRIPTION
1. Added ability for users to add the following parameters to the url:

        a. hideTree = true
        b. hideInspector = true

   These params will enable users to hide the tree and/or inspector. 
   Params will automatically be removed once the PaneController state is triggered. 

2. Changed the way PaneController state is controlled when opening a new tab. Previously we were only checking if new tab is opened, now (newTabOpened=true) param is added to url to act as a trigger to hide Tree and Inspector by default.
 