### PR TITLE
don't allow plot or table view of summary widget

### DIFF
--- a/src/plugins/summaryWidget/SummaryWidgetViewPolicy.js
+++ b/src/plugins/summaryWidget/SummaryWidgetViewPolicy.js
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+
+], function (
+
+) {
+
+    /**
+     * Policy determining which views can apply to summary widget.  Disables
+     * any view other than normal summary widget view.
+     */
+    function SummaryWidgetViewPolicy() {
+    }
+
+    SummaryWidgetViewPolicy.prototype.allow = function (view, domainObject) {
+        if (domainObject.getModel().type === 'summary-widget') {
+            return view.key === 'summary-widget-viewer';
+        }
+        return true;
+
+    };
+
+    return SummaryWidgetViewPolicy;
+});

--- a/src/plugins/summaryWidget/plugin.js
+++ b/src/plugins/summaryWidget/plugin.js
@@ -2,12 +2,14 @@ define([
     './SummaryWidgetsCompositionPolicy',
     './src/telemetry/SummaryWidgetMetadataProvider',
     './src/telemetry/SummaryWidgetTelemetryProvider',
-    './src/views/SummaryWidgetViewProvider'
+    './src/views/SummaryWidgetViewProvider',
+    './SummaryWidgetViewPolicy'
 ], function (
     SummaryWidgetsCompositionPolicy,
     SummaryWidgetMetadataProvider,
     SummaryWidgetTelemetryProvider,
-    SummaryWidgetViewProvider
+    SummaryWidgetViewProvider,
+    SummaryWidgetViewPolicy
 ) {
 
     function plugin() {
@@ -86,6 +88,11 @@ define([
             openmct.types.addType('summary-widget', widgetType);
             openmct.legacyExtension('policies', {category: 'composition',
                 implementation: SummaryWidgetsCompositionPolicy, depends: ['openmct']
+            });
+            openmct.legacyExtension('policies', {
+                category: 'view',
+                implementation: SummaryWidgetViewPolicy,
+                depends: ['openmct']
             });
             openmct.telemetry.addProvider(new SummaryWidgetMetadataProvider(openmct));
             openmct.telemetry.addProvider(new SummaryWidgetTelemetryProvider(openmct));

--- a/src/plugins/summaryWidget/test/SummaryWidgetViewPolicySpec.js
+++ b/src/plugins/summaryWidget/test/SummaryWidgetViewPolicySpec.js
@@ -1,0 +1,66 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    '../SummaryWidgetViewPolicy'
+], function (
+    SummaryWidgetViewPolicy
+) {
+
+    describe('SummaryWidgetViewPolicy', function () {
+        var policy;
+        var domainObject;
+        var view;
+        beforeEach(function () {
+            policy = new SummaryWidgetViewPolicy();
+            domainObject = jasmine.createSpyObj('domainObject', [
+                'getModel'
+            ]);
+            domainObject.getModel.andReturn({});
+            view = {};
+        });
+
+        it('returns true for other object types', function () {
+            domainObject.getModel.andReturn({
+                type: 'random'
+            });
+            expect(policy.allow(view, domainObject)).toBe(true);
+        });
+
+        it('allows summary widget view for summary widgets', function () {
+            domainObject.getModel.andReturn({
+                type: 'summary-widget'
+            });
+            view.key = 'summary-widget-viewer';
+            expect(policy.allow(view, domainObject)).toBe(true);
+        });
+
+        it('disallows other views for summary widgets', function () {
+            domainObject.getModel.andReturn({
+                type: 'summary-widget'
+            });
+            view.key = 'other view';
+            expect(policy.allow(view, domainObject)).toBe(false);
+        });
+
+    });
+});


### PR DESCRIPTION
Adds a view policy for the summary widget to prevent any view other than the summary widget view.  This reduces user confusion about plot and table views of summary widget.

# Author Checklist

1. Changes address original issue? Y (as reported here)
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y