### PR TITLE
[Plot] Prevent duplicate query on bounds change

### DIFF
--- a/src/plugins/plot/src/telemetry/PlotController.js
+++ b/src/plugins/plot/src/telemetry/PlotController.js
@@ -181,7 +181,9 @@ define([
         };
         this.config.xAxis.set('range', newRange);
         if (!isTick) {
+            this.skipReloadOnInteraction = true;
             this.$scope.$broadcast('plot:clearHistory');
+            this.skipReloadOnInteraction = false;
             this.loadMoreData(newRange, true);
         } else {
             // Drop any data that is more than 1x (max-min) before min.
@@ -234,7 +236,9 @@ define([
         var xDisplayRange = this.config.xAxis.get('displayRange');
         var xRange = this.config.xAxis.get('range');
 
-        this.loadMoreData(xDisplayRange);
+        if (!this.skipReloadOnInteraction) {
+            this.loadMoreData(xDisplayRange);
+        }
 
         this.synchronized(xRange.min === xDisplayRange.min &&
                           xRange.max === xDisplayRange.max);


### PR DESCRIPTION
Bounds change triggers a clearing of plot history, which triggers
a user interaction change, which was triggering a second query.

This change sets a flag to prevent the requery from the user interaction on
bounds change.  This flag could potentially be reused elsewhere, e.g. if we
wanted to prevent requery when not utilizing a minmax data source.

fixes #2126

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A, issue exists for backfill
3. Command line build passes? Y
4. Changes have been smoke-tested? Y