### PR TITLE
[Telemetry] Handle unspecified domains/ranges

### DIFF
--- a/src/api/telemetry/TelemetryMetadataManager.js
+++ b/src/api/telemetry/TelemetryMetadataManager.js
@@ -35,7 +35,7 @@ define([
             name: 'Name'
         });
 
-        metadata.domains.forEach(function (domain, index) {
+        (metadata.domains || []).forEach(function (domain, index) {
             var valueMetadata = _.clone(domain);
             valueMetadata.hints = {
                 domain: index + 1
@@ -43,11 +43,11 @@ define([
             valueMetadatas.push(valueMetadata);
         });
 
-        metadata.ranges.forEach(function (range, index) {
+        (metadata.ranges || []).forEach(function (range, index) {
             var valueMetadata = _.clone(range);
             valueMetadata.hints = {
                 range: index,
-                priority: index + metadata.domains.length + 1
+                priority: index + (metadata.domains || []).length + 1
             };
 
             if (valueMetadata.type === 'enum') {


### PR DESCRIPTION
Handle cases where domains and ranges are not set from TelemetryMetadataManager; these properties will only be present on legacy telemetry objects.

Encountered issue while developing heat map view using example telemetry. Stack trace:

```
3angular.min.js:110 TypeError: Cannot read property 'forEach' of undefined
    at t (TelemetryMetadataManager.js:38)
    at new i (TelemetryMetadataManager.js:124)
    at o.getMetadata (TelemetryAPI.js:308)
    at HeatmapController.<anonymous> (VM86785 HeatmapController.js:16)
    at angular.min.js:121
    at d.$eval (angular.min.js:136)
    at d.$digest (angular.min.js:133)
    at d.$apply (angular.min.js:136)
    at angular.min.js:149
    at o (angular.min.js:45)
```

Supports goals for sprint Alice, https://github.com/nasa/openmct/projects/1

### Author Checklist

1. Changes address original issue? Y* (PR documents original issue)
2. Unit tests included and/or updated with changes? N/A (no existing tests to update)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y