### PR TITLE
Allow for ObjectProvider to specify a limitEvaluator

### DIFF
--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -398,11 +398,9 @@ define([
      * @memberof module:openmct.TelemetryAPI~TelemetryProvider#
      */
     TelemetryAPI.prototype.limitEvaluator = function () {
-        if( arguments[0].limitEvaluator && typeof arguments[0].limitEvaluator.evaluate  === 'function')
-        {
+        if (arguments[0].limitEvaluator && typeof arguments[0].limitEvaluator.evaluate  === 'function') {
             return arguments[0].limitEvaluator;
-        }
-        else{
+        } else {
             return this.legacyProvider.limitEvaluator.apply(this.legacyProvider, arguments);
         }
     };

--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -398,7 +398,13 @@ define([
      * @memberof module:openmct.TelemetryAPI~TelemetryProvider#
      */
     TelemetryAPI.prototype.limitEvaluator = function () {
-        return this.legacyProvider.limitEvaluator.apply(this.legacyProvider, arguments);
+        if( arguments[0].limitEvaluator && typeof arguments[0].limitEvaluator.evaluate  === 'function')
+        {
+            return arguments[0].limitEvaluator;
+        }
+        else{
+            return this.legacyProvider.limitEvaluator.apply(this.legacyProvider, arguments);
+        }
     };
 
     return TelemetryAPI;


### PR DESCRIPTION
Inside my object provider I was trying to specify a telemetry Limit,
Couldn't figure out how to do this unless I was allowed to override the telemetryLimiter

```

      var objectProvider = {
       get: function (identifier) {

        var GetObj = function(identifier){
            if (identifier.key === 'spacecraft') {
                return {
                    identifier: identifier,
                    name: TLM_DB_JSON.name,
                    type: 'folder',
                    location: 'ROOT',
                    children: TLM_DB_JSON.children
                };
            }
            else{
                var measurement = FLAT_DB[identifier.key];
                measurement['identifier'] = identifier;

                if (measurement.type == 'folder')
                {

                }
                else{
                    measurement.telemetry = {
                        values: measurement.values
                    }

                    if(measurement.properites.limits)
                    {
                        measurement.limitEvaluator = {
                            evaluate:function (a){
                                if(FLAT_DB[a.id].properites.limits.rh && a.value >= FLAT_DB[a.id].properites.limits.rh)
                                {
                                    return {cssClass: "s-limit-upr s-limit-red",
                                    name: "Red High"}
                                }
                                if(FLAT_DB[a.id].properites.limits.rl && a.value <= FLAT_DB[a.id].properites.limits.rl)
                                {
                                    return {cssClass: "s-limit-lwr s-limit-red",
                                    name: "Red Low"}
                                }
                                if(FLAT_DB[a.id].properites.limits.yh && a.value >= FLAT_DB[a.id].properites.limits.yh)
                                {
                                    return {cssClass: "s-limit-upr s-limit-yellow",
                                    name: "Yellow High"}
                                }
                                if(FLAT_DB[a.id].properites.limits.yl && a.value <= FLAT_DB[a.id].properites.limits.yl)
                                {
                                    return {cssClass: "s-limit-lwr s-limit-yellow",
                                    name: "Yellow Low"}
                                }

                            }}
    
                    }
    
                }

                return measurement;
            }
        }
        var p = new Promise(function(res,rej){
            var obj = GetObj(identifier)
            res(obj);
        });
        return p
    }

  };
  openmct.objects.addProvider('example.taxonomy', objectProvider);

```


Also probably need pointers on how to do a unit test

Had to do the function test as plots were not seeing the evaluate function, but fixed displays were...