### PR TITLE
[persistence] fix for issue #1593

### DIFF
--- a/platform/commonUI/edit/src/capabilities/EditorCapability.js
+++ b/platform/commonUI/edit/src/capabilities/EditorCapability.js
@@ -101,10 +101,15 @@ define(
          */
         EditorCapability.prototype.finish = function () {
             var domainObject = this.domainObject;
-            return this.transactionService.cancel().then(function () {
-                domainObject.getCapability("status").set("editing", false);
-                return domainObject;
-            });
+
+            if (this.transactionService.isActive()) {
+                return this.transactionService.cancel().then(function () {
+                    domainObject.getCapability("status").set("editing", false);
+                    return domainObject;
+                });
+            } else {
+                return Promise.resolve(domainObject);
+            }
         };
 
         /**

--- a/platform/commonUI/edit/test/capabilities/EditorCapabilitySpec.js
+++ b/platform/commonUI/edit/test/capabilities/EditorCapabilitySpec.js
@@ -62,6 +62,7 @@ define(
                 );
                 mockTransactionService.commit.andReturn(fastPromise());
                 mockTransactionService.cancel.andReturn(fastPromise());
+                mockTransactionService.isActive = jasmine.createSpy('isActive');
 
                 mockStatusCapability = jasmine.createSpyObj(
                     "statusCapability",
@@ -141,6 +142,7 @@ define(
 
             describe("finish", function () {
                 beforeEach(function () {
+                    mockTransactionService.isActive.andReturn(true);
                     capability.edit();
                     capability.finish();
                 });
@@ -150,6 +152,23 @@ define(
                 it("resets the edit state", function () {
                     expect(mockStatusCapability.set).toHaveBeenCalledWith('editing', false);
                 });
+            });
+
+            describe("finish", function () {
+                beforeEach(function () {
+                    mockTransactionService.isActive.andReturn(false);
+                    capability.edit();
+                });
+
+                it("does not cancel transaction when transaction is not active", function () {
+                    capability.finish();
+                    expect(mockTransactionService.cancel).not.toHaveBeenCalled();
+                });
+
+                it("returns a promise", function () {
+                    expect(capability.finish() instanceof Promise).toBe(true);
+                });
+
             });
 
             describe("dirty", function () {


### PR DESCRIPTION
Prevent EditorCapability#finish from calling transactionService#cancel when transactionService was not active - leading to console error every time user would leave edit mode

Added tests to check for and support changes made and make sure Promise is returned in either case

# Author Checklist

Changes address original issue? Y
Unit tests included and/or updated with changes? Y
Command line build passes? Y
Changes have been smoke-tested? Y