### PR TITLE
[plot] check if stats is present before reseting zoom

### DIFF
--- a/src/plugins/plot/src/configuration/YAxisModel.js
+++ b/src/plugins/plot/src/configuration/YAxisModel.js
@@ -152,7 +152,7 @@ define([
             this.resetStats();
         },
         toggleAutoscale: function (autoscale) {
-            if (autoscale) {
+            if (autoscale && this.has('stats')) {
                 this.set('displayRange', this.applyPadding(this.get('stats')));
             } else {
                 this.set('displayRange', this.get('range'));


### PR DESCRIPTION
Fixes #2022

Turns out if telemetry is empty and the x and y plots can't align with the telemetry, then the `updateSeries` function won't get updated. In `updateSeries` a fallback value to `this.stats` w.r.t `this.range` gets set. Don't know where you want me to fix this, so I added another if check in the plot so that the reset pan uses range instead of stats. 

# Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Y
Changes have been smoke-tested? N/A