### PR TITLE
[Layout] Select fixed position view only if the parent is not selected

### DIFF
--- a/platform/commonUI/edit/src/controllers/ElementsController.js
+++ b/platform/commonUI/edit/src/controllers/ElementsController.js
@@ -64,8 +64,10 @@ define(
                 var domainObject = selection[0].context.oldItem;
                 self.refreshComposition(domainObject);
 
-                self.mutationListener = domainObject.getCapability('mutation')
-                    .listen(self.refreshComposition.bind(self, domainObject));
+                if (domainObject) {
+                    self.mutationListener = domainObject.getCapability('mutation')
+                        .listen(self.refreshComposition.bind(self, domainObject));
+                }
             }
 
             $scope.filterBy = filterBy;
@@ -86,7 +88,7 @@ define(
          * @private
          */
         ElementsController.prototype.refreshComposition = function (domainObject) {
-            var selectedObjectComposition = domainObject.useCapability('composition');
+            var selectedObjectComposition = domainObject && domainObject.useCapability('composition');
 
             if (selectedObjectComposition) {
                 selectedObjectComposition.then(function (composition) {

--- a/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
+++ b/platform/commonUI/edit/test/controllers/ElementsControllerSpec.js
@@ -127,6 +127,16 @@ define(
                 expect(mockUnlisten).toHaveBeenCalled();
             });
 
+            it("does not listen on mutation for element proxy selectable", function () {
+                selectable[0] = {
+                    context: {
+                        elementProxy: {}
+                    }
+                };
+                mockOpenMCT.selection.on.mostRecentCall.args[1](selectable);
+
+                expect(mockDomainObject.getCapability).not.toHaveBeenCalledWith('mutation');
+            });
         });
     }
 );

--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -272,7 +272,7 @@ define(
                     self.resizeHandles = self.generateDragHandles(self.selectedElementProxy);
                 } else {
                     // Make fixed view selectable if it's not already.
-                    if (!self.fixedViewSelectable) {
+                    if (!self.fixedViewSelectable && selectable.length === 1) {
                         self.fixedViewSelectable = true;
                         selection.context.viewProxy = new FixedProxy(addElement, $q, dialogService);
                         self.openmct.selection.select(selection);


### PR DESCRIPTION
The fixed view should be selected if it's not inside a layout.

Also, make sure domain object is defined to listen on mutation to fix the TypeError.

Fixes #1909 and #1912