### PR TITLE
Change table row layout to use flex

### DIFF
--- a/platform/features/table/res/sass/table.scss
+++ b/platform/features/table/res/sass/table.scss
@@ -35,28 +35,30 @@ mct-table {
     }
 
     .mct-table {
+        tr {
+            display: flex; // flex-flow defaults to row nowrap (which is what we want) so no need to define
+            height: 18px; // Needed when a row has empty values in its cells
+            align-items: stretch;
+        }
+
+        td, th {
+            box-sizing: border-box;
+            display: block;
+            flex: 1 0 auto;
+            white-space: nowrap;
+        }
+
         thead {
             display: block;
-            tr {
-                display: block;
-                white-space: nowrap;
-                th {
-                    display: inline-block;
-                    box-sizing: border-box;
-                }
-            }
         }
+
         tbody {
             tr {
                 position: absolute;
-                white-space: nowrap;
-                display: block;
             }
+
             td {
-                white-space: nowrap;
                 overflow: hidden;
-                box-sizing: border-box;
-                display: inline-block;
             }
         }
     }


### PR DESCRIPTION
Fixes #2132
- flex styles carefully applied;
- CSS gently reorganized for better DRY;
- CSS fixes the height of `<tr>`'s at 18px so that `<td>`'s won't collapse when all cells of a row have empty values. This can occur when columns that have data are hidden in a Telemetry Table leaving only columns that _don't_ have data visible.

### Author Checklist

1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
