### PR TITLE
Handle keyString or identifier

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -56,6 +56,7 @@ define([
 
     // Retrieve the provider for a given key.
     ObjectAPI.prototype.getProvider = function (identifier) {
+        identifier = utils.parseKeyString(identifier);
         if (identifier.key === 'ROOT') {
             return this.rootProvider;
         }


### PR DESCRIPTION
Updates object API to support `.get(keyString)` and `.get(identifier)`.  I thought this behavior was already in place, but found out in the course of debugging that it was not already in place.

# Reviewer Checklist

1. Changes appear to address issue? Y
2. Appropriate unit tests included? N/A, tests not yet provided for this.
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y