### PR TITLE
[DateTime Field] Disabled autocorrect and spellcheck for datetime fields

### DIFF
--- a/platform/commonUI/general/res/templates/controls/datetime-field.html
+++ b/platform/commonUI/general/res/templates/controls/datetime-field.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <span ng-controller="DateTimeFieldController">
-    <input type="text"
+    <input type="text" autocorrect="off" spellcheck="false"
            ng-model="textValue"
            ng-blur="restoreTextValue(); ngBlur()"
            ng-mouseup="ngMouseup()"


### PR DESCRIPTION
Added `autocorrect` and `spellcheck` attributes to the datetime-field template.  Addresses #1682.

## Author Checklist
1. Changes address original issue? Yes
2. Unit tests included and/or updated with changes? No
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes