### PR TITLE
[API] get with keystring, fix transitional race condition

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -50,11 +50,18 @@ define([
         this.rootProvider = new RootObjectProvider(this.rootRegistry);
     }
 
+    /**
+     * Set fallback provider, this is an internal API for legacy reasons.
+     * @private
+     */
     ObjectAPI.prototype.supersecretSetFallbackProvider = function (p) {
         this.fallbackProvider = p;
     };
 
-    // Retrieve the provider for a given key.
+    /**
+     * Retrieve the provider for a given identifier.
+     * @private
+     */
     ObjectAPI.prototype.getProvider = function (identifier) {
         if (identifier.key === 'ROOT') {
             return this.rootProvider;
@@ -135,27 +142,28 @@ define([
      * @returns {Promise} a promise which will resolve when the domain object
      *          has been saved, or be rejected if it cannot be saved
      */
+    ObjectAPI.prototype.get = function (identifier) {
+        identifier = utils.parseKeyString(identifier);
+        var provider = this.getProvider(identifier);
 
-    [
-        'save',
-        'delete',
-        'get'
-    ].forEach(function (method) {
-        ObjectAPI.prototype[method] = function () {
-            var identifier = arguments[0],
-                provider = this.getProvider(identifier);
+        if (!provider) {
+            throw new Error('No Provider Matched');
+        }
 
-            if (!provider) {
-                throw new Error('No Provider Matched');
-            }
+        if (!provider.get) {
+            throw new Error('Provider does not support get!');
+        }
 
-            if (!provider[method]) {
-                throw new Error('Provider does not support [' + method + '].');
-            }
+        return provider.get(identifier);
+    };
 
-            return provider[method].apply(provider, arguments);
-        };
-    });
+    ObjectAPI.prototype.delete = function () {
+        throw new Error('Delete not implemented');
+    };
+
+    ObjectAPI.prototype.save = function () {
+        throw new Error('Save not implemented');
+    };
 
     /**
      * Add a root-level object.


### PR DESCRIPTION
The fix in #1796 failed because it only updated the identifier used to fetch the provider, but then it still used the keystring to get the provider.  The provider would fail because it expected an identifier but got a keystring.

That said `.get(keyString)` works without this change, albeit inconsistently.  That it works is due to the MissingModelCompatibilityDecorator.  That it works inconsistently is due to a race condition in the larger system.

# Previously

**It works:**  The fallback object provider tries to get the keyString from the model service, the MissingModelCompatibilityDecorator sees that it's not available, converts the keyString to an identifier, performs objects.get, and returns the result.

**inconsistently...** to prevent an infinite loop between the fallback object provider and the MissingModelCompatibilityDecorator, the decorator detects a second call for the same ID and returns an empty promise (e.g. missing model).  In OpenMCT, there are other things (the tree, inspector, search service, etc) which are issuing requests for the model, and this can cause a second request and the response to get fulfilled with a missing model.  So instead of an infinite loop, we have a race condition.

# with this PR:

handling keyString -> identifier mapping in objects.get() prevents the request from ever going though the fallback decorator.

Update Object API such that get supports calls with either a keystring or an
identifier.

As save and delete are not implemented and have different calling signatures,
implement them as separate methods so they can be documented separately.

