### PR TITLE
[BUILD] Add v8-compile-cache to improve script performance

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,6 +22,8 @@
 
 /*global require,__dirname*/
 
+require("v8-compile-cache");
+
 var gulp = require('gulp'),
     sourcemaps = require('gulp-sourcemaps'),
     path = require('path'),

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "moment": "^2.11.1",
     "node-bourbon": "^4.2.3",
     "requirejs": "2.1.x",
-    "split": "^1.0.0"
+    "split": "^1.0.0",
+    "v8-compile-cache": "^1.1.0"
   },
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
Rationale
This PR adds [v8-compile-cache](https://github.com/zertosh/v8-compile-cache) to speed up development scripts. Ran it on `gulp test` and it went from `~4.1s` to `~3.3s` locally. Other scripts are also using this module, so performance get's better on things like linting etc too

Author Checklist
Changes address original issue?
N/A

Unit tests included and/or updated with changes?
N/A

Command line build passes?
Y

Changes have been smoke-tested?
