### PR TITLE
Added div element to force horz scroll in table body

### DIFF
--- a/platform/features/table/res/sass/table.scss
+++ b/platform/features/table/res/sass/table.scss
@@ -65,3 +65,10 @@ mct-table {
         margin-bottom: 3px;
     }
 }
+
+.mct-table-scroll-forcer {
+    // Force horz scroll when needed; width set via JS
+    font-size: 0;
+    height: 1px; // Height 0 won't force scroll properly
+    position: relative;
+}

--- a/platform/features/table/res/templates/mct-table.html
+++ b/platform/features/table/res/templates/mct-table.html
@@ -59,6 +59,10 @@
     </tbody>
 </table>
 <div class="l-tabular-body t-scrolling vscroll--persist" mct-resize="resize()" mct-scroll-x="scroll.x">
+    <div class="mct-table-scroll-forcer"
+         ng-style="{
+        width: totalWidth
+    }"></div>
     <table class="mct-table"
            ng-style="{
             height: totalHeight + 'px',


### PR DESCRIPTION
Fixes #2103
The core problem here is that when filtering in such a way that no rows match a filter, _nothing_ is put into the table body area, so the horizontal scrollbar of the div that wraps the table body never triggers. Adding width the table doesn't help; if the table is empty it won't occupy any space. 

The solution is to add _something_ to the scrolling wrapper that forces a horizontal scroll when needed, even when there are no rows in the table. A div 1px high and with width set by the MCTTableController is added before the table. 

![screen shot 2018-07-05 at 9 57 46 am](https://user-images.githubusercontent.com/1056412/42336888-eaa95f5e-8039-11e8-9a3d-5c4b867da125.png)

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
