### PR TITLE
[Example] Limit telemetry responses to 5000 records

### DIFF
--- a/example/generator/generatorWorker.js
+++ b/example/generator/generatorWorker.js
@@ -103,7 +103,7 @@
 
         var data = [];
 
-        for (; nextStep < end; nextStep += step) {
+        for (; nextStep < end && data.length < 5000; nextStep += step) {
             data.push({
                 utc: nextStep,
                 yesterday: nextStep - 60*60*24*1000,

--- a/example/imagery/plugin.js
+++ b/example/imagery/plugin.js
@@ -79,7 +79,7 @@ define([
                 var start = options.start;
                 var end = options.end;
                 var data = [];
-                while (start < end) {
+                while (start < end && data.length < 5000) {
                     data.push(pointForTimestamp(start));
                     start += 5000;
                 }


### PR DESCRIPTION
Update example telemetry providers to limit the number of
datums generated so that queries for long time ranges will
not cause undesired behavior in demos.

This is for example bundles (which don't have tests) so no tests were updated.  It works around some issues with sine wave generators and example imagery when the time conductor is set to a very large time range.

# Reviewer Checklist

1. Changes appear to address issue? Y (as reported here)
2. Appropriate unit tests included? N/A (example code)
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y

@dtailor90 or @psarram please R&I this branch when you have time.