### PR TITLE
Indicators api styling

### DIFF
--- a/example/notifications/res/dialog-launch.html
+++ b/example/notifications/res/dialog-launch.html
@@ -1,9 +1,9 @@
-<span class="status block" ng-controller="DialogLaunchController">
+<span class="h-indicator" ng-controller="DialogLaunchController">
     <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-    <span class="status-indicator icon-box-with-arrow"></span><span class="label">
+    <div class="l-indicator s-indicator icon-box-with-arrow status-available"><span class="label">
         <a ng-click="launchProgress(true)">Known</a> |
         <a ng-click="launchProgress(false)">Unknown</a> |
         <a ng-click="launchError()">Error</a> |
         <a ng-click="launchInfo()">Info</a>
-    </span><span class="count"></span>
+    </span></div>
 </span>

--- a/example/notifications/res/dialog-launch.html
+++ b/example/notifications/res/dialog-launch.html
@@ -1,9 +1,9 @@
 <span class="h-indicator" ng-controller="DialogLaunchController">
     <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
     <div class="l-indicator s-indicator icon-box-with-arrow status-available"><span class="label">
-        <a ng-click="launchProgress(true)">Known</a> |
-        <a ng-click="launchProgress(false)">Unknown</a> |
-        <a ng-click="launchError()">Error</a> |
+        <a ng-click="launchProgress(true)">Known</a>
+        <a ng-click="launchProgress(false)">Unknown</a>
+        <a ng-click="launchError()">Error</a>
         <a ng-click="launchInfo()">Info</a>
     </span></div>
 </span>

--- a/example/notifications/res/dialog-launch.html
+++ b/example/notifications/res/dialog-launch.html
@@ -1,6 +1,6 @@
 <span class="h-indicator" ng-controller="DialogLaunchController">
     <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-    <div class="l-indicator s-indicator icon-box-with-arrow status-available"><span class="label">
+    <div class="ls-indicator icon-box-with-arrow status-available"><span class="label">
         <a ng-click="launchProgress(true)">Known</a>
         <a ng-click="launchProgress(false)">Unknown</a>
         <a ng-click="launchError()">Error</a>

--- a/example/notifications/res/notification-launch.html
+++ b/example/notifications/res/notification-launch.html
@@ -1,6 +1,6 @@
 <span class="h-indicator" ng-controller="NotificationLaunchController">
     <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-    <div class="l-indicator s-indicator icon-bell status-available"><span class="label">
+    <div class="ls-indicator icon-bell status-available"><span class="label">
         <a ng-click="newInfo()">Success</a>
         <a ng-click="newError()">Error</a>
         <a ng-click="newAlert()">Alert</a>

--- a/example/notifications/res/notification-launch.html
+++ b/example/notifications/res/notification-launch.html
@@ -1,9 +1,9 @@
-<span class="status block" ng-controller="NotificationLaunchController">
+<span class="h-indicator" ng-controller="NotificationLaunchController">
     <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-    <span class="status-indicator icon-bell"></span><span class="label">
+    <div class="l-indicator s-indicator icon-bell status-available"><span class="label">
         <a ng-click="newInfo()">Success</a> |
         <a ng-click="newError()">Error</a> |
         <a ng-click="newAlert()">Alert</a> |
         <a ng-click="newProgress()">Progress</a>
-    </span><span class="count"></span>
+    </span></div>
 </span>

--- a/example/notifications/res/notification-launch.html
+++ b/example/notifications/res/notification-launch.html
@@ -1,9 +1,9 @@
 <span class="h-indicator" ng-controller="NotificationLaunchController">
     <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
     <div class="l-indicator s-indicator icon-bell status-available"><span class="label">
-        <a ng-click="newInfo()">Success</a> |
-        <a ng-click="newError()">Error</a> |
-        <a ng-click="newAlert()">Alert</a> |
+        <a ng-click="newInfo()">Success</a>
+        <a ng-click="newError()">Error</a>
+        <a ng-click="newAlert()">Alert</a>
         <a ng-click="newProgress()">Progress</a>
     </span></div>
 </span>

--- a/example/styleguide/res/templates/status.html
+++ b/example/styleguide/res/templates/status.html
@@ -103,6 +103,10 @@
                         <li><code>s-status-diagnostic</code></li>
                         <li><code>s-status-info</code></li>
                         <li><code>s-status-ok</code></li>
+                        <li><code>s-status-available</code> When something is available.</li>
+                        <li><code>s-status-on</code> When something that has on/off states is on.</li>
+                        <li><code>s-status-off</code> When something that has on/off states is off.</li>
+                        <li><code>s-status-disabled</code> When something that might be available has been disabled.</li>
                     </ul>
                     <li>Color and icon</li>
                     <ul>
@@ -125,6 +129,51 @@
 <div class="s-status-info-icon">INFO with icon</div>
 <div class="s-status-ok-icon">OK with icon</div>
 <div class="s-status-warning-hi icon-gear">WARNING HI with custom icon</div>
+</mct-example>
+        </div>
+    </div>
+
+    <div class="l-section">
+        <h2>Status Bar Indicators</h2>
+        <div class="cols cols1-1">
+            <div class="col">
+                <p>Indicators are small iconic notification elements that appear in the Status Bar area of
+                    the application at the window's bottom. They consist of a <code>.ls-indicator</code>
+                    wrapper element with <code>.icon-*</code> classes for the type of thing they represent and
+                    <code>.s-status-*</code> classes to articulate the current status. Title attributes should be used
+                    to provide more verbose information about the thing and/or its status.</p>
+                <p>The wrapper encloses a <code>.label</code> element that is displayed on hover. This element should
+                    include a brief statement of the current status, and can also include clickable elements
+                    as <code>&lt;a&gt;</code> tags.</p>
+                <p>Icon classes are as defined on the
+                    <a href="#/browse/styleguide:home/glyphs?tc.mode=local&tc.timeSystem=utc&tc.startDelta=1800000&tc.endDelta=0&view=styleguide.glyphs">
+                        Glyphs page</a>.
+                    Status classes are as noted above in the &quot;Color only&quot; section of Status section above.</p>
+            </div>
+<mct-example><div class="s-ue-bottom-bar status-holder s-status-bar">
+<span class="ls-indicator icon-database s-status-alert" title="The system is currently lorem ipsum.">
+    <span class="label">Lorem Ipsum</span>
+</span>
+<span class="ls-indicator icon-packet s-status-off" title="Message lorem ipsum dolor sit.">
+    <span class="label">Message Bus</span>
+</span>
+<span class="ls-indicator icon-gear s-status-available" title="Configure lorem ipsum dolor sit.">
+    <span class="label"><a>Preferences</a></span>
+</span>
+<span class="ls-indicator icon-bell s-status-available" title="View alerts and messages.">
+    <span class="label">
+        <a class="icon-alert-triangle">View Alerts</a>
+        <a class="icon-packet">View Messages</a>
+        <a class="icon-gear">Configure</a>
+    </span>
+</span>
+<span class="ls-indicator icon-bell s-status-on" title="System connection status.">
+    <span class="label">
+        Connected to http://lorem-ipsum
+        <a class="icon-gear">Disconnect</a>
+    </span>
+</span>
+</div>
 </mct-example>
         </div>
     </div>

