### PR TITLE
[Fixed Position] Cannot add on objects when creating Fixed Position for the first time

### DIFF
--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -87,7 +87,8 @@ define(
                 'setDisplayedValue',
                 'subscribeToObject',
                 'unsubscribe',
-                'updateView'
+                'updateView',
+                'setSelection'
             ].forEach(function (name) {
                 self[name] = self[name].bind(self);
             });
@@ -170,7 +171,7 @@ define(
 
                 if (self.selectedElementProxy) {
                     // Update the selected element with the new
-                    // value since newDomainOject is mutated.
+                    // value since newDomainOject is mutated.fde
                     self.selectedElementProxy.element = elements[index];
                 }
                 refreshElements();
@@ -224,7 +225,7 @@ define(
             // Respond to external bounds changes
             this.openmct.time.on("bounds", updateDisplayBounds);
 
-            this.openmct.selection.on('change', this.setSelection.bind(this));
+            this.openmct.selection.on('change', this.setSelection);
             this.$element.on('click', this.bypassSelection.bind(this));
             this.unlisten = this.openmct.objects.observe(this.newDomainObject, '*', function (obj) {
                 this.newDomainObject = JSON.parse(JSON.stringify(obj));

--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -233,6 +233,9 @@ define(
 
             this.updateElementPositions(this.newDomainObject.layoutGrid);
             refreshElements();
+
+            //force a click, to initialize Fixed Position Controller on SelectionAPI
+            $element[0].click();
         }
 
         FixedController.prototype.updateElementPositions = function (layoutGrid) {

--- a/platform/features/layout/src/FixedController.js
+++ b/platform/features/layout/src/FixedController.js
@@ -171,7 +171,7 @@ define(
 
                 if (self.selectedElementProxy) {
                     // Update the selected element with the new
-                    // value since newDomainOject is mutated.fde
+                    // value since newDomainOject is mutated.
                     self.selectedElementProxy.element = elements[index];
                 }
                 refreshElements();


### PR DESCRIPTION
Fixes issue #2125

force a click on the fixed position element after initialize to initialize Fixed Position controller on the selection API.

While fixing this issue I found out that the 'change' event listener on the selection API is not cleared on destroy. Filling a separate issue for that (#2130). 

## Author Checklist
Changes address original issue? Y
Unit tests included and/or updated with changes? N/A
Command line build passes? Y
Changes have been smoke-tested? Y