### PR TITLE
Bump Node Version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.7.0
+    version: 8.11.0
 
 dependencies:
   pre:


### PR DESCRIPTION
Bumps node version on CircleCI to 8.11 LTS.  This fixes CircleCI build failures.   Though we need to figure out which underlying library change caused this to start failing.

# Reviewer Checklist

1. Changes appear to address issue? Y
2. Appropriate unit tests included? N/A (CI only change)
3. Code style and in-line documentation are appropriate? Y
4. Commit messages meet standards? Y