### PR TITLE
Version bump - 0.12.0 -> 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "0.12.1-SNAPSHOT",
+  "version": "0.13.1",
   "description": "The Open MCT core platform",
   "dependencies": {
     "d3-array": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "0.13.1",
+  "version": "0.13.2-SNAPSHOT",
   "description": "The Open MCT core platform",
   "dependencies": {
     "d3-array": "^1.0.2",


### PR DESCRIPTION
PR to update version number for release. I've bumped the version from 0.12.0 to 0.13.1 because this was the second sprint of a new release (assuming it's zero-indexed and x.x.0 is sprint 1? I read the versioning doc, but I wasn't entirely clear on whether a x.x.0 release was the first sprint of a new release, or the last sprint [ie the most stable] of a prior release?).

PR is needed because of commit-hook that requires at least one review.

## Author Checklist

* Changes address original issue? N/A
* Unit tests included and/or updated with changes? N/A
* Command line build passes? Y
* Changes have been smoke-tested? Y