### PR TITLE
Updated version range of gulp-sass to allow later versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-jshint-html-reporter": "^0.1.3",
     "gulp-rename": "^1.2.2",
     "gulp-requirejs-optimize": "^0.3.1",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "jasmine-core": "^2.3.0",
     "jscs-html-reporter": "^0.1.0",


### PR DESCRIPTION
Older versions of node-sass do not have binaries for newer versions of Node. Smoke tested it by building the app and checking everyone looks ok. Also tested with gulp-develop.

## Author Checklist

* Changes address original issue? N/A - No associated issue
* Unit tests included and/or updated with changes? N/A - build config change
* Command line build passes? Y
* Changes have been smoke-tested? Y