### PR TITLE
[Tree] [WIP] Auto-scroll to selected item in trees

### DIFF
--- a/platform/commonUI/general/src/directives/MCTTree.js
+++ b/platform/commonUI/general/src/directives/MCTTree.js
@@ -25,6 +25,27 @@ define([
     '../ui/TreeView'
 ], function (angular, TreeView) {
     function MCTTree(gestureService) {
+        function isScrolledIntoView(elem, scrollableParent) {
+            var docViewTop = $(scrollableParent).scrollTop();
+            var docViewBottom = docViewTop + $(scrollableParent).height();
+
+            var elemTop = $(elem).offset().top;
+            var elemBottom = elemTop + $(elem).height();
+
+            return ((elemBottom <= docViewBottom) && (elemTop >= docViewTop));
+        }
+
+        function scrollToSelectedNodeIfNotInView(scrollableParent, selectedNodeView) {
+            if (scrollableParent !== null &&
+                !isScrolledIntoView(selectedNodeView.elements()[0], scrollableParent)) {
+                $(scrollableParent).scrollTop(selectedNodeView.elements().offset().top);
+            }
+        }
+
+        function findSelectedNodeView(rootView) {
+
+        }
+
         function link(scope, element) {
             if (!scope.allowSelection) {
                 scope.allowSelection = function () {
@@ -51,6 +72,10 @@ define([
                 if (event && event instanceof MouseEvent) {
                     scope.$apply();
                 }
+
+                var selectedNode = findSelectedNodeView(treeView);
+                var scrollableParent = treeView.elements()[0];
+                scrollToSelectedNodeIfNotInView(selectedNode, scrollableParent);
             }
 
             var unobserve = treeView.observe(setSelection);


### PR DESCRIPTION
This is a WIP fix for #214 which blocks another PR of mine.

The code as-is won't do much, but I wanted to ask a question before proceeding. It's more or less about figuring out a way to fill in:

```js 
function findSelectedNodeView(rootView)
```

Based on the understanding I've got so far:

* MCTTree is the topmost Tree class (directive) in the hierarchy.
* Below MCTTree there's a recursive hierarchy of TreeViews and TreeNodeViews.
* MCTTree is the best spot to actually trigger the scrolling behavior, because it's at the top of the hierarchy, so the element that has the scrollbar is there.

`MCTTree` doesn't seem to have any knowledge of the currently selected `TreeNodeView`. 

Can we make `TreeNodeView.value()` return a value that indicates which `TreeNodeView` was selected in the hierarchy (so in the `TreeNodeView`'s `value()` there would be something like `if isSelected return self otherwise return children.value()`? Would this go against the currently chosen design (most likely missed many details)?

Or is there a simpler way to get from the currently `selectedObject` to its `TreeNodeView`, other than traveling through the hierarchy of views (i.e. a recursive function) inside `MCTTree`?