### PR TITLE
update mct-split-pane to use userPreferenceWidth only when alias is p…

### DIFF
--- a/platform/commonUI/general/src/directives/MCTSplitPane.js
+++ b/platform/commonUI/general/src/directives/MCTSplitPane.js
@@ -229,14 +229,13 @@ define(
                     anchor: function () {
                         return anchor;
                     },
-                    position: function (initialValue, newValue) {
+                    position: function (newPosition) {
                         if (arguments.length === 0) {
                             return getSetPosition();
                         }
-                        if (initialValue !== newValue) {
-                            setUserWidthPreference(newValue);
-                            getSetPosition(newValue);
-                        }
+
+                        setUserWidthPreference(newPosition);
+                        return getSetPosition(newPosition);
                     },
                     startResizing: function () {
                         toggleClass('resizing');

--- a/platform/commonUI/general/src/directives/MCTSplitPane.js
+++ b/platform/commonUI/general/src/directives/MCTSplitPane.js
@@ -166,13 +166,14 @@ define(
                 // Getter-setter for the pixel offset of the splitter,
                 // relative to the current edge.
                 function getSetPosition(value) {
+                    var prior = position;
                     if (typeof value === 'number') {
                         position = value;
                         enforceExtrema();
                         updateElementPositions();
 
                         // Pass change up so this state can be shared
-                        if (positionParsed.assign) {
+                        if (positionParsed.assign && position !== prior) {
                             positionParsed.assign($scope, position);
                         }
                     }

--- a/platform/commonUI/general/src/directives/MCTSplitPane.js
+++ b/platform/commonUI/general/src/directives/MCTSplitPane.js
@@ -100,7 +100,7 @@ define(
                     anchor,
                     activeInterval,
                     position,
-                    splitterSize, 
+                    splitterSize,
 
                     alias = $attrs.alias !== undefined ?
                       "mctSplitPane-" + $attrs.alias : undefined,
@@ -108,7 +108,7 @@ define(
                     //convert string to number from localStorage
                     userWidthPreference = $window.localStorage.getItem(alias) === null ?
                       undefined : Number($window.localStorage.getItem(alias));
-              
+
                 // Get relevant size (height or width) of DOM element
                 function getSize(domElement) {
                     return (anchor.orientation === 'vertical' ?
@@ -119,8 +119,8 @@ define(
                 function updateChildren(children) {
                     if (alias) {
                         position = userWidthPreference || position;
-                    }                  
-                    
+                    }
+
                     // Pick out correct elements to update, flowing from
                     // selected anchor edge.
                     var first = children.eq(anchor.reversed ? 2 : 0),
@@ -175,7 +175,7 @@ define(
                         if (positionParsed.assign) {
                             positionParsed.assign($scope, position);
                         }
-                    } 
+                    }
 
                     return position;
                 }
@@ -221,7 +221,7 @@ define(
                 $scope.$on('$destroy', function () {
                     $interval.cancel(activeInterval);
                 });
-                
+
 
                 // Interface exposed by controller, for mct-splitter to user
                 return {
@@ -229,7 +229,7 @@ define(
                         return anchor;
                     },
                     position: function (initialValue, newValue) {
-                        if(arguments.length === 0){
+                        if (arguments.length === 0) {
                             return getSetPosition();
                         }
                         if (initialValue !== newValue) {

--- a/platform/commonUI/general/src/directives/MCTSplitter.js
+++ b/platform/commonUI/general/src/directives/MCTSplitter.js
@@ -57,7 +57,10 @@ define(
 
                         // Update the position of this splitter
                         newPosition =  initialPosition + pixelDelta;
-                        mctSplitPane.position(initialPosition, newPosition);
+
+                        if (initialPosition !== newPosition) {
+                            mctSplitPane.position(newPosition);
+                        }
                     },
                     // Grab the event when the user is done moving
                     // the splitter and pass it on

--- a/platform/commonUI/general/src/directives/MCTSplitter.js
+++ b/platform/commonUI/general/src/directives/MCTSplitter.js
@@ -57,7 +57,7 @@ define(
 
                         // Update the position of this splitter
                         newPosition =  initialPosition + pixelDelta;
-                        mctSplitPane.position(newPosition);
+                        mctSplitPane.position(initialPosition, newPosition);
                     },
                     // Grab the event when the user is done moving
                     // the splitter and pass it on

--- a/platform/commonUI/general/test/directives/MCTSplitPaneSpec.js
+++ b/platform/commonUI/general/test/directives/MCTSplitPaneSpec.js
@@ -164,9 +164,8 @@ define(
                 });
 
                 it("allows positions to be set", function () {
-                    var intitialValue = mockChildren[0].offsetWidth;
                     var testValue = mockChildren[0].offsetWidth + 50;
-                    controller.position(intitialValue, testValue);
+                    controller.position(testValue);
                     expect(mockFirstPane.css).toHaveBeenCalledWith(
                         'width',
                         (testValue) + 'px'

--- a/platform/commonUI/general/test/directives/MCTSplitPaneSpec.js
+++ b/platform/commonUI/general/test/directives/MCTSplitPaneSpec.js
@@ -140,7 +140,7 @@ define(
 
                 it("exposes its splitter's initial position", function () {
                     expect(controller.position()).toEqual(
-                        mockFirstPane[0].offsetWidth + mockSplitter[0].offsetWidth
+                        mockFirstPane[0].offsetWidth
                     );
                 });
 
@@ -164,11 +164,12 @@ define(
                 });
 
                 it("allows positions to be set", function () {
+                    var intitialValue = mockChildren[0].offsetWidth;
                     var testValue = mockChildren[0].offsetWidth + 50;
-                    controller.position(testValue);
+                    controller.position(intitialValue, testValue);
                     expect(mockFirstPane.css).toHaveBeenCalledWith(
                         'width',
-                        (testValue - mockSplitter[0].offsetWidth) + 'px'
+                        (testValue) + 'px'
                     );
                 });
 
@@ -200,11 +201,11 @@ define(
                     mockFirstPane[0].offsetWidth += 100;
                     // Should not reflect the change yet
                     expect(controller.position()).not.toEqual(
-                        mockFirstPane[0].offsetWidth + mockSplitter[0].offsetWidth
+                        mockFirstPane[0].offsetWidth
                     );
                     mockInterval.mostRecentCall.args[0]();
                     expect(controller.position()).toEqual(
-                        mockFirstPane[0].offsetWidth + mockSplitter[0].offsetWidth
+                        mockFirstPane[0].offsetWidth
                     );
                 });
 
@@ -216,7 +217,7 @@ define(
 
                 it("saves user preference to localStorage when user is done resizing", function () {
                     controller.endResizing(100);
-                    expect(Number(mockWindow.localStorage.getItem('mctSplitPane-rightSide'))).toEqual(100 - mockSplitter[0].offsetWidth);
+                    expect(Number(mockWindow.localStorage.getItem('mctSplitPane-rightSide'))).toEqual(100);
                 });
 
             });

--- a/platform/commonUI/general/test/directives/MCTSplitterSpec.js
+++ b/platform/commonUI/general/test/directives/MCTSplitterSpec.js
@@ -94,7 +94,7 @@ define(
                     it("repositions during drag", function () {
                         mockScope.splitter.move([10, 0]);
                         expect(mockSplitPane.position)
-                            .toHaveBeenCalledWith(testPosition + 10);
+                            .toHaveBeenCalledWith(testPosition, testPosition + 10);
                     });
 
                     it("tell's the splitter when it is done resizing", function () {

--- a/platform/commonUI/general/test/directives/MCTSplitterSpec.js
+++ b/platform/commonUI/general/test/directives/MCTSplitterSpec.js
@@ -94,7 +94,7 @@ define(
                     it("repositions during drag", function () {
                         mockScope.splitter.move([10, 0]);
                         expect(mockSplitPane.position)
-                            .toHaveBeenCalledWith(testPosition, testPosition + 10);
+                            .toHaveBeenCalledWith(testPosition + 10);
                     });
 
                     it("tell's the splitter when it is done resizing", function () {


### PR DESCRIPTION
update mctSplitPane to use userPreferenceWidth only when alias is provided, otherwise set position as usual (fix for timeline sync issue)