### PR TITLE
use correct duration for historical states

### DIFF
--- a/example/generator/StateGeneratorProvider.js
+++ b/example/generator/StateGeneratorProvider.js
@@ -72,7 +72,7 @@ define([
         var data = [];
         while (start <= end && data.length < 5000) {
             data.push(pointForTimestamp(start, duration, domainObject.name));
-            start += 5000;
+            start += duration;
         }
         return Promise.resolve(data);
     };


### PR DESCRIPTION
Fixes a small bug in the example state generator which was not using the correct state duration for historical requests.  Was reported by @charlesh88.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A, example code
3. Command line build passes? Y
4. Changes have been smoke-tested? Y