### PR TITLE
[Toolbar] set selection initially in fixed controller and toolbar...

### DIFF
--- a/platform/commonUI/edit/src/representers/EditToolbarRepresenter.js
+++ b/platform/commonUI/edit/src/representers/EditToolbarRepresenter.js
@@ -140,7 +140,7 @@ define(
                 this.scope,
                 this.openmct
             );
-            // Initialize toolbar to an empty selection
+            // Initialize toolbar to current selection
             this.updateSelection(this.scope.selection.all());
         };
 

--- a/platform/commonUI/edit/src/representers/EditToolbarRepresenter.js
+++ b/platform/commonUI/edit/src/representers/EditToolbarRepresenter.js
@@ -88,12 +88,6 @@ define(
                     commit("Changes from toolbar.");
                 }
             }
-
-            // Avoid attaching scope to this;
-            // http://errors.angularjs.org/1.2.26/ng/cpws
-            this.setSelection = function (s) {
-                scope.selection = s;
-            };
             this.clearExposedToolbar = function () {
                 // Clear exposed toolbar state (if any)
                 if (attrs.toolbar) {
@@ -110,6 +104,7 @@ define(
             this.toolbar = undefined;
             this.toolbarObject = {};
             this.openmct = openmct;
+            this.scope = scope;
 
             // If this representation exposes a toolbar, set up watches
             // to synchronize with it.
@@ -133,23 +128,21 @@ define(
             var definition = (representation || {}).toolbar || {},
                 self = this;
 
-            // Initialize toolbar (expose object to parent scope)
-            function initialize(def) {
-                // If we have been asked to expose toolbar state...
-                if (self.attrs.toolbar) {
-                    // Initialize toolbar object
-                    self.toolbar = new EditToolbar(def, self.commit);
-                    // Ensure toolbar state is exposed
-                    self.exposeToolbar();
-                }
+            // If we have been asked to expose toolbar state...
+            if (this.attrs.toolbar) {
+                // Initialize toolbar object
+                this.toolbar = new EditToolbar(def, this.commit);
+                // Ensure toolbar state is exposed
+                this.exposeToolbar();
             }
 
-            // Expose the toolbar object to the parent scope
-            initialize(definition);
-            // Create a selection scope
-            this.setSelection(new EditToolbarSelection(this.openmct));
+            // Add toolbar selection to scope.
+            this.scope.selection = new EditToolbarSelection(
+                this.scope,
+                this.openmct
+            );
             // Initialize toolbar to an empty selection
-            this.updateSelection([]);
+            this.updateSelection(this.scope.selection.all());
         };
 
         // Destroy; remove toolbar object from parent scope

--- a/platform/commonUI/edit/src/representers/EditToolbarRepresenter.js
+++ b/platform/commonUI/edit/src/representers/EditToolbarRepresenter.js
@@ -125,13 +125,12 @@ define(
         // Represent a domain object using this definition
         EditToolbarRepresenter.prototype.represent = function (representation) {
             // Get the newest toolbar definition from the view
-            var definition = (representation || {}).toolbar || {},
-                self = this;
+            var definition = (representation || {}).toolbar || {};
 
             // If we have been asked to expose toolbar state...
             if (this.attrs.toolbar) {
                 // Initialize toolbar object
-                this.toolbar = new EditToolbar(def, this.commit);
+                this.toolbar = new EditToolbar(definition, this.commit);
                 // Ensure toolbar state is exposed
                 this.exposeToolbar();
             }

--- a/platform/commonUI/edit/src/representers/EditToolbarSelection.js
+++ b/platform/commonUI/edit/src/representers/EditToolbarSelection.js
@@ -38,24 +38,35 @@ define(
          * @memberof platform/commonUI/edit
          * @constructor
          */
-        function EditToolbarSelection(openmct) {
+        function EditToolbarSelection($scope, openmct) {
             this.selection = [{}];
             this.selecting = false;
             this.selectedObj = undefined;
+            var self = this;
 
-            openmct.selection.on('change', function (selection) {
+            function setSelection (selection) {
                 var selected = selection[0];
 
                 if (selected && selected.context.toolbar) {
-                    this.select(selected.context.toolbar);
+                    self.select(selected.context.toolbar);
                 } else {
-                    this.deselect();
+                    self.deselect();
                 }
 
                 if (selected && selected.context.viewProxy) {
-                    this.proxy(selected.context.viewProxy);
+                    self.proxy(selected.context.viewProxy);
                 }
-            }.bind(this));
+                setTimeout(function () {
+                    $scope.$apply();
+                });
+            }
+
+            $scope.$on("$destroy", function () {
+                self.openmct.selection.off('change', setSelection);
+            });
+
+            openmct.selection.on('change', setSelection);
+            setSelection(openmct.selection.get());
         }
 
         /**

--- a/platform/commonUI/edit/src/representers/EditToolbarSelection.js
+++ b/platform/commonUI/edit/src/representers/EditToolbarSelection.js
@@ -42,6 +42,7 @@ define(
             this.selection = [{}];
             this.selecting = false;
             this.selectedObj = undefined;
+            this.openmct = openmct;
             var self = this;
 
             function setSelection(selection) {
@@ -56,6 +57,7 @@ define(
                 if (selected && selected.context.viewProxy) {
                     self.proxy(selected.context.viewProxy);
                 }
+
                 setTimeout(function () {
                     $scope.$apply();
                 });
@@ -65,8 +67,8 @@ define(
                 self.openmct.selection.off('change', setSelection);
             });
 
-            openmct.selection.on('change', setSelection);
-            setSelection(openmct.selection.get());
+            this.openmct.selection.on('change', setSelection);
+            setSelection(this.openmct.selection.get());
         }
 
         /**

--- a/platform/commonUI/edit/src/representers/EditToolbarSelection.js
+++ b/platform/commonUI/edit/src/representers/EditToolbarSelection.js
@@ -44,7 +44,7 @@ define(
             this.selectedObj = undefined;
             var self = this;
 
-            function setSelection (selection) {
+            function setSelection(selection) {
                 var selected = selection[0];
 
                 if (selected && selected.context.toolbar) {

--- a/platform/commonUI/edit/test/representers/EditToolbarRepresenterSpec.js
+++ b/platform/commonUI/edit/test/representers/EditToolbarRepresenterSpec.js
@@ -36,7 +36,7 @@ define(
             beforeEach(function () {
                 mockScope = jasmine.createSpyObj(
                     '$scope',
-                    ['$on', '$watch', '$watchCollection', "commit"]
+                    ['$on', '$watch', '$watchCollection', "commit", "$apply"]
                 );
                 mockElement = {};
                 testAttrs = { toolbar: 'testToolbar' };

--- a/platform/commonUI/edit/test/representers/EditToolbarSelectionSpec.js
+++ b/platform/commonUI/edit/test/representers/EditToolbarSelectionSpec.js
@@ -30,7 +30,8 @@ define(
                 otherElement,
                 selection,
                 mockSelection,
-                mockOpenMCT;
+                mockOpenMCT,
+                mockScope;
 
             beforeEach(function () {
                 testProxy = { someKey: "some value" };
@@ -46,7 +47,12 @@ define(
                 mockOpenMCT = {
                     selection: mockSelection
                 };
-                selection = new EditToolbarSelection(mockOpenMCT);
+                mockScope = jasmine.createSpyObj('$scope', [
+                    '$on',
+                    '$apply'
+                ]);
+
+                selection = new EditToolbarSelection(mockScope, mockOpenMCT);
                 selection.proxy(testProxy);
             });
 
@@ -101,6 +107,20 @@ define(
             it("treats selection of the proxy as a no-op", function () {
                 selection.select(testProxy);
                 expect(selection.all()).toEqual([testProxy]);
+            });
+
+            it("cleans up selection on scope destroy", function () {
+                expect(mockScope.$on).toHaveBeenCalledWith(
+                    '$destroy',
+                    jasmine.any(Function)
+                );
+
+                mockScope.$on.mostRecentCall.args[1]();
+
+                expect(mockOpenMCT.selection.off).toHaveBeenCalledWith(
+                    'change',
+                    jasmine.any(Function)
+                );
             });
 
         });

--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -315,6 +315,8 @@ define(
             this.openmct.time.on("bounds", updateDisplayBounds);
             this.openmct.selection.on('change', setSelection);
             this.$element.on('click', this.bypassSelection.bind(this));
+
+            setSelection(this.openmct.selection.get());
         }
 
         /**

--- a/platform/features/layout/test/FixedControllerSpec.js
+++ b/platform/features/layout/test/FixedControllerSpec.js
@@ -201,7 +201,7 @@ define(
                     'off',
                     'get'
                 ]);
-                mockSelection.get.andCallThrough();
+                mockSelection.get.andReturn([]);
 
                 mockOpenMCT = {
                     time: mockConductor,
@@ -596,7 +596,7 @@ define(
                 expect(controller.getSelectedElementStyle()).not.toEqual(oldStyle);
             });
 
-            it("cleans up slection on scope destroy", function () {
+            it("cleans up selection on scope destroy", function () {
                 expect(mockScope.$on).toHaveBeenCalledWith(
                     '$destroy',
                     jasmine.any(Function)


### PR DESCRIPTION
... to make the add button appear in the toolbar when a fixed position is created.

Remove selection change listener on destroy.

Start a digest cycle when handling selection in toolbar to avoid delays in toolbar.

Fixes #1991, #1987