### PR TITLE
Broaden selector to handle wrapped links/buttons

### DIFF
--- a/platform/commonUI/general/res/sass/controls/_indicators.scss
+++ b/platform/commonUI/general/res/sass/controls/_indicators.scss
@@ -66,7 +66,8 @@ mct-indicators mct-include {
             }
         }
 
-        > [class*='icon-'] {
+        [class*='icon-'] {
+            // If any elements within label include the class 'icon-*' then deal with their :before's
             &:before {
                 font-size: 0.8em;
                 margin-right: $interiorMarginSm;


### PR DESCRIPTION
Fixes #2116. When buttons or links with icons are wrapped, let the styling set margin and font-size properly on the icon element.

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y