### PR TITLE
[Fixed Position] Fixed position displays now show image URLs

### DIFF
--- a/platform/features/layout/test/FixedControllerSpec.js
+++ b/platform/features/layout/test/FixedControllerSpec.js
@@ -178,7 +178,6 @@ define(
                     Promise.resolve(mockChildren)
                 );
 
-
                 mockScope.model = testModel;
                 mockScope.configuration = testConfiguration;
                 mockScope.selection = jasmine.createSpyObj(
@@ -194,7 +193,8 @@ define(
 
                 mockMetadata = jasmine.createSpyObj('mockMetadata', [
                     'valuesForHints',
-                    'value'
+                    'value',
+                    'values'
                 ]);
                 mockMetadata.value.andReturn({
                     key: 'value'
@@ -651,6 +651,39 @@ define(
                         expect(controller.getElements()[0].value)
                             .toEqual("Formatted " + testValue);
                     });
+                });
+
+                it("selects an range value to display, if available", function () {
+                    mockMetadata.valuesForHints.andReturn([
+                        {
+                            key: 'range',
+                            source: 'range'
+                        }
+                    ]);
+                    var key = controller.chooseTelemetryKeyToDisplay(mockMetadata);
+                    expect(key).toEqual('range');
+                });
+
+                it("selects the first non-domain value to display, if no range available", function () {
+                    mockMetadata.valuesForHints.andReturn([]);
+                    mockMetadata.values.andReturn([
+                        {
+                            key: 'domain',
+                            source: 'domain',
+                            hints: {
+                                domain: 1
+                            }
+                        },
+                        {
+                            key: 'image',
+                            source: 'image',
+                            hints: {
+                                image: 1
+                            }
+                        }
+                    ]);
+                    var key = controller.chooseTelemetryKeyToDisplay(mockMetadata);
+                    expect(key).toEqual('image');
                 });
 
                 it("reflects limit status", function () {


### PR DESCRIPTION
Fixes #1740.

The issue here was that the fixed position display was expecting all telemetry to specify a 'range', which imagery telemetry does not (quite correctly). I've modified the fixed pos display to be a bit more flexible here. It will preferentially attempt to show a 'range' value if one is defined in the metadata, but it will fall back to showing the highest priority non-domain value if no range is available.

In future we might consider allowing the user to select which telemetry value a fixed position display shows for a given telemetry point. Thoughts?

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y
* Command line build passes? Y
* Changes have been smoke-tested? Y