### PR TITLE
[Timer] Fix regression in timer visual indication and add tests

### DIFF
--- a/platform/features/clock/src/controllers/TimerController.js
+++ b/platform/features/clock/src/controllers/TimerController.js
@@ -52,9 +52,12 @@ define(
                     self.textValue = formatter(timeDelta);
                     self.signValue = timeDelta < 0 ? "-" :
                         timeDelta >= 1000 ? "+" : "";
+                    self.signCssClass = timeDelta < 0 ? "icon-minus" :
+                        timeDelta >= 1000 ? "icon-plus" : "";
                 } else {
                     self.textValue = "";
                     self.signValue = "";
+                    self.signCssClass = "";
                 }
             }
 
@@ -213,6 +216,15 @@ define(
          */
         TimerController.prototype.sign = function () {
             return this.signValue;
+        };
+
+        /**
+         * Get the sign (+ or -) of the current timer value, as
+         * a CSS class.
+         * @returns {string} sign of the current timer value
+         */
+        TimerController.prototype.signClass = function () {
+            return this.signCssClass;
         };
 
         /**

--- a/platform/features/clock/test/controllers/TimerControllerSpec.js
+++ b/platform/features/clock/test/controllers/TimerControllerSpec.js
@@ -127,6 +127,7 @@ define(
                 mockNow.andReturn(TEST_TIMESTAMP);
                 mockWindow.requestAnimationFrame.mostRecentCall.args[0]();
                 expect(controller.sign()).toEqual("");
+                expect(controller.signClass()).toEqual("");
                 expect(controller.text()).toEqual("");
             });
 
@@ -139,16 +140,19 @@ define(
                 mockNow.andReturn(TEST_TIMESTAMP + 121000);
                 mockWindow.requestAnimationFrame.mostRecentCall.args[0]();
                 expect(controller.sign()).toEqual("+");
+                expect(controller.signClass()).toEqual("icon-plus");
                 expect(controller.text()).toEqual("0D 00:02:01");
 
                 mockNow.andReturn(TEST_TIMESTAMP - 121000);
                 mockWindow.requestAnimationFrame.mostRecentCall.args[0]();
                 expect(controller.sign()).toEqual("-");
+                expect(controller.signClass()).toEqual("icon-minus");
                 expect(controller.text()).toEqual("0D 00:02:01");
 
                 mockNow.andReturn(TEST_TIMESTAMP);
                 mockWindow.requestAnimationFrame.mostRecentCall.args[0]();
                 expect(controller.sign()).toEqual("");
+                expect(controller.signClass()).toEqual("");
                 expect(controller.text()).toEqual("0D 00:00:00");
             });
 


### PR DESCRIPTION
Fixes regression documented in #1895. Looks like it was introduced in https://github.com/nasa/openmct/commit/5aa93ba50c61258b294cceff3ca37450c2b26f75 cleanup. I kept the original class names, and added some basic tests as well.

Thanks @charlesh88 @akhenry for the pointers in the right direction on the issue!

# Author Checklist

Changes address original issue? Y
Unit tests included and/or updated with changes? Y
Command line build passes? Y
Changes have been smoke-tested? Y
