### PR TITLE
[DateTimePicker] Time Conductor Date Picker menu is missing background

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_menus.scss
+++ b/platform/commonUI/general/res/sass/controls/_menus.scss
@@ -77,6 +77,14 @@
     position: relative;
 }
 
+.s-menu {
+	border-radius: $basicCr;
+	@include containerSubtle($colorMenuBg, $colorMenuFg);
+	@include boxShdw($shdwMenu);
+	@include txtShdw($shdwMenuText);
+	padding: $interiorMarginSm 0;
+}
+
 .menu {
     border-radius: $basicCr;
     @include containerSubtle($colorMenuBg, $colorMenuFg);

--- a/platform/commonUI/general/res/sass/controls/_menus.scss
+++ b/platform/commonUI/general/res/sass/controls/_menus.scss
@@ -78,11 +78,11 @@
 }
 
 .s-menu {
-	border-radius: $basicCr;
-	@include containerSubtle($colorMenuBg, $colorMenuFg);
-	@include boxShdw($shdwMenu);
-	@include txtShdw($shdwMenuText);
-	padding: $interiorMarginSm 0;
+    border-radius: $basicCr;
+    @include containerSubtle($colorMenuBg, $colorMenuFg);
+    @include boxShdw($shdwMenu);
+    @include txtShdw($shdwMenuText);
+    padding: $interiorMarginSm 0;
 }
 
 .menu {


### PR DESCRIPTION
It looks like some styles were consolidated as part of bc7d92ee0d64aa63769d7bb534f251c14d253c88.  I'm not sure if the intention was to completely replace `.s-menu` with `.menu` but I've added the styles which were removed.

The datetime-picker template still references the `.s-menu` class.

## Author Checklist
1. Changes address original issue? Yes
2. Unit tests included and/or updated with changes? N/A (changes relate to styles)
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes

Addresses #1872 