### PR TITLE
[Plot] Handle telemetry panels from plot policy

### DIFF
--- a/platform/features/plot/src/policies/PlotViewPolicy.js
+++ b/platform/features/plot/src/policies/PlotViewPolicy.js
@@ -36,6 +36,13 @@ define(
 
         PlotViewPolicy.prototype.hasNumericTelemetry = function (domainObject) {
             var adaptedObject = domainObject.useCapability('adapter');
+
+            if (!adaptedObject.telemetry) {
+                return domainObject.hasCapability('delegation') &&
+                    domainObject.getCapability('delegation')
+                            .doesDelegateCapability('telemetry');
+            }
+
             var metadata = this.openmct.telemetry.getMetadata(adaptedObject);
             var rangeValues = metadata.valuesForHints(['range']);
             if (rangeValues.length === 0) {

--- a/platform/features/plot/test/policies/PlotViewPolicySpec.js
+++ b/platform/features/plot/test/policies/PlotViewPolicySpec.js
@@ -27,17 +27,19 @@ define(
         describe("Plot view policy", function () {
             var testView,
                 mockDomainObject,
+                testAdaptedObject,
                 openmct,
                 telemetryMetadata,
                 policy;
 
             beforeEach(function () {
                 testView = { key: "plot" };
+                testAdaptedObject = { telemetry: {} };
                 mockDomainObject = jasmine.createSpyObj(
                     'domainObject',
-                    ['useCapability']
+                    ['useCapability', 'hasCapability', 'getCapability']
                 );
-                mockDomainObject.useCapability.andReturn('adaptedObject');
+                mockDomainObject.useCapability.andReturn(testAdaptedObject);
                 openmct = {
                     telemetry: jasmine.createSpyObj('telemetryAPI', [
                         'getMetadata'
@@ -56,7 +58,7 @@ define(
                 expect(mockDomainObject.useCapability)
                     .toHaveBeenCalledWith('adapter');
                 expect(openmct.telemetry.getMetadata)
-                    .toHaveBeenCalledWith('adaptedObject');
+                    .toHaveBeenCalledWith(testAdaptedObject);
                 expect(telemetryMetadata.valuesForHints)
                     .toHaveBeenCalledWith(['range']);
             });

--- a/platform/features/plot/test/policies/PlotViewPolicySpec.js
+++ b/platform/features/plot/test/policies/PlotViewPolicySpec.js
@@ -89,6 +89,30 @@ define(
                 expect(policy.allow(testView, mockDomainObject)).toBe(true);
             });
 
+            it('returns true for telemetry delegators', function () {
+                delete testAdaptedObject.telemetry;
+                mockDomainObject.hasCapability.andCallFake(function (c) {
+                    return c === 'delegation';
+                });
+                mockDomainObject.getCapability.andReturn(
+                    jasmine.createSpyObj('delegation', [
+                        'doesDelegateCapability'
+                    ])
+                );
+                mockDomainObject.getCapability('delegation')
+                    .doesDelegateCapability.andCallFake(function (c) {
+                        return c === 'telemetry';
+                    });
+                expect(policy.allow(testView, mockDomainObject)).toBe(true);
+                expect(openmct.telemetry.getMetadata).not.toHaveBeenCalled();
+            });
+
+            it('returns true for non-telemetry non-delegators', function () {
+                delete testAdaptedObject.telemetry;
+                mockDomainObject.hasCapability.andReturn(false);
+                expect(policy.allow(testView, mockDomainObject)).toBe(false);
+            });
+
             it("allows other views", function () {
                 testView.key = "somethingElse";
                 expect(policy.allow(testView, mockDomainObject)).toBe(true);


### PR DESCRIPTION
Check for telemetry delegation before attempting to interrogate Telemetry Panel objects for telemetry metadata; they're not going to have any. Fixes #1728 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y