### PR TITLE
[Table] Check limit for all values

### DIFF
--- a/platform/features/table/src/TableColumn.js
+++ b/platform/features/table/src/TableColumn.js
@@ -50,9 +50,7 @@ define(function () {
     };
 
     TableColumn.prototype.getValue = function (telemetryDatum, limitEvaluator) {
-        var isValueColumn = !!(this.metadatum.hints.y || this.metadatum.hints.range);
-        var alarm = isValueColumn &&
-                    limitEvaluator &&
+        var alarm = limitEvaluator &&
                     limitEvaluator.evaluate(telemetryDatum, this.metadatum);
         var value = {
             text: this.formatter.format(telemetryDatum),


### PR DESCRIPTION
Check limit status for all values, not just ranges.  This allows
limit evaluators to apply styling to additional columns if
desired by developers.

Have added a note to #1664 to consider changes to limit evaluators to better support color-coding, which is a requirement in VISTA and this pull request is necessary to support that.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N, they work as is.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y