### PR TITLE
Lock filesaver version to prevent ongoing instability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "screenfull": "^3.0.0",
     "node-uuid": "^1.4.7",
     "comma-separated-values": "^3.6.4",
-    "file-saver": "^1.3.3",
+    "file-saver": "1.3.3",
     "zepto": "^1.1.6",
     "eventemitter3": "^1.2.0",
     "lodash": "3.10.1",


### PR DESCRIPTION
Lock filesaver version as there have been a large number of broken
builds from what should be non-breaking version increases.

Fixes currently broken build, and hopefully prevents this from breaking for the umpteenth time.

Given our history with this plugin we may have to find a more stable alternative....

https://github.com/eligrey/FileSaver.js/issues/409

# Reviewer Checklist

1. Changes appear to address issue? Y, as reported here.
2. Appropriate unit tests included? N/A
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y