--- a/example/styleguide/res/templates/status.html
+++ b/example/styleguide/res/templates/status.html
@@ -148,7 +148,7 @@
                 <p>Icon classes are as defined on the
                     <a href="#/browse/styleguide:home/glyphs?tc.mode=local&tc.timeSystem=utc&tc.startDelta=1800000&tc.endDelta=0&view=styleguide.glyphs">
                         Glyphs page</a>.
-                    Status classes are as noted above in the &quot;Color only&quot; section of Status section above.</p>
+                    Status classes are as noted above in the &quot;Color only&quot; part of the Status section above.</p>
             </div>
 <mct-example><div class="s-ue-bottom-bar status-holder s-status-bar">
 <span class="ls-indicator icon-database s-status-alert" title="The system is currently lorem ipsum.">

--- a/platform/commonUI/general/res/sass/_main.scss
+++ b/platform/commonUI/general/res/sass/_main.scss
@@ -42,6 +42,7 @@
 @import "controls/lists";
 @import "controls/menus";
 @import "controls/messages";
+@import "controls/indicators";
 @import "mobile/controls/menus";
 
 /********************************* FORMS */

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -108,6 +108,7 @@
         @include indicatorStatusColors($colorStatusAlert);
     }
 
+    &.s-status-error,
     &.status-error,
     &.status-err {
         @include indicatorStatusColors($colorStatusError);

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -52,7 +52,7 @@
     &:before {
         content:'';
         font-family: symbolsfont;
-        font-size: 0.8em;
+        //font-size: 0.8em; // TODO: This change must be unit tested against these classes applied to other elements
         margin-right: $interiorMarginSm;
     }
 }

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -51,7 +51,6 @@
     &:before {
         content:'';
         font-family: symbolsfont;
-        //font-size: 0.8em; // TODO: This change must be unit tested against these classes applied to other elements
         margin-right: $interiorMarginSm;
     }
 }
@@ -92,8 +91,10 @@
     }
 
     &.status-ok,
+    &.status-enabled,
     &.s-status-ok,
-    &.status-enabled {
+    &.s-status-enabled
+    {
         @include indicatorStatusColors($colorOk);
     }
 
@@ -102,19 +103,24 @@
         @include indicatorStatusColors($colorStatusDisabled);
     }
 
+
     &.status-caution,
     &.status-warning,
