### PR TITLE
do not show warning dialog when user moves an object from one location to another

### DIFF
--- a/platform/commonUI/edit/src/actions/RemoveAction.js
+++ b/platform/commonUI/edit/src/actions/RemoveAction.js
@@ -51,7 +51,7 @@ define([
     /**
      * Perform this action.
      */
-    RemoveAction.prototype.perform = function () {
+    RemoveAction.prototype.perform = function (skipWarning) {
         var dialog,
             dialogService = this.dialogService,
             domainObject = this.domainObject,
@@ -115,12 +115,18 @@ define([
             return parent.useCapability('mutation', doMutate);
         }
 
-        /*
-         * Pass in the function to remove the domain object so it can be
-         * associated with an 'OK' button press
-         */
-        dialog = new RemoveDialog(dialogService, domainObject, removeFromContext);
-        dialog.show();
+        if (skipWarning) {
+
+            removeFromContext(domainObject);
+
+        } else {
+            /*
+            * Pass in the function to remove the domain object so it can be
+            * associated with an 'OK' button press
+            */
+            dialog = new RemoveDialog(dialogService, domainObject, removeFromContext);
+            dialog.show();
+        }
     };
 
     // Object needs to have a parent for Remove to be applicable

--- a/platform/commonUI/edit/test/actions/RemoveActionSpec.js
+++ b/platform/commonUI/edit/test/actions/RemoveActionSpec.js
@@ -124,6 +124,17 @@ define(
                 expect(mockParent.useCapability).not.toHaveBeenCalledWith("mutation", jasmine.any(Function));
             });
 
+            it("does not show a blocking message dialog when true is passed to perform", function () {
+                mockParent = jasmine.createSpyObj(
+                    "parent",
+                    ["getModel", "getCapability", "useCapability"]
+                );
+
+                action.perform(true);
+
+                expect(mockDialogService.showBlockingMessage).not.toHaveBeenCalled();
+            });
+
             describe("after the remove callback is triggered", function () {
                 var mockChildContext,
                     mockChildObject,

--- a/platform/core/src/actions/ActionCapability.js
+++ b/platform/core/src/actions/ActionCapability.js
@@ -102,14 +102,14 @@ define(
          * @returns {Action[]} an array of matching actions
          * @memberof platform/core.ActionCapability#
          */
-        ActionCapability.prototype.perform = function (context) {
+        ActionCapability.prototype.perform = function (context, flag) {
             // Alias to getActions(context)[0].perform, with a
             // check for empty arrays.
             var actions = this.getActions(context);
 
             return this.$q.when(
                 (actions && actions.length > 0) ?
-                    actions[0].perform() :
+                    actions[0].perform(flag) :
                     undefined
             );
         };

--- a/platform/entanglement/src/services/MoveService.js
+++ b/platform/entanglement/src/services/MoveService.js
@@ -92,7 +92,7 @@ define(
                 .then(function () {
                     return object
                         .getCapability('action')
-                        .perform('remove');
+                        .perform('remove', true);
                 });
         };
 

--- a/platform/entanglement/test/services/MoveServiceSpec.js
+++ b/platform/entanglement/test/services/MoveServiceSpec.js
@@ -224,10 +224,11 @@ define(
                             locationPromise.resolve();
                         });
 
-                        it("removes object from parent", function () {
+                        it("removes object from parent without user warning dialog", function () {
                             expect(actionCapability.perform)
-                                .toHaveBeenCalledWith('remove');
+                                .toHaveBeenCalledWith('remove', true);
                         });
+
                     });
 
                 });
@@ -244,9 +245,9 @@ define(
                             .toHaveBeenCalled();
                     });
 
-                    it("removes object from parent", function () {
+                    it("removes object from parent without user warning dialog", function () {
                         expect(actionCapability.perform)
-                            .toHaveBeenCalledWith('remove');
+                            .toHaveBeenCalledWith('remove', true);
                     });
                 });
 


### PR DESCRIPTION
Fixes issue #2141 