### PR TITLE
Painterro fix

### DIFF
--- a/platform/features/notebook/res/templates/annotation.html
+++ b/platform/features/notebook/res/templates/annotation.html
@@ -1,2 +1,2 @@
-<div class="snap-annotation" id="snap-annotation" ng-init="ngModel.tracker()">
+<div class="snap-annotation" id="snap-annotation" ng-controller="ngModel.controller">
 </div>

--- a/platform/features/notebook/src/shims/painterro-shim.js
+++ b/platform/features/notebook/src/shims/painterro-shim.js
@@ -1,0 +1,13 @@
+define(function () {
+    return function (painterroInstance) {
+        painterroInstance.removeEventHandlers = function () {
+            Object.keys(this.documentHandlers).forEach(function (key) {
+                this.doc.removeEventListener(key, this.documentHandlers[key]);
+            }.bind(this));
+
+            Object.keys(this.windowHandlers).forEach(function (key) {
+                window.removeEventListener(key, this.windowHandlers[key]);
+            }.bind(this));
+        }.bind(painterroInstance);
+    };
+});

--- a/platform/representation/src/MCTInclude.js
+++ b/platform/representation/src/MCTInclude.js
@@ -62,8 +62,10 @@ define(
                     scope.key && templateMap[scope.key]
                 );
 
-                scope.$watch('key', function (key) {
-                    changeTemplate(key && templateMap[key]);
+                scope.$watch('key', function (newKey, oldKey) {
+                    if (newKey !== oldKey) {
+                        changeTemplate(newKey && templateMap[newKey]);
+                    }
                 });
             }
 


### PR DESCRIPTION
Fixes #1985 

Fixes the transient issues observed with drag and drop by cleaning up event handlers when the annotation dialog is closed.

Also made a change that will reduce template compilation frequency.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A - Changes did not invalidate existing test cases.
* Command line build passes? Y
* Changes have been smoke-tested? Y