-    &.status-alert {
+    &.status-alert,
+    &.s-status-caution,
+    &.s-status-warning,
+    &.s-status-alert {
         @include indicatorStatusColors($colorStatusAlert);
     }
 
-    &.s-status-error,
     &.status-error,
-    &.status-err {
+    &.status-err,
+    &.s-status-error {
         @include indicatorStatusColors($colorStatusError);
     }
 
-    &.status-available {
+    &.status-available,
+    &.s-status-available {
         @include indicatorStatusColors($colorStatusAvailable);
     }
 }

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -84,7 +84,7 @@
 
 /*************************************************** INDICATORS */
 
-.s-indicator {
+.ls-indicator {
     &.status-info,
     &.s-status-info {
         @include indicatorStatusColors($colorInfo);

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -20,13 +20,16 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 /*************************************************** MIXINS */
-@mixin formulateStatusColors($c) {
+@mixin elementStatusColors($c) {
     // Sets bg and icon colors for elements
     background: rgba($c, 0.4) !important;
     &:before { color: $c !important; }
 }
 
-
+@mixin indicatorStatusColors($c) {
+    background: transparent !important;
+    &:before, .count { color: $c; }
+}
 
 /*************************************************** GENERAL */
 .s-limit-yellow,
@@ -54,14 +57,13 @@
     }
 }
 
-
 /*************************************************** LIMITS */
 .s-limit-yellow, .s-limit-yellow-icon {
-    @include formulateStatusColors($colorWarningLo);
+    @include elementStatusColors($colorWarningLo);
 }
 
 .s-limit-red, .s-limit-red-icon {
-    @include formulateStatusColors($colorWarningHi);
+    @include elementStatusColors($colorWarningHi);
 }
 
 .s-limit-upr:before { content: $glyph-icon-arrow-double-up; }
@@ -70,16 +72,72 @@
 .s-limit-red-icon:before { content: $glyph-icon-alert-triangle; }
 
 /*************************************************** STATUS */
-.s-status-warning-hi, .s-status-warning-hi-icon {  @include formulateStatusColors($colorWarningHi); }
-.s-status-warning-lo, .s-status-warning-lo-icon {  @include formulateStatusColors($colorWarningLo); }
-.s-status-diagnostic, .s-status-diagnostic-icon {  @include formulateStatusColors($colorDiagnostic); }
-.s-status-info, .s-status-info-icon {  @include formulateStatusColors($colorInfo); }
-.s-status-ok, .s-status-ok-icon {  @include formulateStatusColors($colorOk); }
+.s-status-warning-hi, .s-status-warning-hi-icon {  @include elementStatusColors($colorWarningHi); }
+.s-status-warning-lo, .s-status-warning-lo-icon {  @include elementStatusColors($colorWarningLo); }
+.s-status-diagnostic, .s-status-diagnostic-icon {  @include elementStatusColors($colorDiagnostic); }
+.s-status-info, .s-status-info-icon {  @include elementStatusColors($colorInfo); }
+.s-status-ok, .s-status-ok-icon {  @include elementStatusColors($colorOk); }
 
 .s-status-warning-hi-icon:before { content: $glyph-icon-alert-triangle; }
 .s-status-warning-lo-icon:before { content: $glyph-icon-alert-rect; }
 .s-status-diagnostic-icon:before { content: $glyph-icon-eye-open; }
 .s-status-info-icon:before { content: $glyph-icon-info; }
 .s-status-ok-icon:before { content: $glyph-icon-check; }
+
+/*************************************************** INDICATORS */
+
+.s-indicator {
+    &.s-status-info {
+        @include indicatorStatusColors($colorInfo);
+    }
+
+    &.s-status-ok {
+        @include indicatorStatusColors($colorOk);
+    }
+
+    &.status-caution,
+    &.status-warning,
+    &.status-alert {
+        @include indicatorStatusColors($colorStatusAlert);
+    }
+
+    &.status-error,
+    &.status-err {
+        @include indicatorStatusColors($colorStatusError);
+    }
+
+    &.status-available {
+        @include indicatorStatusColors($colorStatusAvailable);
+    }
+
+    &.status-subdued {
+        opacity: 0.7;
+    }
+}
+
+
+/*
+
+
+.s-indicator.s-status-info {
+    @include indicatorStatusColors($colorInfo);
+}
+.s-indicator.s-status-ok {
+    @include indicatorStatusColors($colorOk);
+}
+.s-indicator-status-caution, .s-indicator-status-warning, .s-indicator-status-alert {
+    @include indicatorStatusColors($colorStatusAlert);
+}
+.s-indicator-status-error, .s-indicator-status-err {
+    @include indicatorStatusColors($colorStatusError);
+}
+.s-indicator-status-available {
+    @include indicatorStatusColors($colorStatusAvailable);
+}
+.s-indicator-status-subdued {
+    opacity: 0.7;
+}
+*/
+
 
 

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -91,18 +91,20 @@
     }
 
     &.status-ok,
+    &.status-on,
     &.status-enabled,
     &.s-status-ok,
-    &.s-status-enabled
-    {
+    &.s-status-on,
+    &.s-status-enabled {
         @include indicatorStatusColors($colorOk);
     }
 
+    &.status-off,
     &.status-disabled,
+    &.s-status-off,
     &.s-status-disabled {
         @include indicatorStatusColors($colorStatusDisabled);
     }
-
 
     &.status-caution,
     &.status-warning,

--- a/platform/commonUI/general/res/sass/_status.scss
+++ b/platform/commonUI/general/res/sass/_status.scss
@@ -27,7 +27,6 @@
 }
 
 @mixin indicatorStatusColors($c) {
-    background: transparent !important;
     &:before, .count { color: $c; }
 }
 
@@ -87,12 +86,20 @@
 /*************************************************** INDICATORS */
 
 .s-indicator {
+    &.status-info,
     &.s-status-info {
         @include indicatorStatusColors($colorInfo);
     }
 
-    &.s-status-ok {
+    &.status-ok,
+    &.s-status-ok,
+    &.status-enabled {
         @include indicatorStatusColors($colorOk);
+    }
+
+    &.status-disabled,
+    &.s-status-disabled {
+        @include indicatorStatusColors($colorStatusDisabled);
     }
 
     &.status-caution,
@@ -109,35 +116,7 @@
     &.status-available {
         @include indicatorStatusColors($colorStatusAvailable);
     }
-
-    &.status-subdued {
-        opacity: 0.7;
-    }
 }
-
-
-/*
-
-
-.s-indicator.s-status-info {
-    @include indicatorStatusColors($colorInfo);
-}
-.s-indicator.s-status-ok {
-    @include indicatorStatusColors($colorOk);
-}
-.s-indicator-status-caution, .s-indicator-status-warning, .s-indicator-status-alert {
-    @include indicatorStatusColors($colorStatusAlert);
-}
-.s-indicator-status-error, .s-indicator-status-err {
-    @include indicatorStatusColors($colorStatusError);
-}
-.s-indicator-status-available {
-    @include indicatorStatusColors($colorStatusAvailable);
-}
-.s-indicator-status-subdued {
-    opacity: 0.7;
-}
-*/
 
 
 

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -23,9 +23,6 @@
 /* Indicators are generally only displayed in the ue-bottom-bar element of the main interface */
 
 mct-indicators {
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: flex-start;
     mct-include,
     .h-indicator {
         display: inline; // Fallback for display: contents
@@ -34,121 +31,71 @@ mct-indicators {
 }
 
 .l-indicator {
-    $transDelayHover: 1.5s;
-    $transDelayWhileExpanded: 2.5s;
-    $transSpeedExpand: 0ms;
-    $transSpeedCollapse: 350ms;
-    align-items: center;
-    border-radius: 2px;
-    display: flex;
-    flex-flow: row nowrap;
-    height: 100%;
-    line-height: auto;
-    //margin-right: $interiorMarginSm;
-    padding: 0px $interiorMarginSm;
-
-    &:before,
-    .label,
-    .count {
-        display: inline-block;
-        flex: 1 1 auto;
-    }
+    $bg: rgba(white, 0.2) !important;
+    $hbg: $colorStatusBarBg; //pullForward($colorBodyBg, 10%);
+    $hshdw: rgba(white, 0.4) 0 0 3px;
+    $br: $controlCr;
+    $hoverYOffset: -30px;
+    background: transparent !important;
+    border-radius: $br;
+    display: inline-block;
+    position: relative;
+    padding: 1px $interiorMarginSm; // Use padding instead of margin to keep hover chatter to a minimum
 
     &:before {
-        // Icon
-        margin-right: 0; // $interiorMarginSm;
-        //display: inline-block;
-        //opacity: 0.85;
+        display: inline-block;
+        margin: 0;
     }
 
-    .label,
-    .count {
-        //margin-left: $interiorMarginSm;
-        //@include test(green, 1);
-        //display: inline-block;
-        //vertical-align: middle;
+    .label {
+        display: inline-block;
+        a {
+            // Make <a> in label look like buttons
+            @include trans-prop-nice($props: all, $dur: 100ms);
+            border: 1px solid rgba($colorStatusBarFg, 0.5);
+            border-radius: $br;
+            color: inherit;
+            padding: 0 2px;
+            &:hover {
+                background: $bg;
+                color: #fff;
+            }
+        }
+    }
+
+    &:not(.no-collapse) {
+        .label {
+            @include trans-prop-nice($props: all, $dur: 250ms, $delay: 0);
+            background: $hbg;
+            border-radius: $br;
+            opacity: 0;
+            padding: $interiorMarginSm $interiorMargin;
+            position: absolute;
+            transform: translateY($hoverYOffset + 10px);
+            left: 0;
+            top: 0;
+            white-space: nowrap;
+            &:before {
+                // Infobubble-style arrow element
+                content: '';
+                display: block;
+                position: absolute;
+                top: 100%;
+                @include triangle('down', $size: 4px, $ratio: 1, $color: $hbg);
+            }
+        }
+
+        &:hover {
+            background: $bg;
+            .label {
+                //@include transition-delay(200ms);
+                opacity: 1;
+                transform: translateY($hoverYOffset);
+            }
+        }
     }
 
     &.float-right {
-        //float: right;
-        order: 999;
+        float: right;
     }
-
-    &.no-icon {
-        &:before {
-            display: none;
-        }
-    }
-
-    &.no-collapse {
-        &:before {
-            margin-right: $interiorMarginSm;
-        }
-    }
-
-    &:not(.no-collapse) {
-        &:before,
-        .label {
-            @include trans-prop-nice((max-width, margin-right, background), $transSpeedCollapse, $transDelayWhileExpanded);
-        }
-
-        .label {
-            // Max-width silliness is necessary for width transition
-            overflow: hidden;
-            max-width: 0px;
-            white-space: nowrap;
-        }
-
-        &:hover {
-            &:before {
-                @include trans-prop-nice((margin-right), $transSpeedExpand);
-                margin-right: $interiorMarginSm;
-            }
-
-            .label {
-                @include trans-prop-nice((max-width, background), $transSpeedExpand);
-                max-width: 600px;
-                width: auto;
-            }
-
-            .count {
-                @include trans-prop-nice((opacity, max-width, margin), $transSpeedExpand);
-                opacity: 0;
-                max-width: 0;
-                margin-left: 0;
-                visibility: hidden;
-            }
-        }
-    }
-
-    .count {
-        @include trans-prop-nice((opacity, max-width, margin), $transSpeedCollapse, $transDelayWhileExpanded);
-        font-weight: bold;
-        max-width: 30px;
-        opacity: 1;
-        margin-left: $interiorMarginSm;
-    }
-
-    .s-button {
-        background: $colorStatusBtnBg;
-        padding: 0 $interiorMargin;
-        height: auto;
-        line-height: inherit;
-    }
-}
-
-.s-indicator {
-    background: transparent !important;
-    color: $colorStatusDefault;
-    &:not(.no-collapse) {
-        &:hover {
-            background: rgba(#fff, 0.2) !important;
-        }
-
-    }
-
-    &.subdued {
-        opacity: 0.7;
-    }
-
 }

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -137,8 +137,11 @@ mct-indicators {
 .s-indicator {
     background: transparent !important;
     color: $colorStatusDefault;
-    &:hover {
-        background: rgba(#fff, 0.2) !important;
+    &:not(.no-collapse) {
+        &:hover {
+            background: rgba(#fff, 0.2) !important;
+        }
+
     }
 
     &.subdued {

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -113,3 +113,11 @@ mct-indicators {
         float: right;
     }
 }
+
+/* Mobile */
+// Hide the clock indicator when we're phone portrait
+body.phone.portrait {
+    .l-indicator.t-indicator-clock {
+        display: none;
+    }
+}

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -103,27 +103,30 @@ mct-indicators {
             &:before {
                 @include trans-prop-nice((margin-right), $transSpeedExpand);
                 margin-right: $interiorMarginSm;
-                //opacity: 1;
             }
 
             .label {
                 @include trans-prop-nice((max-width, background), $transSpeedExpand);
-                //margin-right: $interiorMargin;
                 max-width: 600px;
                 width: auto;
             }
 
             .count {
-                @include trans-prop-nice(max-width, $transSpeedExpand);
+                @include trans-prop-nice((opacity, max-width, margin), $transSpeedExpand);
                 opacity: 0;
+                max-width: 0;
+                margin-left: 0;
+                visibility: hidden;
             }
         }
     }
 
     .count {
-        @include trans-prop-nice(opacity, $transSpeedCollapse, $transDelayWhileExpanded);
+        @include trans-prop-nice((opacity, max-width, margin), $transSpeedCollapse, $transDelayWhileExpanded);
         font-weight: bold;
+        max-width: 30px;
         opacity: 1;
+        margin-left: $interiorMarginSm;
     }
 
     .s-button {

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -48,7 +48,6 @@ mct-indicators {
 
     .label {
         display: inline-block;
-        font-size: .6rem;
         a {
             // Make <a> in label look like buttons
             @include trans-prop-nice($props: all, $dur: 100ms);
@@ -82,6 +81,7 @@ mct-indicators {
             @include trans-prop-nice($props: all, $dur: 250ms, $delay: 0);
             background: $hbg;
             border-radius: $br;
+            font-size: .6rem;
             opacity: 0;
             padding: $interiorMarginSm $interiorMargin;
             position: absolute;

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -33,7 +33,7 @@ mct-indicators mct-include {
     $hbg: $colorStatusBarBg;
     $hshdw: rgba(white, 0.4) 0 0 3px;
     $br: $controlCr;
-    $hoverYOffset: -30px;
+    $hoverYOffset: -35px;
     background: transparent !important;
     border-radius: $br;
     display: inline-block;
@@ -91,17 +91,19 @@ mct-indicators mct-include {
     }
 
     &:not(.no-collapse) {
+        z-index: 0;
         .label {
-            @include trans-prop-nice($props: all, $dur: 250ms, $delay: 0);
+            transition: all 250ms ease-in 100ms;
             background: $hbg;
             border-radius: $br;
             font-size: .6rem;
+            left: 0;
+            bottom: 140%;
             opacity: 0;
             padding: $interiorMarginSm $interiorMargin;
             position: absolute;
-            transform: translateY($hoverYOffset + ($hoverYOffset * -0.5));
-            left: 0;
-            top: 0;
+            transform-origin: 10px 100%;
+            transform: scale(0.0);
             white-space: nowrap;
             &:before {
                 // Infobubble-style arrow element
@@ -115,9 +117,11 @@ mct-indicators mct-include {
 
         &:hover {
             background: $bg;
+            z-index: 1;
             .label {
                 opacity: 1;
-                transform: translateY($hoverYOffset);
+                transform: scale(1.0);
+                transition: all 100ms ease-out 0s;
             }
         }
     }

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -32,7 +32,7 @@ mct-indicators {
 
 .l-indicator {
     $bg: rgba(white, 0.2) !important;
-    $hbg: $colorStatusBarBg; //pullForward($colorBodyBg, 10%);
+    $hbg: $colorStatusBarBg;
     $hshdw: rgba(white, 0.4) 0 0 3px;
     $br: $controlCr;
     $hoverYOffset: -30px;
@@ -48,18 +48,27 @@ mct-indicators {
 
     .label {
         display: inline-block;
-        a {
+        a,
+        button,
+        .s-button {
             // Make <a> in label look like buttons
             @include trans-prop-nice($props: all, $dur: 100ms);
+            background: transparent;
             border: 1px solid rgba($colorStatusBarFg, 0.5);
             border-radius: $br;
+            box-sizing: border-box;
             color: inherit;
+            font-size: inherit;
+            height: auto;
+            line-height: normal;
             padding: 0 2px;
             &:hover {
                 background: $bg;
                 color: #fff;
             }
         }
+
+        button { text-transform: uppercase !important; }
     }
 
     &.no-collapse {
@@ -85,7 +94,7 @@ mct-indicators {
             opacity: 0;
             padding: $interiorMarginSm $interiorMargin;
             position: absolute;
-            transform: translateY($hoverYOffset + 10px);
+            transform: translateY($hoverYOffset + ($hoverYOffset * -0.5));
             left: 0;
             top: 0;
             white-space: nowrap;

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -22,27 +22,56 @@
 
 /* Indicators are generally only displayed in the ue-bottom-bar element of the main interface */
 
+mct-indicators {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+    mct-include,
+    .h-indicator {
+        display: inline; // Fallback for display: contents
+        display: contents;
+    }
+}
+
 .l-indicator {
     $transDelayHover: 1.5s;
     $transDelayWhileExpanded: 2.5s;
-    $transSpeed: .25s;
-    display: inline-block;
-    margin-right: $interiorMarginSm;
+    $transSpeedExpand: 0ms;
+    $transSpeedCollapse: 350ms;
+    align-items: center;
+    border-radius: 2px;
+    display: flex;
+    flex-flow: row nowrap;
+    height: 100%;
+    line-height: auto;
+    //margin-right: $interiorMarginSm;
+    padding: 0px $interiorMarginSm;
+
+    &:before,
+    .label,
+    .count {
+        display: inline-block;
+        flex: 1 1 auto;
+    }
 
     &:before {
         // Icon
-        display: inline-block;
-        opacity: 0.85;
+        margin-right: 0; // $interiorMarginSm;
+        //display: inline-block;
+        //opacity: 0.85;
     }
 
     .label,
     .count {
-        display: inline-block;
-        vertical-align: top;
+        //margin-left: $interiorMarginSm;
+        //@include test(green, 1);
+        //display: inline-block;
+        //vertical-align: middle;
     }
 
     &.float-right {
-        float: right;
+        //float: right;
+        order: 999;
     }
 
     &.no-icon {
@@ -51,36 +80,48 @@
         }
     }
 
+    &.no-collapse {
+        &:before {
+            margin-right: $interiorMarginSm;
+        }
+    }
+
     &:not(.no-collapse) {
+        &:before,
+        .label {
+            @include trans-prop-nice((max-width, margin-right, background), $transSpeedCollapse, $transDelayWhileExpanded);
+        }
+
         .label {
             // Max-width silliness is necessary for width transition
-            @include trans-prop-nice((max-width, margin-right), $transSpeed, $transDelayWhileExpanded);
             overflow: hidden;
-            margin-right: 0;
             max-width: 0px;
             white-space: nowrap;
         }
+
         &:hover {
             &:before {
-                opacity: 1;
+                @include trans-prop-nice((margin-right), $transSpeedExpand);
+                margin-right: $interiorMarginSm;
+                //opacity: 1;
             }
 
             .label {
-                @include trans-prop-nice((max-width, margin-right), 0s);
-                margin-right: $interiorMargin;
+                @include trans-prop-nice((max-width, background), $transSpeedExpand);
+                //margin-right: $interiorMargin;
                 max-width: 600px;
                 width: auto;
             }
 
             .count {
-                @include trans-prop-nice(max-width, 0s);
+                @include trans-prop-nice(max-width, $transSpeedExpand);
                 opacity: 0;
             }
         }
     }
 
     .count {
-        @include trans-prop-nice(opacity, $transSpeed, $transDelayWhileExpanded);
+        @include trans-prop-nice(opacity, $transSpeedCollapse, $transDelayWhileExpanded);
         font-weight: bold;
         opacity: 1;
     }
@@ -94,6 +135,14 @@
 }
 
 .s-indicator {
+    background: transparent !important;
     color: $colorStatusDefault;
+    &:hover {
+        background: rgba(#fff, 0.2) !important;
+    }
+
+    &.subdued {
+        opacity: 0.7;
+    }
 
 }

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -22,12 +22,10 @@
 
 /* Indicators are generally only displayed in the ue-bottom-bar element of the main interface */
 
-mct-indicators {
-    mct-include,
-    .h-indicator {
-        display: inline; // Fallback for display: contents
-        display: contents;
-    }
+.h-indicator,
+mct-indicators mct-include {
+    display: inline; // Fallback for display: contents
+    display: contents;
 }
 
 .ls-indicator {
@@ -65,6 +63,13 @@ mct-indicators {
             &:hover {
                 background: $bg;
                 color: #fff;
+            }
+        }
+
+        > [class*='icon-'] {
+            &:before {
+                font-size: 0.8em;
+                margin-right: $interiorMarginSm;
             }
         }
 

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -30,7 +30,7 @@ mct-indicators {
     }
 }
 
-.l-indicator {
+.ls-indicator {
     $bg: rgba(white, 0.2) !important;
     $hbg: $colorStatusBarBg;
     $hshdw: rgba(white, 0.4) 0 0 3px;
@@ -125,7 +125,7 @@ mct-indicators {
 /* Mobile */
 // Hide the clock indicator when we're phone portrait
 body.phone.portrait {
-    .l-indicator.t-indicator-clock {
+    .ls-indicator.t-indicator-clock {
         display: none;
     }
 }

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -102,7 +102,6 @@ mct-indicators {
         &:hover {
             background: $bg;
             .label {
-                //@include transition-delay(200ms);
                 opacity: 1;
                 transform: translateY($hoverYOffset);
             }

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -44,11 +44,11 @@ mct-indicators {
 
     &:before {
         display: inline-block;
-        margin: 0;
     }
 
     .label {
         display: inline-block;
+        font-size: .6rem;
         a {
             // Make <a> in label look like buttons
             @include trans-prop-nice($props: all, $dur: 100ms);
@@ -60,6 +60,20 @@ mct-indicators {
                 background: $bg;
                 color: #fff;
             }
+        }
+    }
+
+    &.no-collapse {
+        display: flex;
+        flex-flow: row nowrap;
+        align-items: center;
+        > *,
+        &:before {
+            flex: 1 1 auto;
+        }
+
+        &:before {
+            margin-right: $interiorMarginSm;
         }
     }
 

--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -1,0 +1,99 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2017, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/* Indicators are generally only displayed in the ue-bottom-bar element of the main interface */
+
+.l-indicator {
+    $transDelayHover: 1.5s;
+    $transDelayWhileExpanded: 2.5s;
+    $transSpeed: .25s;
+    display: inline-block;
+    margin-right: $interiorMarginSm;
+
+    &:before {
+        // Icon
+        display: inline-block;
+        opacity: 0.85;
+    }
+
+    .label,
+    .count {
+        display: inline-block;
+        vertical-align: top;
+    }
+
+    &.float-right {
+        float: right;
+    }
+
+    &.no-icon {
+        &:before {
+            display: none;
+        }
+    }
+
+    &:not(.no-collapse) {
+        .label {
+            // Max-width silliness is necessary for width transition
+            @include trans-prop-nice((max-width, margin-right), $transSpeed, $transDelayWhileExpanded);
+            overflow: hidden;
+            margin-right: 0;
+            max-width: 0px;
+            white-space: nowrap;
+        }
+        &:hover {
+            &:before {
+                opacity: 1;
+            }
+
+            .label {
+                @include trans-prop-nice((max-width, margin-right), 0s);
+                margin-right: $interiorMargin;
+                max-width: 600px;
+                width: auto;
+            }
+
+            .count {
+                @include trans-prop-nice(max-width, 0s);
+                opacity: 0;
+            }
+        }
+    }
+
+    .count {
+        @include trans-prop-nice(opacity, $transSpeed, $transDelayWhileExpanded);
+        font-weight: bold;
+        opacity: 1;
+    }
+
+    .s-button {
+        background: $colorStatusBtnBg;
+        padding: 0 $interiorMargin;
+        height: auto;
+        line-height: inherit;
+    }
+}
+
+.s-indicator {
+    color: $colorStatusDefault;
+
+}

--- a/platform/commonUI/general/res/sass/controls/_messages.scss
+++ b/platform/commonUI/general/res/sass/controls/_messages.scss
@@ -21,7 +21,7 @@
  *****************************************************************************/
 /******************************************************************* STATUS BLOCK ELEMS */
 @mixin statusBannerColors($bg, $fg: $colorStatusFg) {
-	$bgPb: 30%;
+	$bgPb: 10%;
 	$bgPbD: 10%;
 	background-color: darken($bg, $bgPb);
 	color: $fg;

--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -47,6 +47,19 @@
     }
 }
 
+
+.status-holder {
+    text-transform: uppercase;
+}
+
+.s-ue-bottom-bar {
+    background: $colorStatusBarBg;
+    color: $colorStatusBarFg;
+    cursor: default;
+    font-size: .7rem;
+
+}
+
 .user-environ {
     height: 100%;
     width: 100%;
@@ -81,20 +94,16 @@
         }
     }
 
-    .ue-bottom-bar {
+    .l-ue-bottom-bar {
+        $m: $interiorMarginSm;
         @include absPosDefault(0, $overflow: visible);// New status bar design
         top: auto;
         height: $ueFooterH;
-        line-height: $ueFooterH - ($interiorMargin * 2);
-        background: $colorStatusBarBg;
-        color: $colorStatusBarFg;
-        cursor: default;
-        font-size: .7rem;
+        line-height: $ueFooterH - ($m * 2);
         .status-holder {
             box-sizing: border-box;
-            @include absPosDefault($interiorMarginSm, $overflow: visible);
+            @include absPosDefault($m, $overflow: visible);
             right: 120px;
-            text-transform: uppercase;
             z-index: 10;
         }
         .app-logo {

--- a/platform/commonUI/general/res/sass/user-environ/_layout.scss
+++ b/platform/commonUI/general/res/sass/user-environ/_layout.scss
@@ -82,20 +82,20 @@
     }
 
     .ue-bottom-bar {
-        @include absPosDefault(0);// New status bar design
+        @include absPosDefault(0, $overflow: visible);// New status bar design
         top: auto;
         height: $ueFooterH;
         line-height: $ueFooterH - ($interiorMargin * 2);
         background: $colorStatusBarBg;
-        color: lighten($colorBodyBg, 30%);
+        color: $colorStatusBarFg;
+        cursor: default;
         font-size: .7rem;
         .status-holder {
             box-sizing: border-box;
-            @include absPosDefault($interiorMargin);
-            @include ellipsize();
+            @include absPosDefault($interiorMarginSm, $overflow: visible);
             right: 120px;
             text-transform: uppercase;
-            z-index: 1;
+            z-index: 10;
         }
         .app-logo {
             background-position: right center;

--- a/platform/commonUI/general/res/templates/angular-indicator.html
+++ b/platform/commonUI/general/res/templates/angular-indicator.html
@@ -23,8 +23,5 @@
 <div class="l-indicator s-indicator {{ngModel.getCssClass()}}"
 	 title="{{ngModel.getDescription()}}"
 	 ng-show="ngModel.getText().length > 0">
-	<span class="label">
-		{{ngModel.getText()}}
-	</span><span class="count">
-	</span>
+	<span class="label">{{ngModel.getText()}}</span>
 </div>

--- a/platform/commonUI/general/res/templates/angular-indicator.html
+++ b/platform/commonUI/general/res/templates/angular-indicator.html
@@ -20,11 +20,10 @@
  at runtime from the About dialog for additional information.
 -->
 <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-<div class='status block'
+<div class="l-indicator s-indicator {{ngModel.getCssClass()}}"
 	 title="{{ngModel.getDescription()}}"
 	 ng-show="ngModel.getText().length > 0">
-	<span class="status-indicator {{ngModel.getCssClass()}}"></span><span class="label"
-		  ng-class='ngModel.getTextClass()'>
+	<span class="label">
 		{{ngModel.getText()}}
 	</span><span class="count">
 	</span>

--- a/platform/commonUI/general/res/templates/angular-indicator.html
+++ b/platform/commonUI/general/res/templates/angular-indicator.html
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-<div class="l-indicator s-indicator {{ngModel.getCssClass()}}"
+<div class="ls-indicator {{ngModel.getCssClass()}}"
 	 title="{{ngModel.getDescription()}}"
 	 ng-show="ngModel.getText().length > 0">
 	<span class="label">{{ngModel.getText()}}</span>

--- a/platform/commonUI/general/res/templates/bottombar.html
+++ b/platform/commonUI/general/res/templates/bottombar.html
@@ -19,7 +19,7 @@
  this source code distribution or the Licensing information page available
  at runtime from the About dialog for additional information.
 -->
-<div class='abs bottom-bar ue-bottom-bar mobile-disable-select'>
+<div class='abs bottom-bar l-ue-bottom-bar s-ue-bottom-bar mobile-disable-select'>
     <div id='status' class='status-holder'>
         <mct-indicators></mct-indicators>
     </div>

--- a/platform/commonUI/notification/res/notification-indicator.html
+++ b/platform/commonUI/notification/res/notification-indicator.html
@@ -1,5 +1,5 @@
 <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-<div ng-show="notifications.length > 0" class="l-indicator s-indicator status-{{highest.severity}} icon-bell"
+<div ng-show="notifications.length > 0" class="ls-indicator status-{{highest.severity}} icon-bell"
       ng-controller="NotificationIndicatorController">
     <span class="label">
         <a ng-click="showNotificationsList()">

--- a/platform/commonUI/notification/res/notification-indicator.html
+++ b/platform/commonUI/notification/res/notification-indicator.html
@@ -1,9 +1,7 @@
 <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-<a ng-click="showNotificationsList()" ng-show="notifications.length > 0" class="status block"
-      ng-class="highest.severity"
+<a ng-click="showNotificationsList()" ng-show="notifications.length > 0" class="l-indicator s-indicator s-status-{{highest.severity}} icon-bell"
       ng-controller="NotificationIndicatorController">
-    <span class="status-indicator icon-bell"></span><span class="label">
-      {{notifications.length}} Notifications
+    <span class="label">
+        {{notifications.length}} Notification<span ng-show="notifications.length > 1">s</span>
     </span><span class="count">{{notifications.length}}</span>
-
 </a>

--- a/platform/commonUI/notification/res/notification-indicator.html
+++ b/platform/commonUI/notification/res/notification-indicator.html
@@ -1,7 +1,8 @@
 <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-<a ng-click="showNotificationsList()" ng-show="notifications.length > 0" class="l-indicator s-indicator status-{{highest.severity}} icon-bell"
+<div ng-show="notifications.length > 0" class="l-indicator s-indicator status-{{highest.severity}} icon-bell"
       ng-controller="NotificationIndicatorController">
     <span class="label">
-        {{notifications.length}} Notification<span ng-show="notifications.length > 1">s</span>
+        <a ng-click="showNotificationsList()">
+           {{notifications.length}} Notification<span ng-show="notifications.length > 1">s</span></a>
     </span><span class="count">{{notifications.length}}</span>
-</a>
+</div>

--- a/platform/commonUI/notification/res/notification-indicator.html
+++ b/platform/commonUI/notification/res/notification-indicator.html
@@ -1,5 +1,5 @@
 <!-- DO NOT ADD SPACES BETWEEN THE SPANS - IT ADDS WHITE SPACE!! -->
-<a ng-click="showNotificationsList()" ng-show="notifications.length > 0" class="l-indicator s-indicator s-status-{{highest.severity}} icon-bell"
+<a ng-click="showNotificationsList()" ng-show="notifications.length > 0" class="l-indicator s-indicator status-{{highest.severity}} icon-bell"
       ng-controller="NotificationIndicatorController">
     <span class="label">
         {{notifications.length}} Notification<span ng-show="notifications.length > 1">s</span>

--- a/platform/commonUI/themes/espresso/res/sass/_constants.scss
+++ b/platform/commonUI/themes/espresso/res/sass/_constants.scss
@@ -3,6 +3,8 @@ $colorBodyBg: #333;
 $colorBodyFg: #999;
 $colorGenBg: #222;
 $colorStatusBarBg: #000;
+$colorStatusBarFg: #999;
+$colorStatusBarFgHov: #aaa;
 $colorKey: #0099cc;
 $colorKeySelectedBg: #005177;
 $colorKeyFg: #fff;

--- a/platform/commonUI/themes/espresso/res/sass/_constants.scss
+++ b/platform/commonUI/themes/espresso/res/sass/_constants.scss
@@ -55,7 +55,7 @@ $colorTransLucBg: #666; // Used as a visual blocking element over variable backg
 
 // Foundation Colors
 $colorAlt1: #ffc700;
-$colorAlert: #ff3c00;
+$colorAlert: #ff9900;
 $colorWarningHi: #cc0000;
 $colorWarningLo: #ff9900;
 $colorDiagnostic: #a4b442;
@@ -114,11 +114,12 @@ $colorInspectorSectionHeaderFg: pullForward($colorInspectorBg, 40%);
 
 // Status colors, mainly used for messaging and item ancillary symbols
 $colorStatusFg: #ccc;
-$colorStatusDefault: #ccc;
+$colorStatusDefault: #999;
 $colorStatusInfo: $colorInfo;
 $colorStatusAlert: $colorAlert;
 $colorStatusError: #d4585c;
 $colorStatusAvailable: $colorKey;
+$colorStatusDisabled: #666;
 $colorStatusBtnBg: $colorBtnBg;
 $colorProgressBarOuter: rgba(#000, 0.1);
 $colorProgressBarAmt: $colorKey;

--- a/platform/commonUI/themes/snow/res/sass/_constants.scss
+++ b/platform/commonUI/themes/snow/res/sass/_constants.scss
@@ -119,6 +119,7 @@ $colorStatusInfo: #60ba7b;
 $colorStatusAlert: #ffb66c;
 $colorStatusError: #c96b68;
 $colorStatusAvailable: $colorKey;
+$colorStatusDisabled: #666;
 $colorStatusBtnBg: #666;
 $colorProgressBarOuter: rgba(#000, 0.1);
 $colorProgressBarAmt: #0a0;

--- a/platform/commonUI/themes/snow/res/sass/_constants.scss
+++ b/platform/commonUI/themes/snow/res/sass/_constants.scss
@@ -3,6 +3,8 @@ $colorBodyBg: #fcfcfc;
 $colorBodyFg: #666;
 $colorGenBg: #fff;
 $colorStatusBarBg: #000;
+$colorStatusBarFg: #999;
+$colorStatusBarFgHov: #aaa;
 $colorKey: #0099cc;
 $colorKeySelectedBg: $colorKey;
 $colorKeyFg: #fff;

--- a/platform/features/clock/src/indicators/ClockIndicator.js
+++ b/platform/features/clock/src/indicators/ClockIndicator.js
@@ -45,11 +45,11 @@ define(
         }
 
         ClockIndicator.prototype.getGlyphClass = function () {
-            return "no-collapse float-right subdued";
+            return "";
         };
 
         ClockIndicator.prototype.getCssClass = function () {
-            return "icon-clock";
+            return "icon-clock no-collapse float-right";
         };
 
         ClockIndicator.prototype.getText = function () {

--- a/platform/features/clock/src/indicators/ClockIndicator.js
+++ b/platform/features/clock/src/indicators/ClockIndicator.js
@@ -49,7 +49,7 @@ define(
         };
 
         ClockIndicator.prototype.getCssClass = function () {
-            return "icon-clock no-collapse float-right";
+            return "t-indicator-clock icon-clock no-collapse float-right";
         };
 
         ClockIndicator.prototype.getText = function () {

--- a/platform/features/clock/src/indicators/FollowIndicator.js
+++ b/platform/features/clock/src/indicators/FollowIndicator.js
@@ -35,11 +35,11 @@ define([], function () {
         function setIndicatorStatus(newTimer) {
             if (newTimer !== undefined) {
                 indicator.iconClass('icon-timer');
-                indicator.statusClass('s-status-ok');
+                indicator.statusClass('status-enabled');
                 indicator.text('Following timer ' + newTimer.name);
             } else {
                 indicator.iconClass('icon-timer');
-                indicator.statusClass('');
+                indicator.statusClass('status-disabled');
                 indicator.text('No timer being followed');
             }
         }

--- a/platform/features/clock/src/indicators/FollowIndicator.js
+++ b/platform/features/clock/src/indicators/FollowIndicator.js
@@ -35,7 +35,7 @@ define([], function () {
         function setIndicatorStatus(newTimer) {
             if (newTimer !== undefined) {
                 indicator.iconClass('icon-timer');
-                indicator.statusClass('status-enabled');
+                indicator.statusClass('status-on');
                 indicator.text('Following timer ' + newTimer.name);
             } else {
                 indicator.iconClass('icon-timer');

--- a/platform/persistence/couch/src/CouchIndicator.js
+++ b/platform/persistence/couch/src/CouchIndicator.js
@@ -50,7 +50,7 @@ define(
             },
             PENDING = {
                 text: "Checking connection...",
-                statusClass: "status-caution",
+                statusClass: "status-caution"
             };
 
         /**

--- a/platform/persistence/couch/src/CouchIndicator.js
+++ b/platform/persistence/couch/src/CouchIndicator.js
@@ -33,20 +33,24 @@ define(
         var CONNECTED = {
                 text: "Connected",
                 glyphClass: "ok",
+                statusClass: "s-status-ok",
                 description: "Connected to the domain object database."
             },
             DISCONNECTED = {
                 text: "Disconnected",
                 glyphClass: "err",
+                statusClass: "status-caution",
                 description: "Unable to connect to the domain object database."
             },
             SEMICONNECTED = {
                 text: "Unavailable",
                 glyphClass: "caution",
+                statusClass: "status-caution",
                 description: "Database does not exist or is unavailable."
             },
             PENDING = {
-                text: "Checking connection..."
+                text: "Checking connection...",
+                statusClass: "status-caution",
             };
 
         /**
@@ -96,7 +100,7 @@ define(
         }
 
         CouchIndicator.prototype.getCssClass = function () {
-            return "icon-database";
+            return "icon-database " + this.state.statusClass;
         };
 
         CouchIndicator.prototype.getGlyphClass = function () {

--- a/platform/persistence/couch/test/CouchIndicatorSpec.js
+++ b/platform/persistence/couch/test/CouchIndicatorSpec.js
@@ -57,7 +57,7 @@ define(
             });
 
             it("has a database icon", function () {
-                expect(indicator.getCssClass()).toEqual("icon-database");
+                expect(indicator.getCssClass()).toEqual("icon-database status-caution");
             });
 
             it("consults the database at the configured path", function () {

--- a/platform/persistence/elastic/src/ElasticIndicator.js
+++ b/platform/persistence/elastic/src/ElasticIndicator.js
@@ -32,11 +32,13 @@ define(
         var CONNECTED = {
                 text: "Connected",
                 glyphClass: "ok",
+                statusClass: "status-ok",
                 description: "Connected to the domain object database."
             },
             DISCONNECTED = {
                 text: "Disconnected",
                 glyphClass: "err",
+                statusClass: "status-caution",
                 description: "Unable to connect to the domain object database."
             },
             PENDING = {

--- a/platform/persistence/local/src/LocalStorageIndicator.js
+++ b/platform/persistence/local/src/LocalStorageIndicator.js
@@ -26,7 +26,7 @@ define(
 
         var LOCAL_STORAGE_WARNING = [
             "Using browser local storage for persistence.",
-            "Anything you create or change will be visible only",
+            "Anything you create or change will only be saved",
             "in this browser on this machine."
         ].join(' ');
 
@@ -41,7 +41,7 @@ define(
         }
 
         LocalStorageIndicator.prototype.getCssClass = function () {
-            return "icon-database";
+            return "icon-database status-caution";
         };
         LocalStorageIndicator.prototype.getGlyphClass = function () {
             return 'caution';

--- a/platform/persistence/local/test/LocalStorageIndicatorSpec.js
+++ b/platform/persistence/local/test/LocalStorageIndicatorSpec.js
@@ -38,7 +38,7 @@ define(
             });
 
             it("has a database icon", function () {
-                expect(indicator.getCssClass()).toEqual("icon-database");
+                expect(indicator.getCssClass()).toEqual("icon-database status-caution");
             });
 
             it("has a 'caution' class to draw attention", function () {

--- a/src/api/indicators/IndicatorAPI.js
+++ b/src/api/indicators/IndicatorAPI.js
@@ -32,7 +32,7 @@ define([
     var LEGACY_INDICATOR_TEMPLATE =
         '<mct-include ' +
         '   ng-model="indicator" ' +
-        '   key="template" ' +
+        '   key="template">' +
         ' </mct-include>';
 
     function IndicatorAPI(openmct) {

--- a/src/api/indicators/IndicatorAPI.js
+++ b/src/api/indicators/IndicatorAPI.js
@@ -33,8 +33,6 @@ define([
         '<mct-include ' +
         '   ng-model="indicator" ' +
         '   key="template" ' +
-        '   class="status-block-holder" ' +
-        '   ng-class="indicator.getGlyphClass()"> ' +
         ' </mct-include>';
 
     function IndicatorAPI(openmct) {

--- a/src/api/indicators/IndicatorAPI.js
+++ b/src/api/indicators/IndicatorAPI.js
@@ -32,6 +32,7 @@ define([
     var LEGACY_INDICATOR_TEMPLATE =
         '<mct-include ' +
         '   ng-model="indicator" ' +
+        '   class="h-indicator" ' +
         '   key="template">' +
         ' </mct-include>';
 
@@ -71,7 +72,7 @@ define([
         // So that we can consistently position indicator elements,
         // guarantee that they are wrapped in an element we control
         var wrapperNode = document.createElement('div');
-        wrapperNode.className = 'status-block-holder indicator';
+        wrapperNode.className = 'h-indicator';
         wrapperNode.appendChild(indicator.element);
         this.indicatorElements.push(wrapperNode);
     };

--- a/src/api/indicators/IndicatorAPISpec.js
+++ b/src/api/indicators/IndicatorAPISpec.js
@@ -207,11 +207,11 @@ define(
             }
 
             function getIconElement() {
-                return $('.l-indicator', holderElement);
+                return $('.ls-indicator', holderElement);
             }
 
             function getIndicatorElement() {
-                return $('.l-indicator', holderElement);
+                return $('.ls-indicator', holderElement);
             }
 
             function getTextElement() {

--- a/src/api/indicators/IndicatorAPISpec.js
+++ b/src/api/indicators/IndicatorAPISpec.js
@@ -207,11 +207,11 @@ define(
             }
 
             function getIconElement() {
-                return $('.indicator-icon', holderElement);
+                return $('.l-indicator', holderElement);
             }
 
             function getIndicatorElement() {
-                return $('.status', holderElement);
+                return $('.l-indicator', holderElement);
             }
 
             function getTextElement() {

--- a/src/api/indicators/SimpleIndicator.js
+++ b/src/api/indicators/SimpleIndicator.js
@@ -29,7 +29,6 @@ define(['zepto', 'text!./res/indicator-template.html'],
             this.element = $(indicatorTemplate)[0];
 
             this.textElement = this.element.querySelector('.indicator-text');
-            this.iconElement = this.element.querySelector('.indicator-icon');
 
             //Set defaults
             this.text('New Indicator');
@@ -67,10 +66,10 @@ define(['zepto', 'text!./res/indicator-template.html'],
                 // element.classList is precious and throws errors if you try and add
                 // or remove empty strings
                 if (this.iconClassValue) {
-                    this.iconElement.classList.remove(this.iconClassValue);
+                    this.element.classList.remove(this.iconClassValue);
                 }
                 if (iconClass) {
-                    this.iconElement.classList.add(iconClass);
+                    this.element.classList.add(iconClass);
                 }
                 this.iconClassValue = iconClass;
             }
@@ -81,10 +80,10 @@ define(['zepto', 'text!./res/indicator-template.html'],
         SimpleIndicator.prototype.statusClass = function (statusClass) {
             if (statusClass !== undefined && statusClass !== this.statusClassValue) {
                 if (this.statusClassValue) {
-                    this.iconElement.classList.remove(this.statusClassValue);
+                    this.element.classList.remove(this.statusClassValue);
                 }
                 if (statusClass) {
-                    this.iconElement.classList.add(statusClass);
+                    this.element.classList.add(statusClass);
                 }
                 this.statusClassValue = statusClass;
             }

--- a/src/api/indicators/res/indicator-template.html
+++ b/src/api/indicators/res/indicator-template.html
@@ -1,3 +1,3 @@
-<div class="status block indicator-holder" title="">
-    <span class="status-indicator indicator-icon"></span><span class="label indicator-text"></span>
+<div class="l-indicator s-indicator" title="">
+    <span class="label indicator-text"></span>
 </div>

--- a/src/api/indicators/res/indicator-template.html
+++ b/src/api/indicators/res/indicator-template.html
@@ -1,3 +1,3 @@
-<div class="l-indicator s-indicator" title="">
+<div class="ls-indicator" title="">
     <span class="label indicator-text"></span>
 </div>

--- a/src/plugins/URLIndicatorPlugin/URLIndicator.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicator.js
@@ -101,7 +101,7 @@ define(
             this.URLpath = options.url;
             this.label = options.label || options.url;
             this.interval = options.interval || 10000;
-            this.indicator.iconClass(options.iconClass || 'icon-connectivity');
+            this.indicator.iconClass(options.iconClass || 'icon-chain-links');
         };
 
         URLIndicator.prototype.bindMethods = function () {

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
@@ -163,7 +163,6 @@ define(
                     .andReturn(Promise.reject().then(function () {
                         returned = true;
                         //Throw error to ensure chained catch is invoked
-                        throw undefined;
                     }));
             }
 
@@ -176,7 +175,7 @@ define(
             }
 
             function getIconElement() {
-                return $('.indicator-icon', indicatorElement);
+                return $(indicatorElement);
             }
 
             function getTextElement() {

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
@@ -68,7 +68,7 @@ define(
 
                     it("has a default icon class if none supplied", function () {
                         var iconElement = getIconElement();
-                        expect(iconElement.hasClass('icon-connectivity')).toBe(true);
+                        expect(iconElement.hasClass('icon-chain-links')).toBe(true);
                     });
 
                     it("defaults to the URL if no label supplied", function () {


### PR DESCRIPTION
Passes `npm test` and recently merged with master. 

### Changes
- Markup and CSS greatly simplified. 
- Indicators now use "infobubble" hover instead of expand/collapse:
<img width="191" alt="screen shot 2018-06-15 at 2 39 46 pm" src="https://user-images.githubusercontent.com/1056412/41493950-cfd5017e-70c1-11e8-98e3-68919abc8387.png">

- Better styling for `<a>` tags and s-button elements in Indicators:
<img width="337" alt="screen shot 2018-06-15 at 2 39 36 pm" src="https://user-images.githubusercontent.com/1056412/41493956-e6297c20-70c1-11e8-96d9-f7e5d6a3ab90.png">

- More statuses and colors added.
- Style Guide content added.

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
