### PR TITLE
[Controls] pass item as structure

### DIFF
--- a/platform/forms/res/templates/controls/composite.html
+++ b/platform/forms/res/templates/controls/composite.html
@@ -27,7 +27,7 @@
                          ng-required="ngRequired || compositeCtrl.isNonEmpty(ngModel[field])"
                          ng-pattern="ngPattern"
                          options="item.options"
-                         structure="row"
+                         structure="item"
                          field="$index">
             </mct-control>
             <span class="composite-control-label">


### PR DESCRIPTION
Pass the item to child controls inside of a composite instead of
the row object.   Thus, options are correctly passed to children.

Fixes #1785.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y