### PR TITLE
[List] Use standard format for modified/persisted times

### DIFF
--- a/platform/features/listview/bundle.js
+++ b/platform/features/listview/bundle.js
@@ -49,7 +49,7 @@
                 {
                     "key": "ListViewController",
                     "implementation": ListViewController,
-                    "depends": ["$scope"]
+                    "depends": ["$scope", "formatService"]
                 }
             ],
             "directives": [

--- a/platform/features/listview/src/controllers/ListViewController.js
+++ b/platform/features/listview/src/controllers/ListViewController.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-define(['moment'], function (moment) {
+define(function () {
     function ListViewController($scope, formatService) {
         this.$scope = $scope;
         $scope.orderByField = 'title';

--- a/platform/features/listview/src/controllers/ListViewController.js
+++ b/platform/features/listview/src/controllers/ListViewController.js
@@ -20,8 +20,8 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-define(function () {
-    function ListViewController($scope) {
+define(['moment'], function (moment) {
+    function ListViewController($scope, formatService) {
         this.$scope = $scope;
         $scope.orderByField = 'title';
         $scope.reverseSort = false;
@@ -29,6 +29,8 @@ define(function () {
         this.updateView();
         var unlisten = $scope.domainObject.getCapability('mutation')
             .listen(this.updateView.bind(this));
+
+        this.utc = formatService.getFormat('utc');
 
         $scope.$on('$destroy', function () {
             unlisten();
@@ -50,17 +52,13 @@ define(function () {
                 icon: child.getCapability('type').getCssClass(),
                 title: child.getModel().name,
                 type: child.getCapability('type').getName(),
-                persisted: new Date(
-                    child.getModel().persisted
-                ).toUTCString(),
-                modified: new Date(
-                    child.getModel().modified
-                ).toUTCString(),
+                persisted: this.utc.format(child.getModel().persisted),
+                modified: this.utc.format(child.getModel().modified),
                 asDomainObject: child,
                 location: child.getCapability('location'),
                 action: child.getCapability('action')
             };
-        });
+        }, this);
     };
 
     return ListViewController;


### PR DESCRIPTION
This provides consistency with other times and dates in the user interface,
and also provides a meaningful sort order due to the use of ISO formats for
standard date/time presentation. Fixes #1730.

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y