### PR TITLE
[Table] Retain rows in scope

### DIFF
--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -170,6 +170,9 @@ define(
          * @param rows
          */
         TelemetryTableController.prototype.addRowsToTable = function (rows) {
+            rows.forEach(function (row) {
+                this.$scope.rows.push(row);
+            }, this);
             this.$scope.$broadcast('add:rows', rows);
         };
 

--- a/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
@@ -441,8 +441,8 @@ define(
                 var expectedRows;
 
                 beforeEach(function () {
-                    testRows = [ { a: 0 }, { a: 1 }, { a: 2 } ];
-                    mockScope.rows = [ { a: -1 }];
+                    testRows = [{ a: 0 }, { a: 1 }, { a: 2 }];
+                    mockScope.rows = [{ a: -1 }];
                     expectedRows = mockScope.rows.concat(testRows);
 
                     spyOn(controller.telemetry, "on").andCallThrough();

--- a/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
+++ b/platform/features/table/test/controllers/TelemetryTableControllerSpec.js
@@ -436,5 +436,28 @@ define(
                 expect(mockScope.$broadcast).toHaveBeenCalledWith("remove:rows", discardedRows);
             });
 
+            describe('when telemetry is added', function () {
+                var testRows;
+                var expectedRows;
+
+                beforeEach(function () {
+                    testRows = [ { a: 0 }, { a: 1 }, { a: 2 } ];
+                    mockScope.rows = [ { a: -1 }];
+                    expectedRows = mockScope.rows.concat(testRows);
+
+                    spyOn(controller.telemetry, "on").andCallThrough();
+                    controller.registerChangeListeners();
+
+                    controller.telemetry.on.calls.forEach(function (call) {
+                        if (call.args[0] === 'added') {
+                            call.args[1](testRows);
+                        }
+                    });
+                });
+
+                it("adds it to rows in scope", function () {
+                    expect(mockScope.rows).toEqual(expectedRows);
+                });
+            });
         });
     });


### PR DESCRIPTION
This avoids losing rows during table sorting, which fixes #1738 

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y