### PR TITLE
[Inspector] Prevent race condition when refreshing composition...

### DIFF
--- a/platform/commonUI/edit/src/controllers/ElementsController.js
+++ b/platform/commonUI/edit/src/controllers/ElementsController.js
@@ -88,11 +88,15 @@ define(
          * @private
          */
         ElementsController.prototype.refreshComposition = function (domainObject) {
-            var selectedObjectComposition = domainObject && domainObject.useCapability('composition');
+            var refreshTracker = {};
+            this.currentRefresh = refreshTracker;
 
+            var selectedObjectComposition = domainObject && domainObject.useCapability('composition');
             if (selectedObjectComposition) {
                 selectedObjectComposition.then(function (composition) {
-                    this.scope.composition = composition;
+                    if (this.currentRefresh === refreshTracker) {
+                        this.scope.composition = composition;
+                    }
                 }.bind(this));
             } else {
                 this.scope.composition = [];


### PR DESCRIPTION
... by creating a new object and saving it on each request, and on response, checking the saved one is the one we already have.

Fixes #1918