### PR TITLE
[Layout] prototype drop into frames

### DIFF
--- a/platform/commonUI/edit/bundle.js
+++ b/platform/commonUI/edit/bundle.js
@@ -152,7 +152,10 @@ define([
             "actions": [
                 {
                     "key": "compose",
-                    "implementation": EditAndComposeAction
+                    "implementation": EditAndComposeAction,
+                    "depends": [
+                        "navigationService"
+                    ]
                 },
                 {
                     "key": "edit",

--- a/platform/commonUI/edit/src/actions/EditAction.js
+++ b/platform/commonUI/edit/src/actions/EditAction.js
@@ -69,7 +69,6 @@ define(
          * Enter edit mode.
          */
         EditAction.prototype.perform = function () {
-
             //If this is not the currently navigated object, then navigate
             // to it.
             if (this.navigationService.getNavigation() !== this.domainObject) {

--- a/platform/commonUI/edit/src/actions/EditAndComposeAction.js
+++ b/platform/commonUI/edit/src/actions/EditAndComposeAction.js
@@ -31,14 +31,17 @@ define(
          * @memberof platform/commonUI/edit
          * @implements {Action}
          */
-        function EditAndComposeAction(context) {
+        function EditAndComposeAction(navigationService, context) {
             this.domainObject = (context || {}).domainObject;
             this.selectedObject = (context || {}).selectedObject;
+            this.navigatedObject = navigationService.getNavigation();
         }
 
         EditAndComposeAction.prototype.perform = function () {
-            var self = this,
-                editAction = this.domainObject.getCapability('action').getActions("edit")[0];
+            var self = this;
+
+            var editNavigatedAction = this.navigatedObject.getCapability('action').getActions("edit")[0];
+            var editAction = this.domainObject.getCapability('action').getActions("edit")[0];
 
             // Link these objects
             function doLink() {
@@ -47,7 +50,9 @@ define(
                 return composition && composition.add(self.selectedObject);
             }
 
-            if (editAction) {
+            if (editNavigatedAction) {
+                editNavigatedAction.perform();
+            } else if (editAction) {
                 editAction.perform();
             }
 

--- a/platform/commonUI/edit/src/policies/EditActionPolicy.js
+++ b/platform/commonUI/edit/src/policies/EditActionPolicy.js
@@ -77,7 +77,7 @@ define(
             var domainObject = (context || {}).domainObject;
             return domainObject &&
                 domainObject.hasCapability('editor') &&
-                domainObject.getCapability('editor').isEditContextRoot();
+                domainObject.getCapability('editor').inEditContext();
         }
 
         EditActionPolicy.prototype.allow = function (action, context) {

--- a/platform/features/layout/bundle.js
+++ b/platform/features/layout/bundle.js
@@ -221,7 +221,8 @@ define([
             "representations": [
                 {
                     "key": "frame",
-                    "template": frameTemplate
+                    "template": frameTemplate,
+                    "gestures": ["drop"]
                 }
             ],
             "directives": [

--- a/platform/representation/src/gestures/DropGesture.js
+++ b/platform/representation/src/gestures/DropGesture.js
@@ -96,11 +96,12 @@ define(
                 // destination domain object's composition, and persist
                 // the change.
                 if (id) {
+                    e.stopPropagation();
                     e.preventDefault();
                     $q.when(action && action.perform()).then(function () {
                         broadcastDrop(id, event);
                     });
-
+                    return false;
                 }
             }
 


### PR DESCRIPTION
Update layout to allow drag and drop composition into sub objects.  Allows users to add domain objects directly to a view in a layout.

Drag and drop to fixed position in a layout is a bit buggy, but this works nicely for plots and table.  

Opening so people can experiment, still needs more work.