### PR TITLE
Review and merge fixes for Hyperlinks

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_controls.scss
+++ b/platform/commonUI/general/res/sass/controls/_controls.scss
@@ -72,11 +72,13 @@
     }
 }
 
+// Hyperlink objects
 .s-hyperlink {
-    // Hyperlink objects
+    .label {
+        font-size: 0.8rem !important;
+    }
     &:not(.s-button) {
         color: $colorKey;
-        font-size: 0.8rem;
         &:hover { color: $colorKeyHov; }
     }
 }

--- a/platform/commonUI/general/res/sass/user-environ/_frame.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_frame.scss
@@ -122,7 +122,10 @@
 
     /********************************************************** OBJECT TYPES */
     .t-object-type-hyperlink {
-        .s-hyperlink.s-button {
+        .object-holder {
+            overflow: hidden;
+        }
+        .l-hyperlink.s-button {
             // When a hyperlink is a button in a frame, make it expand to fill out to the object-holder
             @extend .abs;
             .label {

--- a/platform/features/hyperlink/res/templates/hyperlink.html
+++ b/platform/features/hyperlink/res/templates/hyperlink.html
@@ -19,10 +19,10 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<a class="s-hyperlink" ng-controller="HyperlinkController as hyperlink" href="{{domainObject.getModel().url}}"
+<a class="l-hyperlink s-hyperlink" ng-controller="HyperlinkController as hyperlink" href="{{domainObject.getModel().url}}"
    ng-attr-target="{{hyperlink.openNewTab() ? '_blank' : undefined}}"
    ng-class="{
        's-button': hyperlink.isButton()
    }">
-    <div class="label">{{domainObject.getModel().displayText}}</div>
+    <span class="label">{{domainObject.getModel().displayText}}</span>
 </a>


### PR DESCRIPTION
Fixes #1710. Minor HTML and CSS mods.
- Converted to span to confine clickable area to text only
- Link now uses `overflow: hidden` in frame
- Normalized font-size when .s-button

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y