### PR TITLE
Fixes Import / Export to work correctly with links and contained objects.

### DIFF
--- a/platform/import-export/src/actions/ExportAsJSONAction.js
+++ b/platform/import-export/src/actions/ExportAsJSONAction.js
@@ -133,7 +133,7 @@ define(['lodash'], function (_) {
         copyOfChild.location = parentId;
         parent.composition[index] = copyOfChild.identifier;
         this.tree[newIdString] = copyOfChild;
-        this.tree[parentId].composition[index] = newIdString;
+        this.tree[parentId].composition[index] = copyOfChild.identifier;
 
         return copyOfChild;
     };

--- a/platform/import-export/test/actions/ImportAsJSONActionSpec.js
+++ b/platform/import-export/test/actions/ImportAsJSONActionSpec.js
@@ -47,7 +47,12 @@ define(
                 uniqueId = 0;
                 newObjects = [];
                 openmct = {
-                    $injector: jasmine.createSpyObj('$injector', ['get'])
+                    $injector: jasmine.createSpyObj('$injector', ['get']),
+                    objects: {
+                        makeKeyString: function (identifier) {
+                            return identifier.key;
+                        }
+                    }
                 };
                 mockInstantiate = jasmine.createSpy('instantiate').and.callFake(
                     function (model, id) {
@@ -154,7 +159,7 @@ define(
                             body: JSON.stringify({
                                 "openmct": {
                                     "infiniteParent": {
-                                        "composition": ["infinteChild"],
+                                        "composition": [{key: "infinteChild", namespace: ""}],
                                         "name": "1",
                                         "type": "folder",
                                         "modified": 1503598129176,
@@ -162,7 +167,7 @@ define(
                                         "persisted": 1503598129176
                                     },
                                     "infinteChild": {
-                                        "composition": ["infiniteParent"],
+                                        "composition": [{key: "infinteParent", namespace: ""}],
                                         "name": "2",
                                         "type": "folder",
                                         "modified": 1503598132428,


### PR DESCRIPTION
Issue was twofold. 

1. Export was exporting objects with a composition array consisting of [identifier objects](https://github.com/nasa/openmct/blob/9582fb2b06bb656ef3a2298deec8434d9bc8f39b/platform/import-export/src/actions/ExportAsJSONAction.js#L134), and/or [key-strings](https://github.com/nasa/openmct/blob/9582fb2b06bb656ef3a2298deec8434d9bc8f39b/platform/import-export/src/actions/ExportAsJSONAction.js#L136). Corrected to only export object identifiers.
2. Import was [expecting object IDs as strings](https://github.com/nasa/openmct/blob/9582fb2b06bb656ef3a2298deec8434d9bc8f39b/platform/import-export/src/actions/ImportAsJSONAction.js#L84).

Import was also [adding newly instantiated objects back to their parent](https://github.com/nasa/openmct/blob/9582fb2b06bb656ef3a2298deec8434d9bc8f39b/platform/import-export/src/actions/ImportAsJSONAction.js#L89) for reasons that aren't clear. This step appeared to be redundant, and also resulted in duplicate child objects in the parent's composition, so I removed it. Side effect of setting location was mutation, which persisted the newly instantiated objects. Have replaced this with an [explicit persist call](https://github.com/nasa/openmct/compare/import-export-links?expand=1#diff-8c59c63179298d114f3521eb303b5a2dR93), which also makes the code a little clearer.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? Y
* Command line build passes? Y
* Changes have been smoke-tested? Y