### PR TITLE
Added brief readmes for all plugins.

### DIFF
--- a/API.md
+++ b/API.md
@@ -52,7 +52,6 @@
     - [The URL Status Indicator](#the-url-status-indicator)
     - [Creating a Simple Indicator](#creating-a-simple-indicator)
     - [Custom Indicators](#custom-indicators)
-  - [Included Plugins](#included-plugins)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -994,7 +993,7 @@ A common use case for indicators is to convey the state of some external system 
 persistence backend or HTTP server. So long as this system is accessible via HTTP request, 
 Open MCT provides a general purpose indicator to show whether the server is available and 
 returing a 2xx status code. The URL Status Indicator is made available as a default plugin. See
-[Included Plugins](#included-plugins) below for details on how to install and configure the 
+the [documentation](./src/plugins/URLIndicatorPlugin) for details on how to install and configure the 
 URL Status Indicator.
 
 ### Creating a Simple Indicator
@@ -1045,60 +1044,4 @@ A completely custom indicator can be added by simple providing a DOM element to 
     openmct.indicators.add({
         element: domNode
     });
-```
-
-## Included Plugins
-
-Open MCT is packaged along with a few general-purpose plugins:
-
-* `openmct.plugins.Conductor` provides a user interface for working with time
-within the application. If activated, configuration must be provided. This is 
-detailed in the section on [Time Conductor Configuration](#time-conductor-configuration).
-* `openmct.plugins.CouchDB` is an adapter for using CouchDB for persistence
-  of user-created objects. This is a constructor that takes the URL for the
-  CouchDB database as a parameter, e.g.
-```javascript
-openmct.install(openmct.plugins.CouchDB('http://localhost:5984/openmct'))
-```
-* `openmct.plugins.Elasticsearch` is an adapter for using Elasticsearch for
-  persistence of user-created objects. This is a
-  constructor that takes the URL for the Elasticsearch instance as a
-  parameter. eg.
-```javascript
-openmct.install(openmct.plugins.CouchDB('http://localhost:9200'))
-```
-* `openmct.plugins.Espresso` and `openmct.plugins.Snow` are two different
-  themes (dark and light) available for Open MCT. Note that at least one
-  of these themes must be installed for Open MCT to appear correctly.
-* `openmct.plugins.URLIndicator` adds an indicator which shows the
-availability of a URL with the following options: 
-  - `url` : URL to indicate the status of
-  - `iconClass`: Icon to show in the status bar, defaults to `icon-database`, [list of all icons](https://nasa.github.io/openmct/style-guide/#/browse/styleguide:home?view=items)
-  - `interval`: Interval between checking the connection, defaults to `10000`
-  - `label` Name showing up as text in the status bar, defaults to url
-```javascript
-openmct.install(openmct.plugins.URLIndicator({
-  url: 'http://localhost:8080',
-    iconClass: 'check',
-    interval: 10000,
-    label: 'Localhost'
- })
-);
-```
-* `openmct.plugins.LocalStorage` provides persistence of user-created
-  objects in browser-local storage. This is particularly useful in
-  development environments.
-* `openmct.plugins.MyItems` adds a top-level folder named "My Items"
-  when the application is first started, providing a place for a
-  user to store created items.
-* `openmct.plugins.UTCTimeSystem` provides a default time system for Open MCT.
-
-Generally, you will want to either install these plugins, or install
-different plugins that provide persistence and an initial folder
-hierarchy.
-
-eg.
-```javascript
-openmct.install(openmct.plugins.LocalStorage());
-openmct.install(openmct.plugins.MyItems());
 ```

--- a/platform/commonUI/themes/espresso/README.md
+++ b/platform/commonUI/themes/espresso/README.md
@@ -1,0 +1,7 @@
+# Espresso Theme
+Dark theme for the Open MCT user interface.
+
+## Installation
+```js
+openmct.install(openmct.plugins.Espresso());
+```

--- a/platform/commonUI/themes/snow/README.md
+++ b/platform/commonUI/themes/snow/README.md
@@ -1,0 +1,7 @@
+# Espresso Theme
+A light colored theme for the Open MCT user interface.
+
+## Installation
+```js
+openmct.install(openmct.plugins.Snow());
+```

--- a/platform/features/my-items/README.md
+++ b/platform/features/my-items/README.md
@@ -1,0 +1,8 @@
+# My Items plugin
+Defines top-level folder named "My Items" to store user-created items. Enabled by default, this can be disabled in a 
+read-only deployment with no user-editable objects.
+
+## Installation
+```js
+openmct.install(openmct.plugins.MyItems());
+```

--- a/platform/import-export/README.md
+++ b/platform/import-export/README.md
@@ -1,0 +1,14 @@
+# Import / Export Plugin
+The Import/Export plugin allows objects to be exported as JSON files. This allows for sharing of objects between users 
+who are not using a shared persistence store. It also allows object trees to be backed up. Additionally, object trees 
+exported using this tool can then be exposed as read-only static root trees using the 
+[Static Root Plugin](../../src/plugins/staticRootPlugin/README.md).
+
+Upon installation it will add two new context menu actions to allow import and export of objects. Initiating the Export 
+action on an object will produce a JSON file that includes the object and all of its composed children. Selecting import 
+on an object will allow the user to import a previously exported object tree as a child of the selected object.
+
+## Installation
+```js
+openmct.install(openmct.plugins.ImportExport())
+```

--- a/platform/import-export/README.md
+++ b/platform/import-export/README.md
@@ -5,7 +5,7 @@ exported using this tool can then be exposed as read-only static root trees usin
 [Static Root Plugin](../../src/plugins/staticRootPlugin/README.md).
 
 Upon installation it will add two new context menu actions to allow import and export of objects. Initiating the Export 
-action on an object will produce a JSON file that includes the object and all of its composed children. Selecting import 
+action on an object will produce a JSON file that includes the object and all of its composed children. Selecting Import 
 on an object will allow the user to import a previously exported object tree as a child of the selected object.
 
 ## Installation

--- a/platform/persistence/couch/README.md
+++ b/platform/persistence/couch/README.md
@@ -1,2 +1,8 @@
-This bundle implements a connection to an external CouchDB persistence 
-store in Open MCT.
+# Couch DB Persistence Plugin
+An adapter for using CouchDB for persistence of user-created objects. The plugin installation function takes the URL 
+for the CouchDB database as a parameter.
+
+## Installation
+```js
+openmct.install(openmct.plugins.CouchDB('http://localhost:5984/openmct'))
+```

--- a/platform/persistence/elastic/README.md
+++ b/platform/persistence/elastic/README.md
@@ -1,2 +1,8 @@
-This bundle implements a connection to an external ElasticSearch persistence 
-store in Open MCT.
+# Elasticsearch Persistence Provider
+An adapter for using Elastic for persistence of user-created objects. The installation function takes the URL for an 
+Elasticsearch server as a parameter.
+
+## Installation
+```js
+openmct.install(openmct.plugins.Elasticsearch('http://localhost:9200'))
+```

--- a/platform/persistence/local/README.md
+++ b/platform/persistence/local/README.md
@@ -1,0 +1,9 @@
+# Local Storage Plugin
+Provides persistence of user-created objects in browser Local Storage. Objects persisted on this way will only be 
+available from the browser and machine on which they were persisted. For shared persistence, consider the 
+[Elasticsearch](../elastic/) and [CouchDB](../couch/) persistence plugins.
+
+## Installation
+```js
+openmct.install(openmct.plugins.LocalStorage());
+```

--- a/platform/persistence/local/README.md
+++ b/platform/persistence/local/README.md
@@ -1,5 +1,5 @@
 # Local Storage Plugin
-Provides persistence of user-created objects in browser Local Storage. Objects persisted on this way will only be 
+Provides persistence of user-created objects in browser Local Storage. Objects persisted in this way will only be 
 available from the browser and machine on which they were persisted. For shared persistence, consider the 
 [Elasticsearch](../elastic/) and [CouchDB](../couch/) persistence plugins.
 

--- a/src/plugins/URLIndicatorPlugin/README.md
+++ b/src/plugins/URLIndicatorPlugin/README.md
@@ -1,0 +1,21 @@
+# URL Indicator
+Adds an indicator which shows the availability of a URL, with success based on receipt of a 200 HTTP code. Can be used 
+for monitoring the availability of web services.
+
+## Installation
+```js
+openmct.install(openmct.plugins.URLIndicator({
+  url: 'http://localhost:8080',
+    iconClass: 'check',
+    interval: 10000,
+    label: 'Localhost'
+ })
+);
+```
+
+## Options
+* __url__: URL to indicate the status of
+* __iconClass__: Icon to show in the status bar, defaults to icon-database. See the [Style Guide](https://nasa.github.io/openmct/style-guide/#/browse/styleguide:home/glyphs?view=styleguide.glyphs) for more icon options.
+* __interval__: Interval between checking the connection, defaults to 10000
+* __label__: Name showing up as text in the status bar, defaults to url
+

--- a/src/plugins/autoflow/AutoflowTabularPlugin.js
+++ b/src/plugins/autoflow/AutoflowTabularPlugin.js
@@ -25,15 +25,6 @@ define([
 ], function (
     AutoflowTabularView
 ) {
-    /**
-     * This plugin provides an Autoflow Tabular View for domain objects
-     * in Open MCT.
-     *
-     * @param {Object} options
-     * @param {String} [options.type] the domain object type for which
-     *        this view should be available; if omitted, this view will
-     *        be available for all objects
-     */
     return function (options) {
         return function (openmct) {
             var views = (openmct.mainViews || openmct.objectViews);

--- a/src/plugins/autoflow/README.md
+++ b/src/plugins/autoflow/README.md
@@ -1,0 +1,15 @@
+# Autoflow View
+
+This plugin provides the Autoflow View for domain objects in Open MCT. This view allows users to visualize the latest 
+values of a collection of telemetry points in a condensed list.
+
+## Installation
+``` js
+    openmct.install(openmct.plugins.AutoflowView({
+        type: "telemetry.fixed"
+    }));
+```
+
+## Options
+* `type`: The object type to add the Autoflow View to. Currently supports a single value. If not provided, will make the 
+Autoflow view available for all objects (which is probably not what you want).

--- a/src/plugins/plot/README.md
+++ b/src/plugins/plot/README.md
@@ -1,8 +1,8 @@
 # Plot Plugin
 
 Enables plot visualization of telemetry data. This plugin adds a plot view that is available from the view switcher for 
-all telemetry objects. Two user createble objects are also added by this plugin, for overlay and stacked plots. 
-Telemetry objects can be added to overlay and stacked plots and dragging and dropping them into the plots.
+all telemetry objects. Two user createble objects are also added by this plugin, for Overlay and Stacked Plots. 
+Telemetry objects can be added to Overlay and Stacked Plots via drag and drop.
 
 ## Installation
 ``` js

--- a/src/plugins/plot/README.md
+++ b/src/plugins/plot/README.md
@@ -1,0 +1,10 @@
+# Plot Plugin
+
+Enables plot visualization of telemetry data. This plugin adds a plot view that is available from the view switcher for 
+all telemetry objects. Two user createble objects are also added by this plugin, for overlay and stacked plots. 
+Telemetry objects can be added to overlay and stacked plots and dragging and dropping them into the plots.
+
+## Installation
+``` js
+openmct.install(openmct.plugins.Plot());
+```

--- a/src/plugins/staticRootPlugin/README.md
+++ b/src/plugins/staticRootPlugin/README.md
@@ -1,0 +1,19 @@
+# Static Root Plugin
+
+This plugin takes an object tree as JSON and exposes it as a non-editable root level tree. This can be useful if you 
+have static non-editable content that you wish to expose, such as a standard set of displays that should not be edited 
+(but which can be copied and then modified if desired).
+
+Any object tree in Open MCT can be exported as JSON after installing the 
+[Import/Export plugin](../../../platform/import-export/README.md).
+
+## Installation
+``` js
+openmct.install(openmct.plugins.StaticRootPlugin('mission', 'data/static-objects.json'));
+```
+
+## Parameters
+The StaticRootPlugin takes two parameters:
+1. __namespace__: This should be a name that uniquely identifies this collection of objects.
+2. __path__: The file that the static tree should be exposed from. This will need to be a path that is reachable by a web 
+browser, ie not a path on the local file system.

--- a/src/plugins/summaryWidget/README.md
+++ b/src/plugins/summaryWidget/README.md
@@ -1,0 +1,10 @@
+# Summary Widget Plugin
+Summary widgets can be used to provide visual indication of state based on telemetry data. They allow rules to be 
+defined that can then be used to change the appearance of the summary widget element based on data. For example, a 
+summary widget could be defined that is green when a temparature reading is between `0` and `100` centigrade, red when 
+it's above `100`, and orange when it's below `0`.
+
+## Installation
+```js
+openmct.install(openmct.plugins.SummaryWidget());
+```


### PR DESCRIPTION
Adds some rudimentary docs to our various plugins. These docs will be linked from the plugins cards on the plugins section of the website. In cases where documentation is minimal (eg. the themes) they do at the very least provide example code for installing them.

Since doing this I've decided not to include plots as a plugin listed on the plugins page, as it's core functionality of Open MCT. I've left the basic docs in place anyway.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A - docs only
* Command line build passes? Y
* Changes have been smoke-tested? Y