### PR TITLE
[Documentation] Add security guide

### DIFF
--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -19,21 +19,31 @@ Open MCT has been architected assuming the following deployment pattern:
 * A tagged, tested Open MCT version will be used.
 * Externally authored plugins will be installed.
 * A server will provide persistent storage, telemetry, and other shared data.
-* Authorization, authentication, and auditing will be handled by the server.
+* Authorization, authentication, and auditing will be handled by a server.
 
 
 ## Security Procedures
 
-* **Code review**: All contributions are reviewed by internal team members.
-  External contributors receive increased scrutiny for security and quality,
-  and must sign a licensing agreement.
-* **Dependency review**: Before integrating third-party dependencies, they
-  are reviewed for security and quality, with consideration given to authors
-  and users of these dependencies, as well as review of open source code.
-* **Periodic security reviews**: Open MCT's code, design, and architecture
-  are periodically reviewed (approximately annually) for common security
-  issues, such as the
-  [OWASP Top Ten](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project).
+The Open MCT team secures our code base using a combination of code review,
+dependency review, and periodic security reviews.
+
+### Code Review
+
+All contributions are reviewed by internal team members. External
+contributors receive increased scrutiny for security and quality,
+and must sign a licensing agreement.
+
+### Dependency Review
+
+Before integrating third-party dependencies, they are reviewed for security
+and quality, with consideration given to authors and users of these
+dependencies, as well as review of open source code.
+
+### Periodic Security Reviews
+
+Open MCT's code, design, and architecture are periodically reviewed
+(approximately annually) for common security issues, such as the
+[OWASP Top Ten](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project).
 
 
 ## Security Concerns

