### PR TITLE
Only include grippy when there's more than one element

### DIFF
--- a/platform/commonUI/edit/res/templates/elements.html
+++ b/platform/commonUI/edit/res/templates/elements.html
@@ -25,10 +25,12 @@
                  ng-model="filterBy">
     </mct-include>
     <div class="flex-elem grows vscroll">
-        <ul class="tree" id="inspector-elements-tree" ng-if="composition.length > 0">
+        <ul class="tree" id="inspector-elements-tree"
+            ng-if="composition.length > 0">
             <li ng-repeat="containedObject in composition | filter:searchElements">
                 <span class="tree-item">
                     <span class="grippy-sm"
+                          ng-if="composition.length > 1"
                           data-id="{{ containedObject.id }}"
                           mct-drag-down="dragDown($event)"
                           mct-drag="drag($event)"


### PR DESCRIPTION
Added ng-if to look at length of composition. Fixes #2053

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
