### PR TITLE
[plot] cleanup alarms, don't error on mutate, fallback on context lost

### DIFF
--- a/src/plugins/plot/src/chart/MCTChartController.js
+++ b/src/plugins/plot/src/chart/MCTChartController.js
@@ -61,7 +61,7 @@ function (
         this.alarmSets = [];
         this.offset = {};
         this.config = $scope.config;
-        this.listenTo(this.$scope, '$destoy', this.destroy, this);
+        this.listenTo(this.$scope, '$destroy', this.destroy, this);
         this.draw = this.draw.bind(this);
         this.scheduleDraw = this.scheduleDraw.bind(this);
         this.seriesElements = new WeakMap();

--- a/src/plugins/plot/src/chart/MCTChartController.js
+++ b/src/plugins/plot/src/chart/MCTChartController.js
@@ -231,6 +231,10 @@ function (
             this.pointSets.splice(this.pointSets.indexOf(pointSet), 1);
             pointSet.destroy();
         }, this);
+        if (elements.alarmSet) {
+            elements.alarmSet.destroy();
+            this.alarmSets.splice(this.alarmSets.indexOf(elements.alarmSet), 1);
+        }
         this.seriesElements.delete(series);
     };
 

--- a/src/plugins/plot/src/chart/MCTChartDirective.js
+++ b/src/plugins/plot/src/chart/MCTChartDirective.js
@@ -43,6 +43,7 @@ define([
             restrict: "E",
             template: TEMPLATE,
             link: function ($scope, $element, attrs, ctrl) {
+                ctrl.TEMPLATE = TEMPLATE;
                 var mainCanvas = $element.find("canvas")[1];
                 var overlayCanvas = $element.find("canvas")[0];
 

--- a/src/plugins/plot/src/configuration/PlotConfigurationModel.js
+++ b/src/plugins/plot/src/configuration/PlotConfigurationModel.js
@@ -75,11 +75,14 @@ define([
                 openmct: options.openmct
             });
 
-            this.removeMutationListener = this.openmct.objects.observe(
-                this.get('domainObject'),
-                '*',
-                this.updateDomainObject.bind(this)
-            );
+            if (this.get('domainObject').type === 'telemetry.plot.overlay') {
+                this.removeMutationListener = this.openmct.objects.observe(
+                    this.get('domainObject'),
+                    '*',
+                    this.updateDomainObject.bind(this)
+                );
+            }
+
             this.yAxis.listenToSeriesCollection(this.series);
             this.legend.listenToSeriesCollection(this.series);
 
@@ -112,7 +115,9 @@ define([
             this.yAxis.destroy();
             this.series.destroy();
             this.legend.destroy();
-            this.removeMutationListener();
+            if (this.removeMutationListener) {
+                this.removeMutationListener();
+            }
         },
         /**
          * Return defaults, which are extracted from the passed in domain

--- a/src/plugins/plot/src/draw/Draw2D.js
+++ b/src/plugins/plot/src/draw/Draw2D.js
@@ -22,9 +22,13 @@
 
 
 define([
-
+    'lodash',
+    'EventEmitter',
+    '../lib/eventHelpers'
 ], function (
-
+    _,
+    EventEmitter,
+    eventHelpers
 ) {
 
     /**
@@ -46,6 +50,9 @@ define([
             throw new Error("Canvas 2d API unavailable.");
         }
     }
+
+    _.extend(Draw2D.prototype, EventEmitter.prototype);
+    eventHelpers.extend(Draw2D.prototype);
 
     // Convert from logical to physical x coordinates
     Draw2D.prototype.x = function (v) {

--- a/src/plugins/plot/src/draw/DrawLoader.js
+++ b/src/plugins/plot/src/draw/DrawLoader.js
@@ -35,7 +35,7 @@ define(
                     ALLOCATIONS: []
                 },
                 {
-                    MAX_INSTANCES: Number.MAX_INFINITY,
+                    MAX_INSTANCES: Number.POSITIVE_INFINITY,
                     API: Draw2D,
                     ALLOCATIONS: []
                 }
@@ -83,12 +83,24 @@ define(
                 return api;
             },
 
+            /**
+             * Returns a fallback draw api.
+             */
+            getFallbackDrawAPI: function (canvas, overlay) {
+                var api = new CHARTS[1].API(canvas, overlay);
+                CHARTS[1].ALLOCATIONS.push(api);
+                return api;
+            },
+
             releaseDrawAPI: function (api) {
                 CHARTS.forEach(function (CHART_TYPE) {
                     if (api instanceof CHART_TYPE.API) {
                         CHART_TYPE.ALLOCATIONS.splice(CHART_TYPE.ALLOCATIONS.indexOf(api), 1);
                     }
                 });
+                if (api.destroy) {
+                    api.destroy();
+                }
             }
         };
     }

--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -70,7 +70,7 @@ define([
         this.listenTo(this.$canvas, 'mousedown', this.onMouseDown, this);
 
         this.watchForMarquee();
-    }
+    };
 
     MCTPlotController.prototype.initialize = function () {
         this.$canvas = this.$element.find('canvas');

--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -59,6 +59,19 @@ define([
 
     eventHelpers.extend(MCTPlotController.prototype);
 
+    MCTPlotController.prototype.initCanvas = function () {
+        if (this.$canvas) {
+            this.stopListening(this.$canvas);
+        }
+        this.$canvas = this.$element.find('canvas');
+
+        this.listenTo(this.$canvas, 'mousemove', this.trackMousePosition, this);
+        this.listenTo(this.$canvas, 'mouseleave', this.untrackMousePosition, this);
+        this.listenTo(this.$canvas, 'mousedown', this.onMouseDown, this);
+
+        this.watchForMarquee();
+    }
+
     MCTPlotController.prototype.initialize = function () {
         this.$canvas = this.$element.find('canvas');
 
@@ -82,6 +95,7 @@ define([
         this.listenTo(this.$scope, '$destroy', this.destroy, this);
         this.listenTo(this.$scope, 'plot:tickWidth', this.onTickWidthChange, this);
         this.listenTo(this.$scope, 'plot:highlight:set', this.onPlotHighlightSet, this);
+        this.listenTo(this.$scope, 'plot:reinitializeCanvas', this.initCanvas, this);
 
         this.listenTo(this.config.xAxis, 'change:displayRange', this.onXAxisChange, this);
         this.listenTo(this.config.yAxis, 'change:displayRange', this.onYAxisChange, this);


### PR DESCRIPTION
This fixes #1976, #1935, #1945.  It also fixes a typo which meant you'd get webgl for the first 16 plots and then everything else would be 2d until you reloaded Open MCT... oops.

For contextlost, waiting for webglcontextrestored does not work when the webgl limit has been reached, and I didn't have a good way to quickly determine when the limit had been hit.  So went with fallback-to-2d whenever the webgl context is lost.

More notes in commit messages.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N, issue exists for test backfill.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y