### PR TITLE
Allow property values of zero.

### DIFF
--- a/example/generator/GeneratorProvider.js
+++ b/example/generator/GeneratorProvider.js
@@ -66,7 +66,7 @@ define([
             if (request && request.hasOwnProperty(prop)) {
                 workerRequest[prop] = request[prop];
             }
-            if (!workerRequest[prop]) {
+            if (!workerRequest.hasOwnProperty(prop)) {
                 workerRequest[prop] = REQUEST_DEFAULTS[prop];
             }
             workerRequest[prop] = Number(workerRequest[prop]);


### PR DESCRIPTION
Allow SWG properties of zero to be used instead of overwriting
them with defaults.  This used to work because properties were strings, but now that we're using a number input they're numbers.

# Author Checklist

1. Changes address original issue? Y, as reported here
2. Unit tests included and/or updated with changes? N/A, example code
3. Command line build passes? Y
4. Changes have been smoke-tested? Y