### PR TITLE
[API] provider support for dynamic composition is optional

### DIFF
--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -76,20 +76,22 @@ define([
             throw new Error('Event not supported by composition: ' + event);
         }
 
-        if (event === 'add') {
-            this.provider.on(
-                this.domainObject,
-                'add',
-                this.onProviderAdd,
-                this
-            );
-        } if (event === 'remove') {
-            this.provider.on(
-                this.domainObject,
-                'remove',
-                this.onProviderRemove,
-                this
-            );
+        if (this.provider.on && this.provider.off) {
+            if (event === 'add') {
+                this.provider.on(
+                    this.domainObject,
+                    'add',
+                    this.onProviderAdd,
+                    this
+                );
+            } if (event === 'remove') {
+                this.provider.on(
+                    this.domainObject,
+                    'remove',
+                    this.onProviderRemove,
+                    this
+                );
+            }
         }
 
         this.listeners[event].push({
@@ -124,20 +126,22 @@ define([
         if (this.listeners[event].length === 0) {
             // Remove provider listener if this is the last callback to
             // be removed.
-            if (event === 'add') {
-                this.provider.off(
-                    this.domainObject,
-                    'add',
-                    this.onProviderAdd,
-                    this
-                );
-            } else if (event === 'remove') {
-                this.provider.off(
-                    this.domainObject,
-                    'remove',
-                    this.onProviderRemove,
-                    this
-                );
+            if (this.provider.off && this.provider.on) {
+                if (event === 'add') {
+                    this.provider.off(
+                        this.domainObject,
+                        'add',
+                        this.onProviderAdd,
+                        this
+                    );
+                } else if (event === 'remove') {
+                    this.provider.off(
+                        this.domainObject,
+                        'remove',
+                        this.onProviderRemove,
+                        this
+                    );
+                }
             }
         }
     };


### PR DESCRIPTION
All views are expected to implement dynamic composition handling
by listening for the "add" and "remove" events and then calling
"collection.load()" when they are ready to handle these events.

However, it does not make sense that every composition provider will
be dynamic, so implementing support for dynamic composition should
not be a requirement.  This commit removes that requirement, without 
changing the interface of the Composition Collection.

Fixes #1914

# Reviewer Checklist

1. Changes appear to address issue? Y
2. Appropriate unit tests included? N/A, issues exist for API test backfill.
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y

I am currently backfilling tests for the Composition API and will be opening a separate pull request for those tests.