### PR TITLE
[Layout] Fix regression in selecting object when it's dropped

### DIFF
--- a/platform/features/layout/src/LayoutController.js
+++ b/platform/features/layout/src/LayoutController.js
@@ -127,9 +127,7 @@ define(
                         if (self.droppedIdToSelectAfterRefresh) {
                             self.select(null, self.droppedIdToSelectAfterRefresh);
                             delete self.droppedIdToSelectAfterRefresh;
-                        }
-
-                        if (composition.indexOf(self.selectedId) === -1) {
+                        } else if (composition.indexOf(self.selectedId) === -1) {
                             self.clearSelection();
                         }
                     }


### PR DESCRIPTION
Clear the selection only if the selected object is no longer in the composition and there's no newly dropped object.

Fixes # 1790