### PR TITLE
[Layout] Don't use class name to query by id

### DIFF
--- a/platform/features/layout/res/templates/layout.html
+++ b/platform/features/layout/res/templates/layout.html
@@ -36,7 +36,8 @@
              ng-style="{ 'background-size': '100% ' + controller.getGridSize() [1] + 'px' }"></div>
     </div>
 
-    <div class="abs frame t-frame-outer child-frame panel s-selectable s-moveable s-hover-border {{childObject.getId() + '-' + $id}} t-object-type-{{ childObject.getModel().type }}"
+    <div class="abs frame t-frame-outer child-frame panel s-selectable s-moveable s-hover-border t-object-type-{{ childObject.getModel().type }}"
+         data-layout-id="{{childObject.getId() + '-' + $id}}"
          ng-class="{ 'no-frame': !controller.hasFrame(childObject), 's-drilled-in': controller.isDrilledIn(childObject) }"
          ng-repeat="childObject in composition"
          ng-init="controller.selectIfNew(childObject.getId() + '-' + $id, childObject)"

--- a/platform/features/layout/src/LayoutController.js
+++ b/platform/features/layout/src/LayoutController.js
@@ -515,7 +515,7 @@ define(
         LayoutController.prototype.selectIfNew = function (selector, domainObject) {
             if (domainObject.getId() === this.droppedIdToSelectAfterRefresh) {
                 setTimeout(function () {
-                    $('.' + selector)[0].click();
+                    $('[data-layout-id="' + selector + '"]')[0].click();
                     delete this.droppedIdToSelectAfterRefresh;
                 }.bind(this), 0);
             }

--- a/platform/features/layout/test/LayoutControllerSpec.js
+++ b/platform/features/layout/test/LayoutControllerSpec.js
@@ -475,11 +475,11 @@ define(
                 );
 
                 var childObj = mockDomainObject("d");
-                var testElement = $("<div class='some-class'></div>");
+                var testElement = $("<div data-layout-id='some-id'></div>");
                 $element.append(testElement);
                 spyOn(testElement[0], 'click');
 
-                controller.selectIfNew('some-class', childObj);
+                controller.selectIfNew('some-id', childObj);
                 jasmine.Clock.tick(0);
 
                 expect(testElement[0].click).toHaveBeenCalled();


### PR DESCRIPTION
...since ids may be invalid class names. Instead, use a data attribute. Fixes #1846