### PR TITLE
[Plot] Update formDomainObject on mutate

### DIFF
--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -83,6 +83,7 @@ define([
 
             this.listenTo(this, 'change:xKey', this.onXKeyChange, this);
             this.listenTo(this, 'change:yKey', this.onYKeyChange, this);
+            this.persistedConfig = options.persistedConfig;
 
             Model.apply(this, arguments);
             this.onXKeyChange(this.get('xKey'));
@@ -176,8 +177,7 @@ define([
                 return;
             }
             var valueMetadata = this.metadata.value(newKey);
-            var persistedConfig = this.get('persistedConfiguration');
-            if (!persistedConfig || !persistedConfig.interpolate) {
+            if (!this.persistedConfig || !this.persistedConfig.interpolate) {
                 if (valueMetadata.format === 'enum') {
                     this.set('interpolate', 'stepAfter');
                 } else {

--- a/src/plugins/plot/src/configuration/SeriesCollection.js
+++ b/src/plugins/plot/src/configuration/SeriesCollection.js
@@ -54,7 +54,7 @@ define([
             domainObject.configuration.series.forEach(function (seriesConfig) {
                 var series = this.byIdentifier(seriesConfig.identifier);
                 if (series) {
-                    series.set('persistedConfiguration', seriesConfig);
+                    series.persistedConfig = seriesConfig;
                 }
             }, this);
         },
@@ -90,7 +90,9 @@ define([
                 model: seriesConfig,
                 domainObject: domainObject,
                 collection: this,
-                openmct: this.openmct
+                openmct: this.openmct,
+                persistedConfig: this.plot
+                    .getPersistedSeriesConfig(domainObject.identifier)
             }));
         },
         removeTelemetryObject: function (identifier) {

--- a/src/plugins/plot/src/inspector/PlotOptionsController.js
+++ b/src/plugins/plot/src/inspector/PlotOptionsController.js
@@ -45,6 +45,7 @@ define([
 
     PlotOptionsController.prototype.updateDomainObject = function (domainObject) {
         this.domainObject = domainObject;
+        this.$scope.formDomainObject = domainObject;
     };
 
     PlotOptionsController.prototype.destroy = function () {
@@ -63,8 +64,7 @@ define([
         this.config = this.$scope.config = config;
         this.$scope.plotSeries = [];
 
-        this.domainObject = this.config.get('domainObject');
-        this.$scope.formDomainObject = this.domainObject;
+        this.updateDomainObject(this.config.get('domainObject'));
         this.unlisten = this.openmct.objects.observe(this.domainObject, '*', this.updateDomainObject.bind(this));
 
         this.listenTo(this.$scope, '$destroy', this.destroy, this);


### PR DESCRIPTION
When a new series is added to a plot, a plot series form controller
is instantiated and passed in a domain object via scope that it will
mutate upon changes.  If a mutation results in a composition add, then
the plot series form controller needs to get a version of the domain
object with the updated composition array, which it was not previously
doing.

This fixes #2120.

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y