### PR TITLE
Json export fix

### DIFF
--- a/platform/import-export/bundle.js
+++ b/platform/import-export/bundle.js
@@ -49,9 +49,11 @@ define([
                             "category": "contextual",
                             "cssClass": "icon-export",
                             "depends": [
+                                "openmct",
                                 "exportService",
                                 "policyService",
-                                "identifierService"
+                                "identifierService",
+                                "typeService"
                             ]
                         },
                         {

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -91,14 +91,6 @@ define([
     };
 
     /**
-     * @param {module:openmct.ObjectAPI~Identifier} identifier
-     * @returns {string} A string representation of the given identifier, including namespace and key
-     */
-    ObjectAPI.prototype.makeKeyString = function (identifier) {
-        return utils.makeKeyString(identifier);
-    }
-
-    /**
      * Provides the ability to read, write, and delete domain objects.
      *
      * When registering a new object provider, all methods on this interface
@@ -213,6 +205,14 @@ define([
             new MutableObject(this.eventEmitter, domainObject);
         mutableObject.on(path, callback);
         return mutableObject.stopListening.bind(mutableObject);
+    };
+
+    /**
+     * @param {module:openmct.ObjectAPI~Identifier} identifier
+     * @returns {string} A string representation of the given identifier, including namespace and key
+     */
+    ObjectAPI.prototype.makeKeyString = function (identifier) {
+        return utils.makeKeyString(identifier);
     };
 
     /**

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -91,6 +91,14 @@ define([
     };
 
     /**
+     * @param {module:openmct.ObjectAPI~Identifier} identifier
+     * @returns {string} A string representation of the given identifier, including namespace and key
+     */
+    ObjectAPI.prototype.makeKeyString = function (identifier) {
+        return utils.makeKeyString(identifier);
+    }
+
+    /**
      * Provides the ability to read, write, and delete domain objects.
      *
      * When registering a new object provider, all methods on this interface


### PR DESCRIPTION
Addresses issues found in #2042

The main fix here is to deal only with a single instance of an object, rather than a mix of duplicate and original objects. This was causing the wrong objects to be updated with new object Ids, and resulted in export files that had a mix of duplicated and original objects.

Have refactored `ExportAsJSONAction` to use new-style objects as this made a few things a little easier.

Note that it also includes a [small change to the Object API](https://github.com/nasa/openmct/blob/976bf5ce60ad2e5af01f81c32e1570584b6cc483/src/api/objects/ObjectAPI.js#L214). I think that usage of `makeKeyString` on object-utils is common enough to justify adding it to the API to avoid the convoluted dependency.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y
* Command line build passes? Y
* Changes have been smoke-tested? Y
