### PR TITLE
[Tabular] Add uuid to tabular

### DIFF
--- a/src/plugins/autoflow/AutoflowTabularPlugin.js
+++ b/src/plugins/autoflow/AutoflowTabularPlugin.js
@@ -21,9 +21,11 @@
  *****************************************************************************/
 
 define([
-    './AutoflowTabularView'
+    './AutoflowTabularView',
+    'uuid'
 ], function (
-    AutoflowTabularView
+    AutoflowTabularView,
+    uuid
 ) {
     /**
      * This plugin provides an Autoflow Tabular View for domain objects
@@ -40,7 +42,7 @@ define([
 
             views.addProvider({
                 name: "Autoflow Tabular",
-                key: "autoflow",
+                key: "autoflow-" + uuid(),
                 cssClass: "icon-packet",
                 description: "A tabular view of packet contents.",
                 canView: function (d) {


### PR DESCRIPTION
@larkin adding an unique id to the provider makes it possible to add multiple `autoFlowPlugins`, but this is used some way based on the provider name, isn't it? If so, we can add an id prop to the domainObject which we can check against? 

What would we need to do in order for this to work? 