### PR TITLE
[Tables] Address performance issues observed in testathon

### DIFF
--- a/example/eventGenerator/bundle.js
+++ b/example/eventGenerator/bundle.js
@@ -60,8 +60,8 @@ define([
                         "source": "eventGenerator",
                         "domains": [
                             {
-                                "key": "time",
-                                "name": "Time",
+                                "key": "utc",
+                                "name": "Timestamp",
                                 "format": "utc"
                             }
                         ],

--- a/platform/features/table/res/templates/telemetry-table.html
+++ b/platform/features/table/res/templates/telemetry-table.html
@@ -3,7 +3,7 @@
     <mct-table
         headers="headers"
         rows="rows"
-        time-columns="tableController.timeColumns"
+        time-columns="[tableController.table.timeSystemColumnTitle]"
         format-cell="formatCell"
         enableFilter="true"
         enableSort="true"

--- a/platform/features/table/src/TableColumn.js
+++ b/platform/features/table/src/TableColumn.js
@@ -20,51 +20,49 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 define(function () {
-    function TableColumn(openmct, metadatum) {
+    function TableColumn(openmct, telemetryObject, metadatum) {
         this.openmct = openmct;
+        this.telemetryObject = telemetryObject;
         this.metadatum = metadatum;
         this.formatter = openmct.telemetry.getValueFormatter(metadatum);
-        
-        this._title = this.metadatum.name;
+
+        this.titleValue = this.metadatum.name;
     }
 
     TableColumn.prototype.title = function (title) {
         if (arguments.length > 0) {
-            this._title = title;
+            this.titleValue = title;
         }
-        return this._title;
+        return this.titleValue;
     };
 
     TableColumn.prototype.isCurrentTimeSystem = function () {
-        return this.metadatum.hints.hasOwnProperty('domain') && 
-            this.metadatum.key === this.openmct.time.timeSystem().key;
+        var isCurrentTimeSystem = this.metadatum.hints.hasOwnProperty('domain') &&
+        this.metadatum.key === this.openmct.time.timeSystem().key;
+
+        return isCurrentTimeSystem;
     };
 
-    TableColumn.prototype.hasValue = function (telemetryDatum) {
-        return telemetryDatum.hasOwnProperty(this.metadatum.source);
+    TableColumn.prototype.hasValue = function (telemetryObject, telemetryDatum) {
+        var keyStringForDatum = this.openmct.objects.makeKeyString(telemetryObject.identifier);
+        var keyStringForColumn = this.openmct.objects.makeKeyString(this.telemetryObject.identifier);
+        return keyStringForDatum === keyStringForColumn && telemetryDatum.hasOwnProperty(this.metadatum.source);
     };
 
     TableColumn.prototype.getValue = function (telemetryDatum, limitEvaluator) {
-        if (this.hasValue(telemetryDatum)) {
-            var isValueColumn = !!(this.metadatum.hints.y || this.metadatum.hints.range);
-            var alarm = isValueColumn &&
-                        limitEvaluator &&
-                        limitEvaluator.evaluate(telemetryDatum, this.metadatum);
-            var value = {
-                text: this.formatter.format(telemetryDatum),
-                value: this.formatter.parse(telemetryDatum)
-            };
+        var isValueColumn = !!(this.metadatum.hints.y || this.metadatum.hints.range);
+        var alarm = isValueColumn &&
+                    limitEvaluator &&
+                    limitEvaluator.evaluate(telemetryDatum, this.metadatum);
+        var value = {
+            text: this.formatter.format(telemetryDatum),
+            value: this.formatter.parse(telemetryDatum)
+        };
 
-            if (alarm) {
-                value.cssClass = alarm.cssClass;
-            }
-            return value;
-        } else {
-            return {
-                text: '',
-                value: undefined
-            };
+        if (alarm) {
+            value.cssClass = alarm.cssClass;
         }
+        return value;
     };
 
     return TableColumn;

--- a/platform/features/table/src/TableColumn.js
+++ b/platform/features/table/src/TableColumn.js
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+define(function () {
+    function TableColumn(openmct, metadatum) {
+        this.openmct = openmct;
+        this.metadatum = metadatum;
+        this.formatter = openmct.telemetry.getValueFormatter(metadatum);
+        
+        this._title = this.metadatum.name;
+    }
+
+    TableColumn.prototype.title = function (title) {
+        if (arguments.length > 0) {
+            this._title = title;
+        }
+        return this._title;
+    };
+
+    TableColumn.prototype.isCurrentTimeSystem = function () {
+        return this.metadatum.hints.hasOwnProperty('domain') && 
+            this.metadatum.key === this.openmct.time.timeSystem().key;
+    };
+
+    TableColumn.prototype.hasValue = function (telemetryDatum) {
+        return telemetryDatum.hasOwnProperty(this.metadatum.source);
+    };
+
+    TableColumn.prototype.getValue = function (telemetryDatum, limitEvaluator) {
+        if (this.hasValue(telemetryDatum)) {
+            var isValueColumn = !!(this.metadatum.hints.y || this.metadatum.hints.range);
+            var alarm = isValueColumn &&
+                        limitEvaluator &&
+                        limitEvaluator.evaluate(telemetryDatum, this.metadatum);
+            var value = {
+                text: this.formatter.format(telemetryDatum),
+                value: this.formatter.parse(telemetryDatum)
+            };
+
+            if (alarm) {
+                value.cssClass = alarm.cssClass;
+            }
+            return value;
+        } else {
+            return {
+                text: '',
+                value: undefined
+            };
+        }
+    };
+
+    return TableColumn;
+});

--- a/platform/features/table/src/TableConfiguration.js
+++ b/platform/features/table/src/TableConfiguration.js
@@ -19,7 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-
+/* global Set */
 define(
     ['./TableColumn'],
     function (TableColumn) {
@@ -32,56 +32,31 @@ define(
          */
         function TableConfiguration(domainObject, openmct) {
             this.domainObject = domainObject;
-            this.columns = [];
             this.openmct = openmct;
             this.timeSystemColumn = undefined;
+            this.columns = [];
+            this.headers = new Set();
+            this.timeSystemColumnTitle = undefined;
         }
 
         /**
-         * Build column definitions based on supplied telemetry metadata
+         * Build column definition based on supplied telemetry metadata
+         * @param telemetryObject the telemetry producing object associated with this column
          * @param metadata Metadata describing the domains and ranges available
          * @returns {TableConfiguration} This object
          */
-        TableConfiguration.prototype.populateColumns = function (metadata) {
-            var self = this;
-            var openmct = this.openmct;
+        TableConfiguration.prototype.addColumn = function (telemetryObject, metadatum) {
+            var column = new TableColumn(this.openmct, telemetryObject, metadatum);
 
-            this.columns = [];
-
-            if (metadata) {
-                var timeSystemTitle;
-                metadata.forEach(function (metadatum) {
-                    var column = new TableColumn(openmct, metadatum);
-                    if (column.isCurrentTimeSystem()){
-                        if (!timeSystemTitle) {
-                            timeSystemTitle = column.title();
-                        }
-                        column.title = timeSystemTitle;
-                    }
-                    self.columns.push(new TableColumn(openmct, metadatum));
-                });
-            }
-            return this;
-        };
-
-        /**
-         * Get a simple list of column titles
-         * @returns {Array} The titles of the columns
-         */
-        TableConfiguration.prototype.getHeaders = function () {
-            var collapse = false;
-            return this.columns.filter(function (column) {
-                if (column.isCurrentTimeSystem()){
-                    if (collapse) {
-                        return false
-                    } else {
-                        collapse = true;
-                    }
+            if (column.isCurrentTimeSystem()) {
+                if (!this.timeSystemColumnTitle) {
+                    this.timeSystemColumnTitle = column.title();
                 }
-                return true;
-            }).map(function (column, i) {
-                return column.title();
-            });
+                column.title(this.timeSystemColumnTitle);
+            }
+
+            this.columns.push(column);
+            this.headers.add(column.title());
         };
 
         /**
@@ -92,22 +67,32 @@ define(
          * @returns {Object} Key value pairs where the key is the column
          * title, and the value is the formatted value from the provided datum.
          */
-        TableConfiguration.prototype.getRowValues = function (limitEvaluator, datum) {
-            return this.columns.reduce(function (rowObject, column, i) {
-                var columnTitle = column.title(),
-                    columnValue = column.getValue(datum, limitEvaluator);
-
-                if (columnValue !== undefined && columnValue.text === undefined) {
-                    columnValue.text = '';
-                }
-                // Don't replace something with nothing.
-                // This occurs when there are multiple columns with the same
-                // column title
-                if (rowObject[columnTitle] === undefined ||
-                    rowObject[columnTitle].text === undefined ||
-                    rowObject[columnTitle].text.length === 0) {
+        TableConfiguration.prototype.getRowValues = function (telemetryObject, limitEvaluator, datum) {
+            return this.columns.reduce(function (rowObject, column) {
+                var columnTitle = column.title();
+                var columnValue = {
+                    text: '',
+                    value: undefined
+                };
+                if (rowObject[columnTitle] === undefined) {
                     rowObject[columnTitle] = columnValue;
                 }
+
+                if (column.hasValue(telemetryObject, datum)) {
+                    columnValue = column.getValue(datum, limitEvaluator);
+
+                    if (columnValue.text === undefined) {
+                        columnValue.text = '';
+                    }
+                    // Don't replace something with nothing.
+                    // This occurs when there are multiple columns with the same
+                    // column title
+                    if (rowObject[columnTitle].text === undefined ||
+                        rowObject[columnTitle].text.length === 0) {
+                        rowObject[columnTitle] = columnValue;
+                    }
+                }
+
                 return rowObject;
             }, {});
         };
@@ -158,7 +143,7 @@ define(
              * specifying whether the column is visible or not. Default to
              * existing (persisted) configuration if available
              */
-            this.getHeaders().forEach(function (columnTitle) {
+            this.headers.forEach(function (columnTitle) {
                 configuration[columnTitle] =
                     typeof defaultConfig[columnTitle] === 'undefined' ? true :
                         defaultConfig[columnTitle];

--- a/platform/features/table/src/TelemetryCollection.js
+++ b/platform/features/table/src/TelemetryCollection.js
@@ -93,7 +93,9 @@ define(
                 // Calculate the new index of the last item in bounds
                 endIndex = _.sortedLastIndex(this.highBuffer, testValue, this.sortField);
                 added = this.highBuffer.splice(0, endIndex);
-                this.telemetry = this.telemetry.concat(added);
+                added.forEach(function (datum) {
+                    this.telemetry.push(datum);
+                }.bind(this));
             }
 
             if (discarded && discarded.length > 0) {
@@ -132,6 +134,7 @@ define(
             // bounds events, so no bounds checking necessary
             if (this.sortField === undefined) {
                 this.telemetry.push(item);
+
                 return true;
             }
 
@@ -153,7 +156,6 @@ define(
 
             // If out of bounds low, disregard data
             if (!boundsLow) {
-
                 // Going to check for duplicates. Bound the search problem to
                 // items around the given time. Use sortedIndex because it
                 // employs a binary search which is O(log n). Can use binary search

--- a/platform/features/table/src/controllers/TelemetryTableController.js
+++ b/platform/features/table/src/controllers/TelemetryTableController.js
@@ -118,23 +118,18 @@ define(
          * to sort by. By default will just match on key.
          *
          * @private
-         * @param {TimeSystem} timeSystem
          */
-        TelemetryTableController.prototype.sortByTimeSystem = function (timeSystem) {
+        TelemetryTableController.prototype.sortByTimeSystem = function () {
             var scope = this.$scope;
             var sortColumn;
             scope.defaultSort = undefined;
 
-            if (timeSystem !== undefined) {
-                this.table.columns.forEach(function (column) {
-                    if (column.getKey() === timeSystem.key) {
-                        sortColumn = column;
-                    }
-                });
-                if (sortColumn) {
-                    scope.defaultSort = sortColumn.getTitle();
-                    this.telemetry.sort(sortColumn.getTitle() + '.value');
-                }
+            sortColumn = this.table.columns.filter(function (column) {
+                return column.isCurrentTimeSystem();
+            })[0];
+            if (sortColumn) {
+                scope.defaultSort = sortColumn.title();
+                this.telemetry.sort(sortColumn.title() + '.value');
             }
         };
 
@@ -255,17 +250,7 @@ define(
                 });
 
                 this.filterColumns();
-
-                // Default to no sort on underlying telemetry collection. Sorting
-                // is necessary to do bounds filtering, but this is only possible
-                // if data matches selected time system
-                this.telemetry.sort(undefined);
-
-                var timeSystem = this.openmct.time.timeSystem();
-                if (timeSystem !== undefined) {
-                    this.sortByTimeSystem(timeSystem);
-                }
-
+                this.sortByTimeSystem();
             }
 
             return objects;

--- a/src/plugins/localTimeSystem/LocalTimeFormat.js
+++ b/src/plugins/localTimeSystem/LocalTimeFormat.js
@@ -113,6 +113,9 @@ define([
     };
 
     LocalTimeFormat.prototype.parse = function (text) {
+        if (typeof text === 'number') {
+            return text;
+        }
         return moment(text, DATE_FORMATS).valueOf();
     };
 


### PR DESCRIPTION
Addresses [issues with tables](https://github.com/nasa/openmct/issues/2027) discovered during testathon as well as during subsequent testing.

1. Merge time columns that are in the active time system. This fixes performance issues observed during testathon that were due to attempts to do a sorted insert with undefined values.
2. Only provide values where the telemetry object supports them. Previously behavior was the formatter for a column would attempt to provide a value for a datum irrespective of whether that telemetry point actually provided that data.
3. Fixed an issue where telemetry data was not being evicted correctly after table was sorted. This was due to a fairly brittle requirement that the scope.rows array instance does not change, [but it was](https://github.com/nasa/openmct/compare/table-performance?expand=1#diff-1966b0b3bf0df00385b3667845cbc2ebL96). Also removed [code added in previous attempt to address related issue](https://github.com/nasa/openmct/compare/table-performance?expand=1#diff-55986c5fb870a6a73eabedb119b650baL175). This fix does not address the underlying brittleness, which should be addressed in subsequent refactoring.
4. Small modification to Event Generator to provide 'utc' time system data.
5. Support parsing of Numbers in `LocalTimeFormat` to make it consistent with other telemetry formatters.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y
* Command line build passes? Y
* Changes have been smoke-tested? Y