--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -1,0 +1,15 @@
+# Security
+
+Open MCT is a rich client with plugin support that executes as a single page
+web application in a browser environment. Security concerns and
+vulnerabilities associated with the web as a platform should be considered
+before deploying Open MCT (or any other web application) for mission or
+production usage.
+
+This document describes several important points to consider when developing
+for or deploying Open MCT securely. Other resources such as
+[Open Web Application Security Project (OWASP)](https://www.owasp.org)
+provide a deeper and more general overview of security for web applications.
+
+
+

--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -25,7 +25,10 @@ Open MCT has been architected assuming the following deployment pattern:
 ## Security Procedures
 
 The Open MCT team secures our code base using a combination of code review,
-dependency review, and periodic security reviews.
+dependency review, and periodic security reviews. Static analysis performed 
+during automated verification additionally safeguards against common 
+coding errors which may result in vulnerabilities.
+
 
 ### Code Review
 

--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -100,10 +100,19 @@ Open MCT assumes that server-side components will be insulated against
 denial-of-service attacks. Services should only permit resource-intensive
 tasks to be initiated by known or trusted users.
 
-### Elevation of privilege
+### Elevation of Privilege
 
 Corollary to the assumption that servers guide against identity spoofing,
 Open MCT assumes that services do not allow a user to act with
 inappropriately escalated privileges. Open MCT cannot protect against
 such escalation; in the clearest case, a malicious actor could interact
 with web services directly to exploit such a vulnerability.
+
+## Additional Reading
+
+The following resources have been used as a basis for identifying potential
+security threats to Open MCT deployments in preparation of this document:
+
+* [STRIDE model](https://www.owasp.org/index.php/Threat_Risk_Modeling#STRIDE)
+* [Attack Surface Analysis Cheat Sheet](https://www.owasp.org/index.php/Attack_Surface_Analysis_Cheat_Sheet)
+* [XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet)

--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -48,24 +48,62 @@ Open MCT's code, design, and architecture are periodically reviewed
 
 ## Security Concerns
 
-* Identity spoofing may occur if source code is compromiesd.
-  * Prevent man-in-the-middle attacks using SSL (https rather than http).
-    * Avoid serving up a malicious version of Open MCT or your plugins.
+Certain security concerns deserve special attention when deploying Open MCT,
+or when authoring plugins.
 
-* Information disclosure.
-  * Don't send sensitive data to third-party servers or insecure APIs.
+### Identity Spoofing
 
-* Tampering with data
-  * Assume that the server validates data.
-  * Plugins which serialize and write data to server must escape that data.
+Open MCT issues calls to web services with the privileges of a logged in user.
+Compromised sources (either for Open MCT itself or a plugin) could
+therefore allow malicious code to execute with those privileges.
 
-* Repudiation
-  * Assume server logs relevant actions associated with a user identity.
-  * If client-side behavior must be logged, plugins must do this.
+To avoid this:
 
-* Denial-of-service
-  * We assume resource-intensive tasks cannot be initiated by untrusted users.
+* Serve Open MCT and other scripts over SSL (https rather than http)
+  to prevent man-in-the-middle attacks.
+* Exercise precautions such as security reviews for any plugins or
+  applications built for or with Open MCT to reject malicious changes.
 
-* Elevation of privilege
-  * Assume this
+### Information Disclosure
 
+If Open MCT is used to handle or display sensitive data, any components
+(such as adapter plugins) must take care to avoid leaking or disclosing
+this information. For example, avoid sending sensitive data to third-party
+servers or insecure APIs.
+
+### Data Tampering
+
+The web application architecture leaves open the possibility that direct
+calls will be made to back-end services, circumventing Open MCT entirely.
+As such, Open MCT assumes that server components will perform any necessary
+data validation during calls issues to the server.
+
+Additionally, plugins which serialize and write data to the server must
+escape that data to avoid database injection attacks, and similar.
+
+### Repudiation
+
+Open MCT assumes that servers log any relevant interactions and associates
+these with a user identity; the specific user actions taken within the
+application are assumed not to be of concern for auditing.
+
+In the absence of server-side logging, users may disclaim (maliciously,
+mistakenly, or otherwise) actions taken within the system without any
+way to prove otherwise.
+
+If keeping client-level interactions is important, this will need to be
+implemented via a plugin.
+
+### Denial-of-service
+
+Open MCT assumes that server-side components will be insulated against
+denial-of-service attacks. Services should only permit resource-intensive
+tasks to be initiated by known or trusted users.
+
+### Elevation of privilege
+
+Corollary to the assumption that servers guide against identity spoofing,
+Open MCT assumes that services do not allow a user to act with
+inappropriately escalated privileges. Open MCT cannot protect against
+such escalation; in the clearest case, a malicious actor could interact
+with web services directly to exploit such a vulnerability.

--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -1,4 +1,4 @@
-# Security
+# Security Guide
 
 Open MCT is a rich client with plugin support that executes as a single page
 web application in a browser environment. Security concerns and

--- a/docs/src/guide/security.md
+++ b/docs/src/guide/security.md
@@ -12,4 +12,50 @@ for or deploying Open MCT securely. Other resources such as
 provide a deeper and more general overview of security for web applications.
 
 
+## Security Model
+
+Open MCT has been architected assuming the following deployment pattern:
+
+* A tagged, tested Open MCT version will be used.
+* Externally authored plugins will be installed.
+* A server will provide persistent storage, telemetry, and other shared data.
+* Authorization, authentication, and auditing will be handled by the server.
+
+
+## Security Procedures
+
+* **Code review**: All contributions are reviewed by internal team members.
+  External contributors receive increased scrutiny for security and quality,
+  and must sign a licensing agreement.
+* **Dependency review**: Before integrating third-party dependencies, they
+  are reviewed for security and quality, with consideration given to authors
+  and users of these dependencies, as well as review of open source code.
+* **Periodic security reviews**: Open MCT's code, design, and architecture
+  are periodically reviewed (approximately annually) for common security
+  issues, such as the
+  [OWASP Top Ten](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project).
+
+
+## Security Concerns
+
+* Identity spoofing may occur if source code is compromiesd.
+  * Prevent man-in-the-middle attacks using SSL (https rather than http).
+    * Avoid serving up a malicious version of Open MCT or your plugins.
+
+* Information disclosure.
+  * Don't send sensitive data to third-party servers or insecure APIs.
+
+* Tampering with data
+  * Assume that the server validates data.
+  * Plugins which serialize and write data to server must escape that data.
+
+* Repudiation
+  * Assume server logs relevant actions associated with a user identity.
+  * If client-side behavior must be logged, plugins must do this.
+
+* Denial-of-service
+  * We assume resource-intensive tasks cannot be initiated by untrusted users.
+
+* Elevation of privilege
+  * Assume this
 


### PR DESCRIPTION
Add a security guide to address #1833. Handled this as a separate document, rephrasing the concerns identified in that document for an audience of plugin developers and system administrators.