### PR TITLE
[Views] Clear regions on destroy

### DIFF
--- a/src/adapter/directives/MCTView.js
+++ b/src/adapter/directives/MCTView.js
@@ -33,6 +33,7 @@ define([
             link: function (scope, element, attrs) {
                 var region = new Region(element[0]);
                 scope.$watch(attrs.mctView, region.show.bind(region));
+                scope.$on("$destroy", region.clear.bind(region));
             }
         };
     }


### PR DESCRIPTION
Clear regions when a view is destroyed. This causes a view's destroy method to be correctly invoked, allowing views to do cleanup. Used by NSS heatmap view for sprint Alice, https://github.com/nasa/openmct/projects/1

### Author Checklist

1. Changes address original issue? Y (as reported in this PR)
2. Unit tests included and/or updated with changes? N (no tests to update)
3. Command line build passes? Y
4. Changes have been smoke-tested? Y