### PR TITLE
[Inspector] Refresh the elements pool after removing an item

### DIFF
--- a/platform/commonUI/edit/src/controllers/ElementsController.js
+++ b/platform/commonUI/edit/src/controllers/ElementsController.js
@@ -52,8 +52,20 @@ define(
             }
 
             function setSelection(selection) {
-                self.scope.selection = selection;
-                self.refreshComposition(selection);
+                if (!selection[0]) {
+                    return;
+                }
+
+                if (self.mutationListener) {
+                    self.mutationListener();
+                    delete self.mutationListener;
+                }
+
+                var domainObject = selection[0].context.oldItem;
+                self.refreshComposition(domainObject);
+
+                self.mutationListener = domainObject.getCapability('mutation')
+                    .listen(self.refreshComposition.bind(self, domainObject));
             }
 
             $scope.filterBy = filterBy;
@@ -70,16 +82,11 @@ define(
         /**
          * Gets the composition for the selected object and populates the scope with it.
          *
-         * @param selection the selection object
+         * @param domainObject the selected object
          * @private
          */
-        ElementsController.prototype.refreshComposition = function (selection) {
-            if (!selection[0]) {
-                return;
-            }
-
-            var selected = selection[0].context.oldItem;
-            var selectedObjectComposition = selected && selected.useCapability('composition');
+        ElementsController.prototype.refreshComposition = function (domainObject) {
+            var selectedObjectComposition = domainObject.useCapability('composition');
 
             if (selectedObjectComposition) {
                 selectedObjectComposition.then(function (composition) {

--- a/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
+++ b/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
@@ -29,9 +29,25 @@ define(
             var mockScope,
                 mockOpenMCT,
                 mockSelection,
+                mockDomainObject,
+                mockMutationCapability,
+                mockUnlisten,
+                selectable = [],
                 controller;
 
             beforeEach(function () {
+                mockUnlisten = jasmine.createSpy('unlisten');
+                mockMutationCapability = jasmine.createSpyObj("mutationCapability", [
+                    "listen"
+                ]);
+                mockMutationCapability.listen.andReturn(mockUnlisten);
+                mockDomainObject = jasmine.createSpyObj("domainObject", [
+                    "getCapability",
+                    "useCapability"
+                ]);
+                mockDomainObject.useCapability.andCallThrough();
+                mockDomainObject.getCapability.andReturn(mockMutationCapability);
+
                 mockScope = jasmine.createSpyObj("$scope", ['$on']);
                 mockSelection = jasmine.createSpyObj("selection", [
                     'on',
@@ -42,6 +58,14 @@ define(
                 mockOpenMCT = {
                     selection: mockSelection
                 };
+
+                selectable[0] = {
+                    context: {
+                        oldItem: mockDomainObject
+                    }
+                };
+
+                spyOn(ElementsController.prototype, 'refreshComposition');
 
                 controller = new ElementsController(mockScope, mockOpenMCT);
             });
@@ -73,6 +97,34 @@ define(
                 expect(objects.filter(mockScope.searchElements).length).toBe(2);
                 mockScope.filterBy("element");
                 expect(objects.filter(mockScope.searchElements).length).toBe(4);
+            });
+
+            it("refreshes composition on selection", function () {
+                mockOpenMCT.selection.on.mostRecentCall.args[1](selectable);
+
+                expect(ElementsController.prototype.refreshComposition).toHaveBeenCalledWith(mockDomainObject);
+            });
+
+            it("listens on mutation and refreshes composition", function () {
+                mockOpenMCT.selection.on.mostRecentCall.args[1](selectable);
+
+                expect(mockDomainObject.getCapability).toHaveBeenCalledWith('mutation');
+                expect(mockMutationCapability.listen).toHaveBeenCalled();
+                expect(ElementsController.prototype.refreshComposition.calls.length).toBe(1);
+
+                mockMutationCapability.listen.mostRecentCall.args[0](mockDomainObject);
+
+                expect(ElementsController.prototype.refreshComposition.calls.length).toBe(2);
+            });
+
+            it("cleans up mutation listener when selection changes", function () {
+                mockOpenMCT.selection.on.mostRecentCall.args[1](selectable);
+
+                expect(mockMutationCapability.listen).toHaveBeenCalled();
+
+                mockOpenMCT.selection.on.mostRecentCall.args[1](selectable);
+
+                expect(mockUnlisten).toHaveBeenCalled();
             });
 
         });


### PR DESCRIPTION
Listen for mutation and refresh composition so that elements pool is updated when selected object's composition changes. 

Fixes #1869.

# Author Checklist

1. Changes address original issue? Yes
2. Unit tests included and/or updated with changes? Yes
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes