### PR TITLE
[Telemetry] Provide legacy domains/ranges

### DIFF
--- a/platform/telemetry/src/TelemetryCapability.js
+++ b/platform/telemetry/src/TelemetryCapability.js
@@ -138,6 +138,11 @@ define(
                 typeRequest = (type && type.getDefinition().telemetry) || {},
                 modelTelemetry = domainObject.getModel().telemetry,
                 fullRequest = Object.create(typeRequest),
+                newObject = objectUtils.toNewFormat(
+                    domainObject.getModel(),
+                    domainObject.getId()
+                ),
+                metadata = this.openmct.telemetry.getMetadata(newObject),
                 bounds,
                 timeSystem;
 
@@ -171,6 +176,14 @@ define(
                 if (timeSystem !== undefined) {
                     fullRequest.domain = timeSystem.key;
                 }
+            }
+
+            if (!fullRequest.ranges) {
+                fullRequest.ranges = metadata.valuesForHints(['range']);
+            }
+
+            if (!fullRequest.domains) {
+                fullRequest.domains = metadata.valuesForHints(['domain']);
             }
 
             return fullRequest;

--- a/platform/telemetry/test/TelemetryCapabilitySpec.js
+++ b/platform/telemetry/test/TelemetryCapabilitySpec.js
@@ -91,8 +91,10 @@ define(
                     "findSubscriptionProvider"
                 ]);
                 mockTelemetryAPI.getMetadata.andReturn({
-                    valuesForHints: function () {
-                        return [{}];
+                    valuesForHints: function (hint) {
+                        var metadatum = {};
+                        metadatum[hint] = "foo";
+                        return [metadatum];
                     }
                 });
 
@@ -147,7 +149,9 @@ define(
                         source: "testSource", // from model
                         key: "testKey", // from model
                         start: 42, // from argument
-                        domain: 'mockTimeSystem'
+                        domain: 'mockTimeSystem',
+                        domains: [{ domain: "foo" }],
+                        ranges: [{ range: "foo" }]
                     }]);
             });
 
@@ -167,7 +171,9 @@ define(
                     key: "testKey",
                     start: 0,
                     end: 1,
-                    domain: 'mockTimeSystem'
+                    domain: 'mockTimeSystem',
+                    domains: [{ domain: "foo" }],
+                    ranges: [{ range: "foo" }]
                 });
             });
 
@@ -184,7 +190,9 @@ define(
                     key: "testId", // from domain object
                     start: 0,
                     end: 1,
-                    domain: 'mockTimeSystem'
+                    domain: 'mockTimeSystem',
+                    domains: [{ domain: "foo" }],
+                    ranges: [{ range: "foo" }]
                 });
             });
 
@@ -266,7 +274,9 @@ define(
                         key: "testKey",
                         start: 0,
                         end: 1,
-                        domain: 'mockTimeSystem'
+                        domain: 'mockTimeSystem',
+                        domains: [{ domain: "foo" }],
+                        ranges: [{ range: "foo" }]
                     }]
                 );
 


### PR DESCRIPTION
Provide domains and ranges when converting from current telemetry API to the legacy telemetry capability used by plot and other views. Partially fixes #1684 (see comments in that issue)

### Author Checklist

1. Changes address original issue? Y (partially)
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y