### PR TITLE
Summary widget telemetry provider

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,7 +23,7 @@
           - [Value Hints](#value-hints)
         - [The Time Conductor and Telemetry](#the-time-conductor-and-telemetry)
       - [Telemetry Providers](#telemetry-providers)
-      - [Telemetry Requests](#telemetry-requests)
+      - [Telemetry Requests and Responses.](#telemetry-requests-and-responses)
       - [Request Strategies **draft**](#request-strategies-draft)
         - [`latest` request strategy](#latest-request-strategy)
         - [`minmax` request strategy](#minmax-request-strategy)
@@ -32,7 +32,7 @@
       - [Telemetry Data](#telemetry-data)
         - [Telemetry Datums](#telemetry-datums)
       - [Limit Evaluators **draft**](#limit-evaluators-draft)
-    - [Telemetry Visualization APIs **draft**](#telemetry-visualization-apis-draft)
+    - [Telemetry Consumer APIs **draft**](#telemetry-consumer-apis-draft)
   - [Time API](#time-api)
     - [Time Systems and Bounds](#time-systems-and-bounds)
       - [Defining and Registering Time Systems](#defining-and-registering-time-systems)
@@ -449,7 +449,7 @@ A telemetry provider is a javascript object with up to four methods:
 * `supportsSubscribe(domainObject, callback, options)` optional.  Must be implemented to provide realtime telemetry.  Should return `true` if the provider supports subscriptions for the given domain object (and request options).
 * `subscribe(domainObject, callback, options)` required if `supportsSubscribe` is implemented.  Establish a subscription for realtime data for the given domain object.  Should invoke `callback` with a single telemetry datum every time data is received.  Must return an unsubscribe function.  Multiple views can subscribe to the same telemetry object, so it should always return a new unsubscribe function.
 * `supportsRequest(domainObject, options)` optional.  Must be implemented to provide historical telemetry.  Should return `true` if the provider supports historical requests for the given domain object.
-* `request(domainObject, options)` required if `supportsRequest` is implemented.  Must return a promise for an array of telemetry datums that fulfills the request.  The `options` argument will include a `start`, `end`, and `domain` attribute representing the query bounds.  For more request properties, see Request Properties below.
+* `request(domainObject, options)` required if `supportsRequest` is implemented.  Must return a promise for an array of telemetry datums that fulfills the request.  The `options` argument will include a `start`, `end`, and `domain` attribute representing the query bounds.  See [Telemetry Requests and Responses](#telemetry-requests-and-responses) for more info on how to respond to requests.
 * `supportsMetadata(domainObject)` optional.  Implement and return `true` for objects that you want to provide dynamic metadata for.
 * `getMetadata(domainObject)` required if `supportsMetadata` is implemented.  Must return a valid telemetry metadata definition that includes at least one valueMetadata definition.
 * `supportsLimits(domainObject)` optional.  Implement and return `true` for domain objects that you want to provide a limit evaluator for.
@@ -466,7 +466,7 @@ openmct.telemetry.addProvider({
 
 Note: it is not required to implement all of the methods on every provider.  Depending on the complexity of your implementation, it may be helpful to instantiate and register your realtime, historical, and metadata providers separately.
 
-#### Telemetry Requests
+#### Telemetry Requests and Responses.
 
 Telemetry requests support time bounded queries. A call to a _Telemetry Provider_'s `request` function will include an `options` argument. These are simply javascript objects with attributes for the request parameters. An example of a telemetry request object with a start and end time is included below:
 
@@ -480,8 +480,7 @@ Telemetry requests support time bounded queries. A call to a _Telemetry Provider
 
 In this case, the `domain` is the currently selected time-system, and the start and end dates are valid dates in that time system.
 
-The response to a telemetry request is an array of telemetry datums.  
-These datums must be sorted by `domain` in ascending order.
+A telemetry provider's `request` method should return a promise for an array of telemetry datums.  These datums must be sorted by `domain` in ascending order.
 
 #### Request Strategies **draft**
 

--- a/src/plugins/summaryWidget/plugin.js
+++ b/src/plugins/summaryWidget/plugin.js
@@ -19,8 +19,40 @@ define([
             cssClass: 'icon-summary-widget',
             initialize: function (domainObject) {
                 domainObject.composition = [];
-                domainObject.configuration = {};
+                domainObject.configuration = {
+                    ruleOrder: ['default'],
+                    ruleConfigById: {
+                        default: {
+                            name: 'Default',
+                            label: 'Unnamed Rule',
+                            message: '',
+                            id: 'default',
+                            icon: ' ',
+                            style: {
+                                'color': '#ffffff',
+                                'background-color': '#38761d',
+                                'border-color': 'rgba(0,0,0,0)'
+                            },
+                            description: 'Default appearance for the widget',
+                            conditions: [{
+                                object: '',
+                                key: '',
+                                operation: '',
+                                values: []
+                            }],
+                            jsCondition: '',
+                            trigger: 'any',
+                            expanded: 'true'
+                        }
+                    },
+                    testDataConfig: [{
+                        object: '',
+                        key: '',
+                        value: ''
+                    }]
+                };
                 domainObject.openNewTab = 'thisTab';
+                domainObject.telemetry = {};
             },
             form: [
                 {

--- a/src/plugins/summaryWidget/plugin.js
+++ b/src/plugins/summaryWidget/plugin.js
@@ -1,13 +1,13 @@
 define([
-    './src/SummaryWidget',
     './SummaryWidgetsCompositionPolicy',
     './src/telemetry/SummaryWidgetMetadataProvider',
-    './src/telemetry/SummaryWidgetTelemetryProvider'
+    './src/telemetry/SummaryWidgetTelemetryProvider',
+    './src/views/SummaryWidgetViewProvider'
 ], function (
-    SummaryWidget,
     SummaryWidgetsCompositionPolicy,
     SummaryWidgetMetadataProvider,
-    SummaryWidgetTelemetryProvider
+    SummaryWidgetTelemetryProvider,
+    SummaryWidgetViewProvider
 ) {
 
     function plugin() {
@@ -50,28 +50,14 @@ define([
             ]
         };
 
-        function initViewProvider(openmct) {
-            return {
-                name: 'Widget View',
-                view: function (domainObject) {
-                    return new SummaryWidget(domainObject, openmct);
-                },
-                canView: function (domainObject) {
-                    return (domainObject.type === 'summary-widget');
-                },
-                editable: true,
-                key: 'summaryWidgets'
-            };
-        }
-
         return function install(openmct) {
             openmct.types.addType('summary-widget', widgetType);
-            openmct.objectViews.addProvider(initViewProvider(openmct));
             openmct.legacyExtension('policies', {category: 'composition',
                 implementation: SummaryWidgetsCompositionPolicy, depends: ['openmct']
             });
             openmct.telemetry.addMetadataProvider(new SummaryWidgetMetadataProvider(openmct));
             openmct.telemetry.addProvider(new SummaryWidgetTelemetryProvider(openmct));
+            openmct.objectViews.addProvider(new SummaryWidgetViewProvider(openmct));
         };
     }
 

--- a/src/plugins/summaryWidget/plugin.js
+++ b/src/plugins/summaryWidget/plugin.js
@@ -1,4 +1,14 @@
-define(['./src/SummaryWidget', './SummaryWidgetsCompositionPolicy'], function (SummaryWidget, SummaryWidgetsCompositionPolicy) {
+define([
+    './src/SummaryWidget',
+    './SummaryWidgetsCompositionPolicy',
+    './src/telemetry/SummaryWidgetMetadataProvider',
+    './src/telemetry/SummaryWidgetTelemetryProvider'
+], function (
+    SummaryWidget,
+    SummaryWidgetsCompositionPolicy,
+    SummaryWidgetMetadataProvider,
+    SummaryWidgetTelemetryProvider
+) {
 
     function plugin() {
 
@@ -60,6 +70,8 @@ define(['./src/SummaryWidget', './SummaryWidgetsCompositionPolicy'], function (S
             openmct.legacyExtension('policies', {category: 'composition',
                 implementation: SummaryWidgetsCompositionPolicy, depends: ['openmct']
             });
+            openmct.telemetry.addMetadataProvider(new SummaryWidgetMetadataProvider(openmct));
+            openmct.telemetry.addProvider(new SummaryWidgetTelemetryProvider(openmct));
         };
     }
 

--- a/src/plugins/summaryWidget/plugin.js
+++ b/src/plugins/summaryWidget/plugin.js
@@ -87,7 +87,7 @@ define([
             openmct.legacyExtension('policies', {category: 'composition',
                 implementation: SummaryWidgetsCompositionPolicy, depends: ['openmct']
             });
-            openmct.telemetry.addMetadataProvider(new SummaryWidgetMetadataProvider(openmct));
+            openmct.telemetry.addProvider(new SummaryWidgetMetadataProvider(openmct));
             openmct.telemetry.addProvider(new SummaryWidgetTelemetryProvider(openmct));
             openmct.objectViews.addProvider(new SummaryWidgetViewProvider(openmct));
         };

--- a/src/plugins/summaryWidget/src/ConditionManager.js
+++ b/src/plugins/summaryWidget/src/ConditionManager.js
@@ -125,12 +125,13 @@ define ([
     ConditionManager.prototype.parsePropertyTypes = function (object) {
 
         this.telemetryTypesById[object.identifier.key] = {};
-        Object.values(this.telemetryMetadataById[object.identifier.key]).forEach(function(valueMetadata) {
+        Object.values(this.telemetryMetadataById[object.identifier.key]).forEach(function (valueMetadata) {
+            var type;
             if (valueMetadata.hints.hasOwnProperty('range')) {
                 type = 'number';
             } else if (valueMetadata.hints.hasOwnProperty('domain')) {
                 type = 'number';
-            } else if (valueMetadata.key == 'name') {
+            } else if (valueMetadata.key === 'name') {
                 type = 'string';
             } else {
                 type = 'string';
@@ -247,7 +248,7 @@ define ([
     ConditionManager.prototype.onCompositionLoad = function () {
         this.loadComplete = true;
         this.eventEmitter.emit('load');
-        this.parseAllPropertyTypes()
+        this.parseAllPropertyTypes();
     };
 
     /**

--- a/src/plugins/summaryWidget/src/TestDataItem.js
+++ b/src/plugins/summaryWidget/src/TestDataItem.js
@@ -127,6 +127,13 @@ define([
     };
 
     /**
+     * Implement "off" to complete event emitter interface.
+     */
+    TestDataItem.prototype.off = function (event, callback, context) {
+        this.eventEmitter.off(event, callback, context);
+    };
+
+    /**
      * Hide the appropriate inputs when this is the only item
      */
     TestDataItem.prototype.hideButtons = function () {

--- a/src/plugins/summaryWidget/src/TestDataManager.js
+++ b/src/plugins/summaryWidget/src/TestDataManager.js
@@ -131,15 +131,20 @@ define([
      */
     TestDataManager.prototype.refreshItems = function () {
         var self = this;
+        if (this.items) {
+            this.items.forEach(function (item) {
+                this.stopListening(item);
+            }, this);
+        }
 
         self.items = [];
         $('.t-test-data-item', this.domElement).remove();
 
         this.config.forEach(function (item, index) {
             var newItem = new TestDataItem(item, index, self.manager);
-            newItem.on('remove', self.removeItem, self);
-            newItem.on('duplicate', self.initItem, self);
-            newItem.on('change', self.onItemChange, self);
+            self.listenTo(newItem, 'remove', self.removeItem, self);
+            self.listenTo(newItem, 'duplicate', self.initItem, self);
+            self.listenTo(newItem, 'change', self.onItemChange, self);
             self.items.push(newItem);
         });
 
@@ -190,10 +195,10 @@ define([
     };
 
     TestDataManager.prototype.destroy = function () {
+        this.stopListening();
         this.items.forEach(function (item) {
             item.remove();
         });
-        this.stopListening();
     };
 
     return TestDataManager;

--- a/src/plugins/summaryWidget/src/input/ObjectSelect.js
+++ b/src/plugins/summaryWidget/src/input/ObjectSelect.js
@@ -1,4 +1,10 @@
-define(['./Select'], function (Select) {
+define([
+    './Select',
+    '../../../../api/objects/object-utils'
+], function (
+    Select,
+    objectUtils
+) {
 
     /**
      * Create a {Select} element whose composition is dynamically updated with
@@ -37,7 +43,7 @@ define(['./Select'], function (Select) {
          * @private
          */
         function onCompositionAdd(obj) {
-            self.select.addOption(obj.identifier.key, obj.name);
+            self.select.addOption(objectUtils.makeKeyString(obj.identifier), obj.name);
         }
 
         /**
@@ -75,7 +81,7 @@ define(['./Select'], function (Select) {
      */
     ObjectSelect.prototype.generateOptions = function () {
         var items = Object.values(this.compositionObjs).map(function (obj) {
-            return [obj.identifier.key, obj.name];
+            return [objectUtils.makeKeyString(obj.identifier), obj.name];
         });
         this.baseOptions.forEach(function (option, index) {
             items.splice(index, 0, option);

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
@@ -1,0 +1,44 @@
+define([
+    './SummaryWidgetEvaluator',
+    '../../../../api/objects/object-utils'
+], function (
+    SummaryWidgetEvaluator,
+    objectUtils
+) {
+
+    function EvaluatorPool(openmct) {
+        this.openmct = openmct;
+        this.byObjectId = {};
+        this.byEvaluator = new WeakMap();
+    };
+
+    EvaluatorPool.prototype.get = function (domainObject) {
+        var objectId = objectUtils.makeKeyString(domainObject);
+        var poolEntry = this.byObjectId[objectId];
+        if (!poolEntry) {
+            console.log('new evaluator!');
+            poolEntry = {
+                leases: 0,
+                objectId: objectId,
+                evaluator: new SummaryWidgetEvaluator(domainObject, this.openmct)
+            };
+            this.byEvaluator.set(poolEntry.evaluator, poolEntry);
+            this.byObjectId[objectId] = poolEntry;
+        }
+        poolEntry.leases += 1;
+        return poolEntry.evaluator;
+    };
+
+    EvaluatorPool.prototype.release = function (evaluator) {
+        var poolEntry = this.byEvaluator.get(evaluator);
+        poolEntry.leases -= 1;
+        if (poolEntry.leases === 0) {
+            console.log('destroy evaluator!');
+            evaluator.destroy();
+            this.byEvaluator.delete(evaluator);
+            delete this.byObjectId[poolEntry.objectId];
+        }
+    };
+
+    return EvaluatorPool;
+});

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
@@ -10,13 +10,12 @@ define([
         this.openmct = openmct;
         this.byObjectId = {};
         this.byEvaluator = new WeakMap();
-    };
+    }
 
     EvaluatorPool.prototype.get = function (domainObject) {
         var objectId = objectUtils.makeKeyString(domainObject);
         var poolEntry = this.byObjectId[objectId];
         if (!poolEntry) {
-            console.log('new evaluator!');
             poolEntry = {
                 leases: 0,
                 objectId: objectId,
@@ -33,7 +32,6 @@ define([
         var poolEntry = this.byEvaluator.get(evaluator);
         poolEntry.leases -= 1;
         if (poolEntry.leases === 0) {
-            console.log('destroy evaluator!');
             evaluator.destroy();
             this.byEvaluator.delete(evaluator);
             delete this.byObjectId[poolEntry.objectId];

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
@@ -13,7 +13,7 @@ define([
     }
 
     EvaluatorPool.prototype.get = function (domainObject) {
-        var objectId = objectUtils.makeKeyString(domainObject);
+        var objectId = objectUtils.makeKeyString(domainObject.identifier);
         var poolEntry = this.byObjectId[objectId];
         if (!poolEntry) {
             poolEntry = {

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './SummaryWidgetEvaluator',
     '../../../../api/objects/object-utils'

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPoolSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPoolSpec.js
@@ -1,0 +1,80 @@
+define([
+    './EvaluatorPool',
+    './SummaryWidgetEvaluator'
+], function (
+    EvaluatorPool,
+    SummaryWidgetEvaluator
+) {
+    describe('EvaluatorPool', function () {
+        var pool;
+        var openmct;
+        var objectA;
+        var objectB;
+
+        beforeEach(function () {
+            openmct = {
+                composition: jasmine.createSpyObj('compositionAPI', ['get']),
+                objects: jasmine.createSpyObj('objectAPI', ['observe'])
+            };
+            openmct.composition.get.andCallFake(function () {
+                var compositionCollection = jasmine.createSpyObj(
+                    'compositionCollection',
+                    [
+                        'load',
+                        'on',
+                        'off'
+                    ]
+                );
+                compositionCollection.load.andReturn(Promise.resolve());
+                return compositionCollection;
+            });
+            openmct.objects.observe.andCallFake(function () {
+                return function () {};
+            });
+            pool = new EvaluatorPool(openmct);
+            objectA = {
+                identifier: {
+                    namespace: 'someNamespace',
+                    key: 'someKey'
+                },
+                configuration: {
+                    ruleOrder: []
+                }
+            };
+            objectB = {
+                identifier: {
+                    namespace: 'otherNamespace',
+                    key: 'otherKey'
+                },
+                configuration: {
+                    ruleOrder: []
+                }
+            };
+        });
+
+        it('returns new evaluators for different objects', function () {
+            var evaluatorA = pool.get(objectA);
+            var evaluatorB = pool.get(objectB);
+            expect(evaluatorA).not.toBe(evaluatorB);
+        });
+
+        it('returns the same evaluator for the same object', function () {
+            var evaluatorA = pool.get(objectA);
+            var evaluatorB = pool.get(objectA);
+            expect(evaluatorA).toBe(evaluatorB);
+
+            var evaluatorC = pool.get(JSON.parse(JSON.stringify(objectA)));
+            expect(evaluatorA).toBe(evaluatorC);
+        });
+
+        it('returns new evaluator when old is released', function () {
+            var evaluatorA = pool.get(objectA);
+            var evaluatorB = pool.get(objectA);
+            expect(evaluatorA).toBe(evaluatorB);
+            pool.release(evaluatorA);
+            pool.release(evaluatorB);
+            var evaluatorC = pool.get(objectA);
+            expect(evaluatorA).not.toBe(evaluatorC);
+        });
+    });
+});

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPoolSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPoolSpec.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './EvaluatorPool',
     './SummaryWidgetEvaluator'

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetCondition.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetCondition.js
@@ -1,0 +1,58 @@
+define([
+    './operations'
+], function (
+    OPERATIONS
+) {
+
+    function SummaryWidgetCondition(definition) {
+        this.object = definition.object;
+        this.key = definition.key;
+        this.values = definition.values;
+        if (!definition.operation) {
+            // TODO: better handling for default rule.
+            this.evaluate = function () {
+                return true;
+            };
+        } else {
+            this.comparator = OPERATIONS[definition.operation].operation;
+        }
+    }
+
+    SummaryWidgetCondition.prototype.evaluate = function (telemetryState) {
+        var stateKeys = Object.keys(telemetryState);
+        var state;
+        var result;
+        var i;
+
+        if (this.object === 'any') {
+            for (i = 0; i < stateKeys.length; i++) {
+                state = telemetryState[stateKeys[i]];
+                result = this.evaluateState(state);
+                if (result) {
+                    return true;
+                }
+            }
+            return false;
+        } else if (this.object === 'all') {
+            for (i = 0; i < stateKeys.length; i++) {
+                state = telemetryState[stateKeys[i]];
+                result = this.evaluateState(state);
+                if (!result) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return this.evaluateState(telemetryState[this.object]);
+        }
+    };
+
+    SummaryWidgetCondition.prototype.evaluateState = function (state) {
+        var testValues = [
+            state.formats[this.key].parse(state.lastDatum)
+        ].concat(this.values);
+        return this.comparator(testValues);
+    };
+
+    return SummaryWidgetCondition;
+});

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetCondition.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetCondition.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './operations'
 ], function (

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetConditionSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetConditionSpec.js
@@ -1,0 +1,120 @@
+define([
+    './SummaryWidgetCondition'
+], function (
+    SummaryWidgetCondition
+) {
+
+    describe('SummaryWidgetCondition', function () {
+        var condition;
+        var telemetryState;
+
+        beforeEach(function () {
+            // Format map intentionally uses different keys than those present
+            // in datum, which serves to verify conditions use format map to get
+            // data.
+            var formatMap = {
+                adjusted: {
+                    parse: function (datum) {
+                        return datum.value + 10;
+                    }
+                },
+                raw: {
+                    parse: function (datum) {
+                        return datum.value;
+                    }
+                }
+            };
+
+            telemetryState = {
+                objectId: {
+                    formats: formatMap,
+                    lastDatum: {
+                    }
+                },
+                otherObjectId: {
+                    formats: formatMap,
+                    lastDatum: {
+                    }
+                }
+            };
+
+        });
+
+        it('can evaluate if a single object matches', function () {
+            condition = new SummaryWidgetCondition({
+                object: 'objectId',
+                key: 'raw',
+                operation: 'greaterThan',
+                values: [
+                    10
+                ]
+            });
+            telemetryState.objectId.lastDatum.value = 5;
+            expect(condition.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            expect(condition.evaluate(telemetryState)).toBe(true);
+        });
+
+        it('can evaluate if a single object matches (alternate keys)', function () {
+            condition = new SummaryWidgetCondition({
+                object: 'objectId',
+                key: 'adjusted',
+                operation: 'greaterThan',
+                values: [
+                    10
+                ]
+            });
+            telemetryState.objectId.lastDatum.value = -5;
+            expect(condition.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 5;
+            expect(condition.evaluate(telemetryState)).toBe(true);
+        });
+
+        it('can evaluate "if all objects match"', function () {
+            condition = new SummaryWidgetCondition({
+                object: 'all',
+                key: 'raw',
+                operation: 'greaterThan',
+                values: [
+                    10
+                ]
+            });
+            telemetryState.objectId.lastDatum.value = 0;
+            telemetryState.otherObjectId.lastDatum.value = 0;
+            expect(condition.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 0;
+            telemetryState.otherObjectId.lastDatum.value = 15;
+            expect(condition.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 0;
+            expect(condition.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 15;
+            expect(condition.evaluate(telemetryState)).toBe(true);
+        });
+
+        it('can evalute "if any object matches"', function () {
+            condition = new SummaryWidgetCondition({
+                object: 'any',
+                key: 'raw',
+                operation: 'greaterThan',
+                values: [
+                    10
+                ]
+            });
+            telemetryState.objectId.lastDatum.value = 0;
+            telemetryState.otherObjectId.lastDatum.value = 0;
+            expect(condition.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 0;
+            telemetryState.otherObjectId.lastDatum.value = 15;
+            expect(condition.evaluate(telemetryState)).toBe(true);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 0;
+            expect(condition.evaluate(telemetryState)).toBe(true);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 15;
+            expect(condition.evaluate(telemetryState)).toBe(true);
+        });
+
+    });
+});

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetConditionSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetConditionSpec.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './SummaryWidgetCondition'
 ], function (

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -32,7 +32,7 @@ define([
         this.listenTo(composition, 'add', this.addChild, this);
         this.listenTo(composition, 'remove', this.removeChild, this);
 
-        this._loadPromise = composition.load();
+        this.loadPromise = composition.load();
     }
 
     eventHelpers.extend(SummaryWidgetEvaluator.prototype);
@@ -63,7 +63,7 @@ define([
                 );
             }.bind(this));
 
-        return function unsubscribe() {
+        return function () {
             active = false;
             unsubscribes.forEach(function (unsubscribe) {
                 unsubscribe();
@@ -116,7 +116,7 @@ define([
     };
 
     SummaryWidgetEvaluator.prototype.load = function () {
-        return this._loadPromise;
+        return this.loadPromise;
     };
 
     /**

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -14,7 +14,6 @@ define([
      * evaluates rules defined in a summary widget against either lad or
      * realtime state.
      *
-     * Does not handle mutation.
      */
     function SummaryWidgetEvaluator(domainObject, openmct) {
         this.openmct = openmct;
@@ -191,6 +190,7 @@ define([
     /**
      * Given a base datum(containing timestamps) and rule index, adds values
      * from the matching rule.
+     * @private
      */
     SummaryWidgetEvaluator.prototype.makeDatumFromRule = function (ruleIndex, baseDatum) {
         var rule = this.rules[ruleIndex];
@@ -229,6 +229,9 @@ define([
         return this.makeDatumFromRule(i, latestTimestamp);
     };
 
+    /**
+     * remove all listeners and clean up any resources.
+     */
     SummaryWidgetEvaluator.prototype.destroy = function () {
         this.stopListening();
         this.removeObserver();

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -1,0 +1,115 @@
+define([
+    './SummaryWidgetRule',
+    '../eventHelpers',
+    '../../../../api/objects/object-utils'
+], function (
+    SummaryWidgetRule,
+    eventHelpers,
+    objectUtils
+) {
+
+    function SummaryWidgetEvaluator(domainObject, openmct, callback) {
+        this.openmct = openmct;
+        this.telemetryState = {};
+        this.callback = callback;
+        this.loaded = false;
+        this.destroyed = false;
+
+        var composition = openmct.composition.get(domainObject);
+
+        this.listenTo(composition, 'add', this.addChild, this);
+        this.listenTo(composition, 'remove', this.removeChild, this);
+
+        this.rules = domainObject.configuration.ruleOrder.map(function (ruleId) {
+            return new SummaryWidgetRule(domainObject.configuration.ruleConfigById[ruleId]);
+        });
+
+        composition.load()
+            .then(function () {
+                this.loaded = true;
+            }.bind(this));
+    }
+
+    eventHelpers.extend(SummaryWidgetEvaluator.prototype);
+
+    SummaryWidgetEvaluator.prototype.addChild = function (childObject) {
+        var childId = objectUtils.makeKeyString(childObject.identifier);
+        var metadata = this.openmct.telemetry.getMetadata(childObject);
+        var formats = this.openmct.telemetry.getFormatMap(metadata);
+        var unsubscribe = this.openmct.telemetry.subscribe(
+            childObject,
+            this.updateDatum.bind(this, childId)
+        );
+
+        this.telemetryState[childId] = {
+            domainObject: childObject,
+            metadata: metadata,
+            formats: formats,
+            unsubscribe: unsubscribe,
+            lastDatum: undefined,
+            testDatum: undefined
+        };
+    };
+
+    SummaryWidgetEvaluator.prototype.removeChild = function (childObject) {
+        var childId = objectUtils.makeKeyString(childObject.identifier);
+        var telemetrySource = this.telemetrySources[childId];
+        delete this.telemetrySources[childId];
+        telemetrySource.unsubscribe();
+    };
+
+    SummaryWidgetEvaluator.prototype.getTimestampedDatum = function (childId, datum) {
+        var timestampedDatum = {};
+        this.openmct.time.getAllTimeSystems().forEach(function (timeSystem) {
+            timestampedDatum[timeSystem.key] =
+                this.telemetryState[childId].formats[timeSystem.key].parse(datum);
+        }, this);
+        return timestampedDatum;
+    };
+
+    SummaryWidgetEvaluator.prototype.updateDatum = function (childId, datum) {
+        var timestampedDatum = this.getTimestampedDatum(childId, datum);
+        this.telemetryState[childId].lastDatum = datum;
+        this.updateState(timestampedDatum);
+    };
+
+    SummaryWidgetEvaluator.prototype.addCallback = function (callback) {
+        this.callbacks.push(callback);
+    };
+
+    SummaryWidgetEvaluator.prototype.updateStateFromRule = function (ruleIndex, newState) {
+        var rule = this.rules[ruleIndex];
+
+        newState.color = rule.color;
+        newState.ruleName = rule.name;
+        newState.ruleIndex = ruleIndex;
+        newState.backgroundColor = rule.style['background-color'];
+        newState.textColor = rule.style.color;
+        newState.borderColor = rule.style['border-color'];
+        newState.icon = rule.icon;
+
+        this.callback(newState);
+    };
+
+    SummaryWidgetEvaluator.prototype.updateState = function (timestampedDatum) {
+        for (var i = this.rules.length - 1; i > 0; i--) {
+            if (this.rules[i].evaluate(this.telemetryState, false)) {
+                break;
+            }
+        }
+        this.updateStateFromRule(i, timestampedDatum);
+    };
+
+    SummaryWidgetEvaluator.prototype.destroy = function () {
+        Object.keys(this.telemetryState).forEach(function (stateKey) {
+            this.telemetryState[stateKey].unsubscribe();
+        }, this);
+        this.stopListening();
+        this.destroyed = true;
+        delete this.telemetryState;
+        delete this.callback;
+    };
+
+    return SummaryWidgetEvaluator;
+
+});

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -248,6 +248,10 @@ define([
             .sortBy(timestampKey)
             .first();
 
+        if (!latestTimestamp) {
+            latestTimestamp = {};
+        }
+
         latestTimestamp = _.clone(latestTimestamp);
 
         for (var i = this.rules.length - 1; i > 0; i--) {

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -243,10 +243,11 @@ define([
         if (!hasRequiredData) {
             return;
         }
+
         var latestTimestamp = _(state)
             .map('timestamps')
             .sortBy(timestampKey)
-            .first();
+            .last();
 
         if (!latestTimestamp) {
             latestTimestamp = {};

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -75,7 +75,9 @@ define([
                         realtimeStates,
                         this.openmct.time.timeSystem().key
                     );
-                    callback(datum);
+                    if (datum) {
+                        callback(datum);
+                    }
                 }.bind(this);
 
                 unsubscribes = _.map(
@@ -235,6 +237,12 @@ define([
      * @private.
      */
     SummaryWidgetEvaluator.prototype.evaluateState = function (state, timestampKey) {
+        var hasRequiredData = Object.keys(state).reduce(function (itDoes, k) {
+            return itDoes && state[k].lastDatum;
+        }, true);
+        if (!hasRequiredData) {
+            return;
+        }
         var latestTimestamp = _(state)
             .map('timestamps')
             .sortBy(timestampKey)

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetEvaluator.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './SummaryWidgetRule',
     '../eventHelpers',

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -26,9 +26,11 @@ define([
     };
 
     SummaryWidgetMetadataProvider.prototype.getMetadata = function (domainObject) {
-        var enumerations = domainObject
-            .configuration
-            .ruleOrder
+        var ruleOrder = domainObject.configuration.ruleOrder || [];
+        var enumerations = ruleOrder
+            .filter(function (ruleId) {
+                return !!domainObject.configuration.ruleConfigById[ruleId];
+            })
             .map(function (ruleId, ruleIndex) {
                 return {
                     string: domainObject.configuration.ruleConfigById[ruleId].label,

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -50,8 +50,18 @@ define([
                     }
                 },
                 {
+                    name: 'Rule Label',
+                    key: 'ruleLabel',
+                    format: 'string'
+                },
+                {
                     name: 'Rule Name',
                     key: 'ruleName',
+                    format: 'string'
+                },
+                {
+                    name: 'Message',
+                    key: 'message',
                     format: 'string'
                 },
                 {

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -1,0 +1,85 @@
+define([
+
+], function (
+
+) {
+
+    function SummaryWidgetMetadataProvider(openmct) {
+        this.openmct = openmct;
+    }
+
+    SummaryWidgetMetadataProvider.prototype.appliesTo = function (domainObject) {
+        return domainObject.type === 'summary-widget';
+    };
+
+    SummaryWidgetMetadataProvider.prototype.getDomains = function (domainObject) {
+        return this.openmct.time.getAllTimeSystems().map(function (ts, i) {
+            return {
+                key: ts.key,
+                name: 'UTC',
+                format: ts.timeFormat,
+                hints: {
+                    domain: i
+                }
+            };
+        });
+    };
+
+    SummaryWidgetMetadataProvider.prototype.getMetadata = function (domainObject) {
+        var enumerations = domainObject
+            .configuration
+            .ruleOrder
+            .map(function (ruleId, ruleIndex) {
+                return {
+                    string: domainObject.configuration.ruleConfigById[ruleId].label,
+                    value: ruleIndex
+                };
+            });
+
+        var metadata = {
+            // Generally safe assumption is that we have one domain per timeSystem.
+            values: this.getDomains().concat([
+                {
+                    name: 'state',
+                    key: 'state',
+                    source: 'ruleIndex',
+                    format: 'enum',
+                    enumerations: enumerations,
+                    hints: {
+                        range: 1
+                    }
+                },
+                {
+                    name: 'Rule Name',
+                    key: 'ruleName',
+                    format: 'string'
+                },
+                {
+                    name: 'Background Color',
+                    key: 'backgroundColor',
+                    format: 'string'
+                },
+                {
+                    name: 'Text Color',
+                    key: 'textColor',
+                    format: 'string'
+                },
+                {
+                    name: 'Border Color',
+                    key: 'borderColor',
+                    format: 'string'
+                },
+                {
+                    name: 'Display Icon',
+                    key: 'icon',
+                    format: 'string'
+                }
+            ])
+        };
+
+        return metadata;
+    };
+
+    return SummaryWidgetMetadataProvider;
+
+});

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -30,7 +30,7 @@ define([
         this.openmct = openmct;
     }
 
-    SummaryWidgetMetadataProvider.prototype.appliesTo = function (domainObject) {
+    SummaryWidgetMetadataProvider.prototype.supportsMetadata = function (domainObject) {
         return domainObject.type === 'summary-widget';
     };
 

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
 
 ], function (

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
@@ -9,6 +9,7 @@ define([
         this.id = definition.id;
         this.icon = definition.icon;
         this.style = definition.style;
+        this.message = definition.message;
         this.description = definition.description;
         this.conditions = definition.conditions.map(function (cDefinition) {
             return new SummaryWidgetCondition(cDefinition);

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
@@ -1,0 +1,50 @@
+define([
+    './SummaryWidgetCondition'
+], function (
+    SummaryWidgetCondition
+) {
+    function SummaryWidgetRule(definition) {
+        this.name = definition.name;
+        this.label = definition.label;
+        this.id = definition.id;
+        this.icon = definition.icon;
+        this.style = definition.style;
+        this.description = definition.description;
+        this.conditions = definition.conditions.map(function (cDefinition) {
+            return new SummaryWidgetCondition(cDefinition);
+        });
+        this.trigger = definition.trigger;
+    }
+
+    /**
+     * Evaluate the given rule against a telemetryState and return true if it
+     * matches.
+     */
+    SummaryWidgetRule.prototype.evaluate = function (telemetryState) {
+        var i;
+        var result;
+
+        if (this.trigger === 'all') {
+            for (i = 0; i < this.conditions.length; i++) {
+                result = this.conditions[i].evaluate(telemetryState);
+                if (!result) {
+                    return false;
+                }
+            }
+            return true;
+        } else if (this.trigger === 'any') {
+            for (i = 0; i < this.conditions.length; i++) {
+                result = this.conditions[i].evaluate(telemetryState);
+                if (result) {
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            throw new Error('Invalid rule trigger: ' + this.trigger);
+        }
+    };
+
+    return SummaryWidgetRule;
+});
+

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './SummaryWidgetCondition'
 ], function (

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRuleSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRuleSpec.js
@@ -1,0 +1,141 @@
+define([
+    './SummaryWidgetRule'
+], function (
+    SummaryWidgetRule
+) {
+    describe('SummaryWidgetRule', function () {
+
+        var rule;
+        var telemetryState;
+
+        beforeEach(function () {
+            var formatMap = {
+                raw: {
+                    parse: function (datum) {
+                        return datum.value;
+                    }
+                }
+            };
+
+            telemetryState = {
+                objectId: {
+                    formats: formatMap,
+                    lastDatum: {
+                    }
+                },
+                otherObjectId: {
+                    formats: formatMap,
+                    lastDatum: {
+                    }
+                }
+            };
+        });
+
+        it('allows single condition rules with any', function () {
+            rule = new SummaryWidgetRule({
+                trigger: 'any',
+                conditions: [{
+                    object: 'objectId',
+                    key: 'raw',
+                    operation: 'greaterThan',
+                    values: [
+                        10
+                    ]
+                }]
+            });
+
+            telemetryState.objectId.lastDatum.value = 5;
+            expect(rule.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            expect(rule.evaluate(telemetryState)).toBe(true);
+        });
+
+        it('allows single condition rules with all', function () {
+            rule = new SummaryWidgetRule({
+                trigger: 'all',
+                conditions: [{
+                    object: 'objectId',
+                    key: 'raw',
+                    operation: 'greaterThan',
+                    values: [
+                        10
+                    ]
+                }]
+            });
+
+            telemetryState.objectId.lastDatum.value = 5;
+            expect(rule.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            expect(rule.evaluate(telemetryState)).toBe(true);
+        });
+
+        it('can combine multiple conditions with all', function () {
+            rule = new SummaryWidgetRule({
+                trigger: 'all',
+                conditions: [{
+                    object: 'objectId',
+                    key: 'raw',
+                    operation: 'greaterThan',
+                    values: [
+                        10
+                    ]
+                }, {
+                    object: 'otherObjectId',
+                    key: 'raw',
+                    operation: 'greaterThan',
+                    values: [
+                        20
+                    ]
+                }]
+            });
+
+            telemetryState.objectId.lastDatum.value = 5;
+            telemetryState.otherObjectId.lastDatum.value = 5;
+            expect(rule.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 5;
+            telemetryState.otherObjectId.lastDatum.value = 25;
+            expect(rule.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 5;
+            expect(rule.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 25;
+            expect(rule.evaluate(telemetryState)).toBe(true);
+
+        });
+
+        it('can combine multiple conditions with any', function () {
+            rule = new SummaryWidgetRule({
+                trigger: 'any',
+                conditions: [{
+                    object: 'objectId',
+                    key: 'raw',
+                    operation: 'greaterThan',
+                    values: [
+                        10
+                    ]
+                }, {
+                    object: 'otherObjectId',
+                    key: 'raw',
+                    operation: 'greaterThan',
+                    values: [
+                        20
+                    ]
+                }]
+            });
+
+            telemetryState.objectId.lastDatum.value = 5;
+            telemetryState.otherObjectId.lastDatum.value = 5;
+            expect(rule.evaluate(telemetryState)).toBe(false);
+            telemetryState.objectId.lastDatum.value = 5;
+            telemetryState.otherObjectId.lastDatum.value = 25;
+            expect(rule.evaluate(telemetryState)).toBe(true);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 5;
+            expect(rule.evaluate(telemetryState)).toBe(true);
+            telemetryState.objectId.lastDatum.value = 15;
+            telemetryState.otherObjectId.lastDatum.value = 25;
+            expect(rule.evaluate(telemetryState)).toBe(true);
+        });
+    });
+});

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRuleSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRuleSpec.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './SummaryWidgetRule'
 ], function (

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
@@ -9,11 +9,14 @@ define([
     }
 
     SummaryWidgetTelemetryProvider.prototype.supportsRequest = function (domainObject, options) {
-        return domainObject.type === 'summary-widget' &&
-            (options.strategy === 'latest' || options.size === 1);
+        return domainObject.type === 'summary-widget';
     };
 
     SummaryWidgetTelemetryProvider.prototype.request = function (domainObject, options) {
+        if (options.strategy !== 'latest' && options.size !== 1) {
+            return Promise.resolve([]);
+        }
+
         var evaluator = this.pool.get(domainObject);
         return evaluator.requestLatest(options)
             .then(function (latestDatum) {

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
@@ -3,12 +3,22 @@ define([
 ], function (
     SummaryWidgetEvaluator
 ) {
+
     function SummaryWidgetTelemetryProvider(openmct) {
         this.openmct = openmct;
     }
 
-    SummaryWidgetTelemetryProvider.prototype.supportsRequest = function (options, domainObject) {
-        return false;
+    SummaryWidgetTelemetryProvider.prototype.supportsRequest = function (domainObject, options) {
+        return domainObject.type === 'summary-widget' &&
+            (options.strategy === 'latest' || options.size === 1);
+    };
+
+    SummaryWidgetTelemetryProvider.prototype.request = function (domainObject, options) {
+        var evaluator = new SummaryWidgetEvaluator(domainObject, this.openmct);
+        return evaluator.requestLatest(options)
+            .then(function (latestDatum) {
+                return [latestDatum];
+            });
     };
 
     SummaryWidgetTelemetryProvider.prototype.supportsSubscribe = function (domainObject) {
@@ -16,10 +26,8 @@ define([
     };
 
     SummaryWidgetTelemetryProvider.prototype.subscribe = function (domainObject, callback) {
-        var evaluator = new SummaryWidgetEvaluator(domainObject, this.openmct, callback);
-        return function unsubscribe() {
-            evaluator.destroy();
-        };
+        var evaluator = new SummaryWidgetEvaluator(domainObject, this.openmct);
+        return evaluator.subscribe(callback);
     };
 
     return SummaryWidgetTelemetryProvider;

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
@@ -1,0 +1,26 @@
+define([
+    './SummaryWidgetEvaluator'
+], function (
+    SummaryWidgetEvaluator
+) {
+    function SummaryWidgetTelemetryProvider(openmct) {
+        this.openmct = openmct;
+    }
+
+    SummaryWidgetTelemetryProvider.prototype.supportsRequest = function (options, domainObject) {
+        return false;
+    };
+
+    SummaryWidgetTelemetryProvider.prototype.supportsSubscribe = function (domainObject) {
+        return domainObject.type === 'summary-widget';
+    };
+
+    SummaryWidgetTelemetryProvider.prototype.subscribe = function (domainObject, callback) {
+        var evaluator = new SummaryWidgetEvaluator(domainObject, this.openmct, callback);
+        return function unsubscribe() {
+            evaluator.destroy();
+        };
+    };
+
+    return SummaryWidgetTelemetryProvider;
+});

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
     './EvaluatorPool'
 ], function (

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProviderSpec.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProviderSpec.js
@@ -1,0 +1,475 @@
+define([
+    './SummaryWidgetTelemetryProvider'
+], function (
+    SummaryWidgetTelemetryProvider
+) {
+
+    describe('SummaryWidgetTelemetryProvider', function () {
+        var telemObjectA;
+        var telemObjectB;
+        var summaryWidgetObject;
+        var openmct;
+        var telemUnsubscribes;
+        var unobserver;
+        var composition;
+        var telemetryProvider;
+        var loader;
+
+        beforeEach(function () {
+            telemObjectA = {
+                identifier: {
+                    namespace: 'a',
+                    key: 'telem'
+                }
+            };
+            telemObjectB = {
+                identifier: {
+                    namespace: 'b',
+                    key: 'telem'
+                }
+            };
+            summaryWidgetObject = {
+                name: "Summary Widget",
+                type: "summary-widget",
+                identifier: {
+                    namespace: 'base',
+                    key: 'widgetId'
+                },
+                composition: [
+                    'a:telem',
+                    'b:telem'
+                ],
+                configuration: {
+                    ruleOrder: [
+                        "default",
+                        "rule0",
+                        "rule1"
+                    ],
+                    ruleConfigById: {
+                        "default": {
+                            name: "safe",
+                            label: "Don't Worry",
+                            message: "It's Ok",
+                            id: "default",
+                            icon: "a-ok",
+                            style: {
+                                "color": "#ffffff",
+                                "background-color": "#38761d",
+                                "border-color": "rgba(0,0,0,0)"
+                            },
+                            conditions: [
+                                {
+                                    object: "",
+                                    key: "",
+                                    operation: "",
+                                    values: []
+                                }
+                            ],
+                            trigger: "any"
+                        },
+                        "rule0": {
+                            name: "A High",
+                            label: "Start Worrying",
+                            message: "A is a little high...",
+                            id: "rule0",
+                            icon: "a-high",
+                            style: {
+                                "color": "#000000",
+                                "background-color": "#ffff00",
+                                "border-color": "rgba(1,1,0,0)"
+                            },
+                            conditions: [
+                                {
+                                    object: "a:telem",
+                                    key: "measurement",
+                                    operation: "greaterThan",
+                                    values: [
+                                        50
+                                    ]
+                                }
+                            ],
+                            trigger: "any"
+                        },
+                        rule1: {
+                            name: "B Low",
+                            label: "WORRY!",
+                            message: "B is Low",
+                            id: "rule1",
+                            icon: "b-low",
+                            style: {
+                                "color": "#ff00ff",
+                                "background-color": "#ff0000",
+                                "border-color": "rgba(1,0,0,0)"
+                            },
+                            conditions: [
+                                {
+                                    object: "b:telem",
+                                    key: "measurement",
+                                    operation: "lessThan",
+                                    values: [
+                                        10
+                                    ]
+                                }
+                            ],
+                            trigger: "any"
+                        }
+                    }
+                }
+            };
+            openmct = {
+                objects: jasmine.createSpyObj('objectAPI', [
+                    'get',
+                    'observe'
+                ]),
+                telemetry: jasmine.createSpyObj('telemetryAPI', [
+                    'getMetadata',
+                    'getFormatMap',
+                    'request',
+                    'subscribe',
+                    'addProvider'
+                ]),
+                composition: jasmine.createSpyObj('compositionAPI', [
+                    'get'
+                ]),
+                time: jasmine.createSpyObj('timeAPI', [
+                    'getAllTimeSystems',
+                    'timeSystem'
+                ])
+            };
+
+
+            openmct.time.getAllTimeSystems.andReturn([{key: 'timestamp'}]);
+            openmct.time.timeSystem.andReturn({key: 'timestamp'});
+
+
+            unobserver = jasmine.createSpy('unobserver');
+            openmct.objects.observe.andReturn(unobserver);
+
+
+            composition = jasmine.createSpyObj('compositionCollection', [
+                'on',
+                'off',
+                'load'
+            ]);
+
+            function notify(eventName, a, b) {
+                composition.on.calls.filter(function (c) {
+                    return c.args[0] === eventName;
+                }).forEach(function (c) {
+                    if (c.args[2]) { // listener w/ context.
+                        c.args[1].call(c.args[2], a, b);
+                    } else { // listener w/o context.
+                        c.args[1](a, b);
+                    }
+                });
+            }
+
+            loader = {};
+            loader.promise = new Promise(function (resolve, reject) {
+                loader.resolve = resolve;
+                loader.reject = reject;
+            });
+
+            composition.load.andCallFake(function () {
+                setTimeout(function () {
+                    notify('add', telemObjectA);
+                    setTimeout(function () {
+                        notify('add', telemObjectB);
+                        setTimeout(function () {
+                            loader.resolve();
+                            setTimeout(function () {
+                                loader.loaded = true;
+                            });
+                        });
+                    });
+                });
+                return loader.promise;
+            });
+            openmct.composition.get.andReturn(composition);
+
+
+            telemUnsubscribes = [];
+            openmct.telemetry.subscribe.andCallFake(function () {
+                var unsubscriber = jasmine.createSpy('unsubscriber' + telemUnsubscribes.length);
+                telemUnsubscribes.push(unsubscriber);
+                return unsubscriber;
+            });
+
+            openmct.telemetry.getMetadata.andCallFake(function (object) {
+                return {
+                    name: 'fake metadata manager',
+                    object: object,
+                    keys: ['timestamp', 'measurement']
+                };
+            });
+
+            openmct.telemetry.getFormatMap.andCallFake(function (metadata) {
+                expect(metadata.name).toBe('fake metadata manager');
+                return {
+                    metadata: metadata,
+                    timestamp: {
+                        parse: function (datum) {
+                            return datum.t;
+                        }
+                    },
+                    measurement: {
+                        parse: function (datum) {
+                            return datum.m;
+                        }
+                    }
+                };
+            });
+            telemetryProvider = new SummaryWidgetTelemetryProvider(openmct);
+        });
+
+        it("supports subscription for summary widgets", function () {
+            expect(telemetryProvider.supportsSubscribe(summaryWidgetObject))
+                .toBe(true);
+        });
+
+        it("supports requests for summary widgets", function () {
+            expect(telemetryProvider.supportsRequest(summaryWidgetObject))
+                .toBe(true);
+        });
+
+        it("does not support other requests or subscriptions", function () {
+            expect(telemetryProvider.supportsSubscribe(telemObjectA))
+                .toBe(false);
+            expect(telemetryProvider.supportsRequest(telemObjectA))
+                .toBe(false);
+        });
+
+        it("Returns no results for basic requests", function () {
+            var result;
+            telemetryProvider.request(summaryWidgetObject, {})
+                .then(function (r) {
+                    result = r;
+                });
+            waitsFor(function () {
+                return !!result;
+            });
+            runs(function () {
+                expect(result).toEqual([]);
+            });
+        });
+
+        it('provides realtime telemetry', function () {
+            var callback = jasmine.createSpy('callback');
+            telemetryProvider.subscribe(summaryWidgetObject, callback);
+
+            waitsFor(function () {
+                return loader.loaded;
+            });
+
+            runs(function () {
+                expect(openmct.telemetry.subscribe.calls.length).toBe(2);
+                expect(openmct.telemetry.subscribe)
+                    .toHaveBeenCalledWith(telemObjectA, jasmine.any(Function));
+                expect(openmct.telemetry.subscribe)
+                    .toHaveBeenCalledWith(telemObjectB, jasmine.any(Function));
+
+                var aCallback = openmct.telemetry.subscribe.calls[0].args[1];
+                var bCallback = openmct.telemetry.subscribe.calls[1].args[1];
+
+                aCallback({
+                    t: 123,
+                    m: 25
+                });
+                expect(callback).not.toHaveBeenCalled();
+                bCallback({
+                    t: 123,
+                    m: 25
+                });
+                expect(callback).toHaveBeenCalledWith({
+                    timestamp: 123,
+                    ruleLabel: "Don't Worry",
+                    ruleName: "safe",
+                    message: "It's Ok",
+                    ruleIndex: 0,
+                    backgroundColor: '#38761d',
+                    textColor: '#ffffff',
+                    borderColor: 'rgba(0,0,0,0)',
+                    icon: 'a-ok'
+                });
+                callback.reset();
+                aCallback({
+                    t: 140,
+                    m: 55
+                });
+                expect(callback).toHaveBeenCalledWith({
+                    timestamp: 140,
+                    ruleLabel: "Start Worrying",
+                    ruleName: "A High",
+                    message: "A is a little high...",
+                    ruleIndex: 1,
+                    backgroundColor: '#ffff00',
+                    textColor: '#000000',
+                    borderColor: 'rgba(1,1,0,0)',
+                    icon: 'a-high'
+                });
+                callback.reset();
+                bCallback({
+                    t: 140,
+                    m: -10
+                });
+                expect(callback).toHaveBeenCalledWith({
+                    timestamp: 140,
+                    ruleLabel: "WORRY!",
+                    ruleName: "B Low",
+                    message: "B is Low",
+                    ruleIndex: 2,
+                    backgroundColor: '#ff0000',
+                    textColor: '#ff00ff',
+                    borderColor: 'rgba(1,0,0,0)',
+                    icon: 'b-low'
+                });
+                callback.reset();
+                aCallback({
+                    t: 160,
+                    m: 25
+                });
+                expect(callback).toHaveBeenCalledWith({
+                    timestamp: 160,
+                    ruleLabel: "WORRY!",
+                    ruleName: "B Low",
+                    message: "B is Low",
+                    ruleIndex: 2,
+                    backgroundColor: '#ff0000',
+                    textColor: '#ff00ff',
+                    borderColor: 'rgba(1,0,0,0)',
+                    icon: 'b-low'
+                });
+                callback.reset();
+                bCallback({
+                    t: 160,
+                    m: 25
+                });
+                expect(callback).toHaveBeenCalledWith({
+                    timestamp: 160,
+                    ruleLabel: "Don't Worry",
+                    ruleName: "safe",
+                    message: "It's Ok",
+                    ruleIndex: 0,
+                    backgroundColor: '#38761d',
+                    textColor: '#ffffff',
+                    borderColor: 'rgba(0,0,0,0)',
+                    icon: 'a-ok'
+                });
+            });
+        });
+
+        describe('providing lad telemetry', function () {
+            var isResolved;
+            var resolver;
+            var responseDatums;
+            var resultsShouldBe;
+
+            beforeEach(function () {
+                isResolved = false;
+                resolver = jasmine.createSpy('resolved')
+                    .andCallFake(function () {
+                        isResolved = true;
+                    });
+
+                openmct.telemetry.request.andCallFake(function (rObj, options) {
+                    expect(rObj).toEqual(jasmine.any(Object));
+                    expect(options).toEqual({size: 1, strategy: 'latest', domain: 'timestamp'});
+                    expect(responseDatums[rObj.identifier.namespace]).toBeDefined();
+                    return Promise.resolve([responseDatums[rObj.identifier.namespace]]);
+                });
+                responseDatums = {};
+
+                resultsShouldBe = function (results) {
+                    telemetryProvider
+                        .request(summaryWidgetObject, {size: 1, strategy: 'latest', domain: 'timestamp'})
+                        .then(resolver);
+
+                    waitsFor(function () {
+                        return isResolved;
+                    });
+
+                    runs(function () {
+                        expect(resolver).toHaveBeenCalledWith(results);
+                    });
+                };
+            });
+
+            it("returns default when no rule matches", function () {
+                responseDatums = {
+                    a: {
+                        t: 122,
+                        m: 25
+                    },
+                    b: {
+                        t: 111,
+                        m: 25
+                    }
+                };
+
+                resultsShouldBe([{
+                    timestamp: 122,
+                    ruleLabel: "Don't Worry",
+                    ruleName: "safe",
+                    message: "It's Ok",
+                    ruleIndex: 0,
+                    backgroundColor: '#38761d',
+                    textColor: '#ffffff',
+                    borderColor: 'rgba(0,0,0,0)',
+                    icon: 'a-ok'
+                }]);
+            });
+
+            it("returns highest priority when multiple match", function () {
+                responseDatums = {
+                    a: {
+                        t: 131,
+                        m: 55
+                    },
+                    b: {
+                        t: 139,
+                        m: 5
+                    }
+                };
+
+                resultsShouldBe([{
+                    timestamp: 139,
+                    ruleLabel: "WORRY!",
+                    ruleName: "B Low",
+                    message: "B is Low",
+                    ruleIndex: 2,
+                    backgroundColor: '#ff0000',
+                    textColor: '#ff00ff',
+                    borderColor: 'rgba(1,0,0,0)',
+                    icon: 'b-low'
+                }]);
+            });
+
+            it("returns matching rule", function () {
+                responseDatums = {
+                    a: {
+                        t: 144,
+                        m: 55
+                    },
+                    b: {
+                        t: 141,
+                        m: 15
+                    }
+                };
+
+                resultsShouldBe([{
+                    timestamp: 144,
+                    ruleLabel: "Start Worrying",
+                    ruleName: "A High",
+                    message: "A is a little high...",
+                    ruleIndex: 1,
+                    backgroundColor: '#ffff00',
+                    textColor: '#000000',
+                    borderColor: 'rgba(1,1,0,0)',
+                    icon: 'a-high'
+                }]);
+            });
+
+        });
+
+    });
+});

--- a/src/plugins/summaryWidget/src/telemetry/operations.js
+++ b/src/plugins/summaryWidget/src/telemetry/operations.js
@@ -1,0 +1,175 @@
+define([
+
+], function (
+
+) {
+    var OPERATIONS = {
+        equalTo: {
+            operation: function (input) {
+                return input[0] === input[1];
+            },
+            text: 'is equal to',
+            appliesTo: ['number'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' == ' + values[0];
+            }
+        },
+        notEqualTo: {
+            operation: function (input) {
+                return input[0] !== input[1];
+            },
+            text: 'is not equal to',
+            appliesTo: ['number'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' != ' + values[0];
+            }
+        },
+        greaterThan: {
+            operation: function (input) {
+                return input[0] > input[1];
+            },
+            text: 'is greater than',
+            appliesTo: ['number'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' > ' + values[0];
+            }
+        },
+        lessThan: {
+            operation: function (input) {
+                return input[0] < input[1];
+            },
+            text: 'is less than',
+            appliesTo: ['number'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' < ' + values[0];
+            }
+        },
+        greaterThanOrEq: {
+            operation: function (input) {
+                return input[0] >= input[1];
+            },
+            text: 'is greater than or equal to',
+            appliesTo: ['number'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' >= ' + values[0];
+            }
+        },
+        lessThanOrEq: {
+            operation: function (input) {
+                return input[0] <= input[1];
+            },
+            text: 'is less than or equal to',
+            appliesTo: ['number'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' <= ' + values[0];
+            }
+        },
+        between: {
+            operation: function (input) {
+                return input[0] > input[1] && input[0] < input[2];
+            },
+            text: 'is between',
+            appliesTo: ['number'],
+            inputCount: 2,
+            getDescription: function (values) {
+                return ' between ' + values[0] + ' and ' + values[1];
+            }
+        },
+        notBetween: {
+            operation: function (input) {
+                return input[0] < input[1] || input[0] > input[2];
+            },
+            text: 'is not between',
+            appliesTo: ['number'],
+            inputCount: 2,
+            getDescription: function (values) {
+                return ' not between ' + values[0] + ' and ' + values[1];
+            }
+        },
+        textContains: {
+            operation: function (input) {
+                return input[0] && input[1] && input[0].includes(input[1]);
+            },
+            text: 'text contains',
+            appliesTo: ['string'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' contains ' + values[0];
+            }
+        },
+        textDoesNotContain: {
+            operation: function (input) {
+                return input[0] && input[1] && !input[0].includes(input[1]);
+            },
+            text: 'text does not contain',
+            appliesTo: ['string'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' does not contain ' + values[0];
+            }
+        },
+        textStartsWith: {
+            operation: function (input) {
+                return input[0].startsWith(input[1]);
+            },
+            text: 'text starts with',
+            appliesTo: ['string'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' starts with ' + values[0];
+            }
+        },
+        textEndsWith: {
+            operation: function (input) {
+                return input[0].endsWith(input[1]);
+            },
+            text: 'text ends with',
+            appliesTo: ['string'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' ends with ' + values[0];
+            }
+        },
+        textIsExactly: {
+            operation: function (input) {
+                return input[0] === input[1];
+            },
+            text: 'text is exactly',
+            appliesTo: ['string'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' is exactly ' + values[0];
+            }
+        },
+        isUndefined: {
+            operation: function (input) {
+                return typeof input[0] === 'undefined';
+            },
+            text: 'is undefined',
+            appliesTo: ['string', 'number'],
+            inputCount: 0,
+            getDescription: function () {
+                return ' is undefined';
+            }
+        },
+        isDefined: {
+            operation: function (input) {
+                return typeof input[0] !== 'undefined';
+            },
+            text: 'is defined',
+            appliesTo: ['string', 'number'],
+            inputCount: 0,
+            getDescription: function () {
+                return ' is defined';
+            }
+        }
+    };
+
+    return OPERATIONS;
+});

--- a/src/plugins/summaryWidget/src/telemetry/operations.js
+++ b/src/plugins/summaryWidget/src/telemetry/operations.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 define([
 
 ], function (

--- a/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
+++ b/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
@@ -1,0 +1,82 @@
+define([
+    'text!./summary-widget.html'
+], function (
+    summaryWidgetTemplate
+) {
+    function SummaryWidgetView(domainObject, openmct) {
+        this.openmct = openmct;
+        this.domainObject = domainObject;
+        this.hasUpdated = false;
+    }
+
+    SummaryWidgetView.prototype.updateState = function (datum) {
+        this.hasUpdated = true;
+        this.widget.style.color = datum.textColor;
+        this.widget.style.backgroundColor = datum.backgroundColor;
+        this.widget.style.borderColor = datum.borderColor;
+        this.widget.title = datum.message;
+        this.label.innerHTML = datum.ruleLabel;
+        this.label.className = 'label widget-label ' + datum.icon;
+    };
+
+    SummaryWidgetView.prototype.render = function (domainObject) {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+        }
+        this.hasUpdated = false;
+
+        this.container.innerHTML = summaryWidgetTemplate;
+        this.widget = this.container.querySelector('a');
+        this.label = this.container.querySelector('.widget-label');
+
+
+        if (domainObject.url) {
+            this.widget.setAttribute('href', domainObject.url);
+        } else {
+            this.widget.removeAttribute('href');
+        }
+
+        if (domainObject.openNewTab === 'newTab') {
+            this.widget.setAttribute('target', '_blank');
+        } else {
+            this.widget.removeAttribute('target');
+        }
+        var renderTracker = {};
+        this.renderTracker = renderTracker;
+        this.openmct.telemetry.request(this.domainObject, {
+            strategy: 'latest',
+            size: 1
+        }).then(function (results) {
+            if (this.hasUpdated || this.renderTracker !== renderTracker) {
+                return;
+            }
+            this.updateState(results[results.length - 1]);
+        }.bind(this));
+
+        this.unsubscribe = this.openmct
+            .telemetry
+            .subscribe(domainObject, this.updateState.bind(this));
+    };
+
+    SummaryWidgetView.prototype.show = function (container) {
+        this.container = container;
+        this.render(this.domainObject);
+        this.removeMutationListener = this.openmct.objects.observe(
+            this.domainObject,
+            '*',
+            this.render.bind(this)
+        );
+    };
+
+    SummaryWidgetView.prototype.destroy = function (container) {
+        this.unsubscribe();
+        this.removeMutationListener();
+        delete this.widget;
+        delete this.label;
+        delete this.openmct;
+        delete this.domainObject;
+    };
+
+    return SummaryWidgetView;
+
+});

--- a/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
+++ b/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
@@ -15,6 +15,7 @@ define([
         this.widget.style.backgroundColor = datum.backgroundColor;
         this.widget.style.borderColor = datum.borderColor;
         this.widget.title = datum.message;
+        this.label.title = datum.message;
         this.label.innerHTML = datum.ruleLabel;
         this.label.className = 'label widget-label ' + datum.icon;
     };

--- a/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
+++ b/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
@@ -48,7 +48,7 @@ define([
             strategy: 'latest',
             size: 1
         }).then(function (results) {
-            if (this.hasUpdated || this.renderTracker !== renderTracker) {
+            if (this.destroyed || this.hasUpdated || this.renderTracker !== renderTracker) {
                 return;
             }
             this.updateState(results[results.length - 1]);
@@ -72,6 +72,7 @@ define([
     SummaryWidgetView.prototype.destroy = function (container) {
         this.unsubscribe();
         this.removeMutationListener();
+        this.destroyed = true;
         delete this.widget;
         delete this.label;
         delete this.openmct;

--- a/src/plugins/summaryWidget/src/views/SummaryWidgetViewProvider.js
+++ b/src/plugins/summaryWidget/src/views/SummaryWidgetViewProvider.js
@@ -1,0 +1,42 @@
+define([
+    '../SummaryWidget',
+    './SummaryWidgetView',
+    '../../../../api/objects/object-utils'
+], function (
+    SummaryWidgetEditView,
+    SummaryWidgetView,
+    objectUtils
+) {
+
+
+    /**
+     *
+     */
+    function SummaryWidgetViewProvider(openmct) {
+        return {
+            key: 'summary-widget-viewer',
+            name: 'Widget View',
+            canView: function (domainObject) {
+                return domainObject.type === 'summary-widget';
+            },
+            view: function (domainObject) {
+                var statusService = openmct.$injector.get('statusService');
+                var objectId = objectUtils.makeKeyString(domainObject.identifier);
+                var statuses = statusService.listStatuses(objectId);
+                var isEditing = statuses.indexOf('editing') !== -1;
+
+                if (isEditing) {
+                    return new SummaryWidgetEditView(domainObject, openmct);
+                } else {
+                    return new SummaryWidgetView(domainObject, openmct);
+                }
+            },
+            editable: true,
+            priority: function (domainObject) {
+                return 1;
+            }
+        };
+    }
+
+    return SummaryWidgetViewProvider;
+});

--- a/src/plugins/summaryWidget/src/views/summary-widget.html
+++ b/src/plugins/summaryWidget/src/views/summary-widget.html
@@ -1,0 +1,5 @@
+<div class="w-summary-widget s-status-no-data">
+    <a class="t-summary-widget l-summary-widget s-summary-widget labeled">
+        <span class="label widget-label">Loading...</span>
+    </a>
+</div>

--- a/src/plugins/summaryWidget/test/ConditionManagerSpec.js
+++ b/src/plugins/summaryWidget/test/ConditionManagerSpec.js
@@ -19,6 +19,7 @@ define(['../src/ConditionManager'], function (ConditionManager) {
             removeCallbackSpy,
             telemetryCallbackSpy,
             metadataCallbackSpy,
+            telemetryRequests,
             mockTelemetryValues,
             mockTelemetryValues2,
             mockConditionEvaluator;
@@ -61,31 +62,43 @@ define(['../src/ConditionManager'], function (ConditionManager) {
                 mockCompObject1: {
                     property1: {
                         key: 'property1',
-                        name: 'Property 1'
+                        name: 'Property 1',
+                        format: 'string',
+                        hints: {}
                     },
                     property2: {
                         key: 'property2',
-                        name: 'Property 2'
+                        name: 'Property 2',
+                        hints: {
+                            domain: 1
+                        }
                     }
                 },
                 mockCompObject2: {
                     property3: {
                         key: 'property3',
-                        name: 'Property 3'
+                        name: 'Property 3',
+                        format: 'string',
+                        hints: {}
                     },
                     property4: {
                         key: 'property4',
-                        name: 'Property 4'
+                        name: 'Property 4',
+                        hints: {
+                            range: 1
+                        }
                     }
                 },
                 mockCompObject3: {
                     property1: {
                         key: 'property1',
-                        name: 'Property 1'
+                        name: 'Property 1',
+                        hints: {}
                     },
                     property2: {
                         key: 'property2',
-                        name: 'Property 2'
+                        name: 'Property 2',
+                        hints: {}
                     }
                 }
             };
@@ -160,22 +173,20 @@ define(['../src/ConditionManager'], function (ConditionManager) {
                 unregisterSpies[event]();
             });
             mockComposition.load.andCallFake(function () {
-                mockEventCallbacks.add(mockCompObject1);
-                mockEventCallbacks.add(mockCompObject2);
-                mockEventCallbacks.load();
+                mockComposition.triggerCallback('add', mockCompObject1);
+                mockComposition.triggerCallback('add', mockCompObject2);
+                mockComposition.triggerCallback('load');
             });
-            mockComposition.triggerCallback.andCallFake(function (event) {
+            mockComposition.triggerCallback.andCallFake(function (event, obj) {
                 if (event === 'add') {
-                    mockEventCallbacks.add(mockCompObject3);
+                    mockEventCallbacks.add(obj);
                 } else if (event === 'remove') {
-                    mockEventCallbacks.remove({
-                        key: 'mockCompObject2'
-                    });
+                    mockEventCallbacks.remove(obj.identifier);
                 } else {
                     mockEventCallbacks[event]();
                 }
             });
-
+            telemetryRequests = [];
             mockTelemetryAPI = jasmine.createSpyObj('telemetryAPI', [
                 'request',
                 'isTelemetryObject',
@@ -184,9 +195,15 @@ define(['../src/ConditionManager'], function (ConditionManager) {
                 'triggerTelemetryCallback'
             ]);
             mockTelemetryAPI.request.andCallFake(function (obj) {
-                return new Promise(function (resolve, reject) {
-                    resolve(mockTelemetryValues[obj.identifer.key]);
+                var req = {
+                    object: obj
+                };
+                req.promise = new Promise(function (resolve, reject) {
+                    req.resolve = resolve;
+                    req.reject = reject;
                 });
+                telemetryRequests.push(req);
+                return req.promise;
             });
             mockTelemetryAPI.isTelemetryObject.andReturn(true);
             mockTelemetryAPI.getMetadata.andCallFake(function (obj) {
@@ -245,41 +262,50 @@ define(['../src/ConditionManager'], function (ConditionManager) {
             var allKeys = {
                 property1: {
                     key: 'property1',
-                    name: 'Property 1'
+                    name: 'Property 1',
+                    format: 'string',
+                    hints: {}
                 },
                 property2: {
                     key: 'property2',
-                    name: 'Property 2'
+                    name: 'Property 2',
+                    hints: {
+                        domain: 1
+                    }
                 },
                 property3: {
                     key: 'property3',
-                    name: 'Property 3'
+                    name: 'Property 3',
+                    format: 'string',
+                    hints: {}
                 },
                 property4: {
                     key: 'property4',
-                    name: 'Property 4'
+                    name: 'Property 4',
+                    hints: {
+                        range: 1
+                    }
                 }
             };
             expect(conditionManager.getTelemetryMetadata('all')).toEqual(allKeys);
             expect(conditionManager.getTelemetryMetadata('any')).toEqual(allKeys);
-            mockComposition.triggerCallback('add');
+            mockComposition.triggerCallback('add', mockCompObject3);
             expect(conditionManager.getTelemetryMetadata('all')).toEqual(allKeys);
             expect(conditionManager.getTelemetryMetadata('any')).toEqual(allKeys);
         });
 
         it('loads and gets telemetry property types', function () {
-            conditionManager.parseAllPropertyTypes().then(function () {
-                expect(conditionManager.getTelemetryPropertyType('mockCompObject1', 'property1'))
-                    .toEqual('string');
-                expect(conditionManager.getTelemetryPropertyType('mockCompObject2', 'property4'))
-                    .toEqual('number');
-                expect(conditionManager.metadataLoadComplete()).toEqual(true);
-                expect(metadataCallbackSpy).toHaveBeenCalled();
-            });
+            conditionManager.parseAllPropertyTypes();
+            expect(conditionManager.getTelemetryPropertyType('mockCompObject1', 'property1'))
+                .toEqual('string');
+            expect(conditionManager.getTelemetryPropertyType('mockCompObject2', 'property4'))
+                .toEqual('number');
+            expect(conditionManager.metadataLoadCompleted()).toEqual(true);
+            expect(metadataCallbackSpy).toHaveBeenCalled();
         });
 
         it('responds to a composition add event and invokes the appropriate handlers', function () {
-            mockComposition.triggerCallback('add');
+            mockComposition.triggerCallback('add', mockCompObject3);
             expect(addCallbackSpy).toHaveBeenCalledWith(mockCompObject3);
             expect(conditionManager.getComposition()).toEqual({
                 mockCompObject1: mockCompObject1,
@@ -289,7 +315,7 @@ define(['../src/ConditionManager'], function (ConditionManager) {
         });
 
         it('responds to a composition remove event and invokes the appropriate handlers', function () {
-            mockComposition.triggerCallback('remove');
+            mockComposition.triggerCallback('remove', mockCompObject2);
             expect(removeCallbackSpy).toHaveBeenCalledWith({
                 key: 'mockCompObject2'
             });
@@ -300,7 +326,7 @@ define(['../src/ConditionManager'], function (ConditionManager) {
         });
 
         it('unregisters telemetry subscriptions and composition listeners on destroy', function () {
-            mockComposition.triggerCallback('add');
+            mockComposition.triggerCallback('add', mockCompObject3);
             conditionManager.destroy();
             Object.values(unsubscribeSpies).forEach(function (spy) {
                 expect(spy).toHaveBeenCalled();
@@ -311,7 +337,19 @@ define(['../src/ConditionManager'], function (ConditionManager) {
         });
 
         it('populates its LAD cache with historial data on load, if available', function () {
-            conditionManager.parseAllPropertyTypes().then(function () {
+            expect(telemetryRequests.length).toBe(2);
+            expect(telemetryRequests[0].object).toBe(mockCompObject1);
+            expect(telemetryRequests[1].object).toBe(mockCompObject2);
+
+            expect(telemetryCallbackSpy).not.toHaveBeenCalled();
+
+            telemetryRequests[0].resolve([mockTelemetryValues.mockCompObject1]);
+            telemetryRequests[1].resolve([mockTelemetryValues.mockCompObject2]);
+
+            waitsFor(function () {
+                return telemetryCallbackSpy.calls.length === 2;
+            });
+            runs(function () {
                 expect(conditionManager.subscriptionCache.mockCompObject1.property1).toEqual('Its a string');
                 expect(conditionManager.subscriptionCache.mockCompObject2.property4).toEqual(66);
             });
@@ -352,12 +390,10 @@ define(['../src/ConditionManager'], function (ConditionManager) {
         });
 
         it('gets the human-readable name of a telemetry field', function () {
-            conditionManager.parseAllPropertyTypes().then(function () {
-                expect(conditionManager.getTelemetryPropertyName('mockCompObject1', 'property1'))
-                    .toEqual('Property 1');
-                expect(conditionManager.getTelemetryPropertyName('mockCompObject2', 'property4'))
-                    .toEqual('Property 4');
-            });
+            expect(conditionManager.getTelemetryPropertyName('mockCompObject1', 'property1'))
+                .toEqual('Property 1');
+            expect(conditionManager.getTelemetryPropertyName('mockCompObject2', 'property4'))
+                .toEqual('Property 4');
         });
 
         it('gets its associated ConditionEvaluator', function () {


### PR DESCRIPTION
This is a WIP (based off #1941) for improvements to summary widgets.  Opening for visibility and initial feedback.

TODO:
* [x] Add telemetry for summary widgets
    * [x] metadata
    * [x] realtime
    * [x] lad
* [x] Update ConditionManager to use telemetry metadata for filtering operators.
* [x] Create separate "view" mode for summary widget that doesn't include any of editing UI.
* [x] Tests for SummaryWidgetTelemetryProvider
* [x] Update tests for SummaryWidget
* [x] open issue to refactor https://github.com/nasa/openmct/pull/1943/commits/d74d7e3b421dcb2612e8dae6010356b783c00edd -> https://github.com/nasa/openmct/issues/1957
* [x] open issue to refactor https://github.com/nasa/openmct/pull/1943/commits/bdd87ed016e3d989a66f76c18b84045e81efac32 -> https://github.com/nasa/openmct/issues/1958

3db94bc28b0abe95274a499e1963ad28a280af39, 3/9/2018: implements metadata and telemetry providers for summary widgets so they can be used as telemetry sources in other displays (including other summary widgets).

https://github.com/nasa/openmct/pull/1943/commits/752b7c1210ac3b8b80bbe5ae592aaa352312a31a 3/21/2018: implements all providers and code, just waiting to complete tests.  Ready for testathon.