### PR TITLE
Summary widget identifiers 1858

### DIFF
--- a/src/plugins/summaryWidget/src/SummaryWidget.js
+++ b/src/plugins/summaryWidget/src/SummaryWidget.js
@@ -5,6 +5,7 @@ define([
     './TestDataManager',
     './WidgetDnD',
     './eventHelpers',
+    '../../../api/objects/object-utils',
     'lodash',
     'zepto'
 ], function (
@@ -14,6 +15,7 @@ define([
     TestDataManager,
     WidgetDnD,
     eventHelpers,
+    objectUtils,
     _,
     $
 ) {
@@ -77,7 +79,7 @@ define([
         this.addHyperlink(domainObject.url, domainObject.openNewTab);
         this.watchForChanges(openmct, domainObject);
 
-        var id = this.domainObject.identifier.key,
+        var id = objectUtils.makeKeyString(this.domainObject.identifier),
             self = this,
             oldDomainObject,
             statusCapability;

--- a/src/plugins/summaryWidget/test/SummaryWidgetSpec.js
+++ b/src/plugins/summaryWidget/test/SummaryWidgetSpec.js
@@ -14,7 +14,8 @@ define(['../src/SummaryWidget', 'zepto'], function (SummaryWidget, $) {
         beforeEach(function () {
             mockDomainObject = {
                 identifier: {
-                    key: 'testKey'
+                    key: 'testKey',
+                    namespace: 'testNamespace'
                 },
                 name: 'testName',
                 composition: [],
@@ -49,7 +50,7 @@ define(['../src/SummaryWidget', 'zepto'], function (SummaryWidget, $) {
             mockObjectService.getObjects = jasmine.createSpy('objectService');
             mockObjectService.getObjects.andReturn(new Promise(function (resolve, reject) {
                 resolve({
-                    testKey: mockOldDomainObject
+                    'testNamespace:testKey': mockOldDomainObject
                 });
             }));
             mockOpenMCT = jasmine.createSpyObj('openmct', [
@@ -71,6 +72,10 @@ define(['../src/SummaryWidget', 'zepto'], function (SummaryWidget, $) {
             summaryWidget = new SummaryWidget(mockDomainObject, mockOpenMCT);
             mockContainer = document.createElement('div');
             summaryWidget.show(mockContainer);
+        });
+
+        it('queries with legacyId', function () {
+            expect(mockObjectService.getObjects).toHaveBeenCalledWith(['testNamespace:testKey']);
         });
 
         it('adds its DOM element to the view', function () {


### PR DESCRIPTION
Use objectUtils to get a proper legacy id so that namespaces are
properly handled.  Fixes https://github.com/nasa/openmct/issues/1858

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y