### PR TITLE
Create menu

### DIFF
--- a/platform/commonUI/edit/src/capabilities/EditorCapability.js
+++ b/platform/commonUI/edit/src/capabilities/EditorCapability.js
@@ -82,6 +82,7 @@ define(
          */
         EditorCapability.prototype.save = function () {
             console.warn('DEPRECATED: cannot save via edit capability, use openmct.editor instead.');
+            return Promise.resolve();
         };
 
         EditorCapability.prototype.invoke = EditorCapability.prototype.edit;
@@ -93,6 +94,7 @@ define(
          */
         EditorCapability.prototype.finish = function () {
             console.warn('DEPRECATED: cannot finish via edit capability, use openmct.editor instead.');
+            return Promise.resolve();
         };
 
         /**

--- a/src/plugins/folderView/components/GridView.vue
+++ b/src/plugins/folderView/components/GridView.vue
@@ -15,9 +15,6 @@
                 <div class="c-grid-item__metadata"
                      :title="item.type.name">
                     <span class="c-grid-item__metadata__type">{{item.type.name}}</span>
-                    <span class="c-grid-item__metadata__item-count" v-if="item.model.composition !== undefined">
-                        {{item.model.composition.length}} item<span v-if="item.model.composition.length !== 1">s</span>
-                    </span>
                 </div>
             </div>
             <div class="c-grid-item__controls">

--- a/src/plugins/folderView/components/GridView.vue
+++ b/src/plugins/folderView/components/GridView.vue
@@ -4,7 +4,7 @@
             v-bind:key="index"
             class="l-grid-view__item c-grid-item"
              :class="{ 'is-alias': item.isAlias === true }"
-            @click="navigate(item.model.identifier.key)">
+            @click="navigate(item)">
             <div class="c-grid-item__type-icon"
                  :class="(item.type.cssClass != undefined) ? 'bg-' + item.type.cssClass : 'bg-icon-object-unknown'">
             </div>
@@ -177,45 +177,17 @@
 </style>
 
 <script>
+
+import compositionLoader from './composition-loader';
+
 export default {
-    inject: ['openmct', 'domainObject'],
-    data() {
-        var items = [],
-            unknownObjectType = {
-                definition: {
-                    cssClass: 'icon-object-unknown',
-                    name: 'Unknown Type'
-                }
-            };
-
-        var composition = this.openmct.composition.get(this.domainObject);
-
-        if (composition) {
-
-            composition.load().then((array) => {
-                if (Array.isArray(array)) {
-                    array.forEach((model) => {
-                        var type = this.openmct.types.get(model.type) || unknownObjectType;
-
-                        items.push({
-                            model: model,
-                            type: type.definition,
-                            isAlias: this.domainObject.identifier.key !== model.location
-                        });
-                    });
-                }
-            });
-        }
-
-        return {
-            items: items
-        }
-    },
+    mixins: [compositionLoader],
+    inject: ['domainObject', 'openmct'],
     methods: {
-        navigate(identifier) {
+        navigate(item) {
             let currentLocation = this.openmct.router.currentLocation.path,
-                navigateToPath = `${currentLocation}/${identifier}`;
-            
+                navigateToPath = `${currentLocation}/${this.openmct.objects.makeKeyString(item.model.identifier)}`;
+
             this.openmct.router.setPath(navigateToPath);
         }
     }

--- a/src/plugins/folderView/components/composition-loader.js
+++ b/src/plugins/folderView/components/composition-loader.js
@@ -1,0 +1,46 @@
+const unknownObjectType = {
+    definition: {
+        cssClass: 'icon-object-unknown',
+        name: 'Unknown Type'
+    }
+};
+
+export default {
+    inject: ['openmct', 'domainObject'],
+    data() {
+        return {
+            items: []
+        };
+    },
+    mounted() {
+        this.composition = this.openmct.composition.get(this.domainObject);
+        if (!this.composition) {
+            return;
+        }
+        this.composition.on('add', this.add);
+        this.composition.on('remove', this.remove);
+        this.composition.load();
+    },
+    destroyed() {
+        if (!this.composition) {
+            return;
+        }
+        this.composition.off('add', this.add);
+        this.composition.off('remove', this.remove);
+    },
+    methods: {
+        add(child, index, anything) {
+            var type = this.openmct.types.get(child.type) || unknownObjectType;
+
+            this.items.push({
+                model: child,
+                type: type.definition,
+                isAlias: this.domainObject.identifier.key !== child.location
+            });
+        },
+        remove(child) {
+            // TODO: implement remove action
+            console.log('remove child? might be identifier');
+        }
+    }
+}

--- a/src/ui/components/controls/CreateButton.vue
+++ b/src/ui/components/controls/CreateButton.vue
@@ -1,11 +1,11 @@
 <template>
     <div class="c-create-button--w">
         <button class="c-create-button c-button--menu c-button--major icon-plus"
-             @click="toggleCreateMenu">
+             @click="open">
             <span class="c-button__label">Create</span>
         </button>
         <div class="c-create-menu c-super-menu"
-             v-if="showCreateMenu">
+             v-if="opened">
             <div class="c-super-menu__menu">
                 <ul>
                     <li v-for="(item, index) in items"
@@ -67,15 +67,20 @@
     }
     export default {
         inject: ['openmct'],
-        props: {
-            showCreateMenu: {
-                type: Boolean,
-                default: false
-            }
-        },
         methods: {
-            toggleCreateMenu: function () {
-                this.showCreateMenu = !this.showCreateMenu;
+            open: function () {
+                if (this.opened) {
+                    return;
+                }
+                this.opened = true;
+                setTimeout(() => document.addEventListener('click', this.close));
+            },
+            close: function () {
+                if (!this.opened) {
+                    return;
+                }
+                this.opened = false;
+                document.removeEventListener('click', this.close);
             },
             showItemDescription: function (menuItem) {
                 this.selectedMenuItem = menuItem;
@@ -106,6 +111,9 @@
                 return openmct.$injector.get('instantiate')(oldModel, keyString);
             }
         },
+        destroyed () {
+            document.removeEventListener('click', this.close);
+        },
         data: function() {
             let items = [];
 
@@ -126,7 +134,8 @@
 
             return {
                 items: items,
-                selectedMenuItem: {}
+                selectedMenuItem: {},
+                opened: false
             }
         }
     }

--- a/src/ui/router/Browse.js
+++ b/src/ui/router/Browse.js
@@ -42,6 +42,11 @@ define([
                 }
 
                 let navigatedObject = objects[objects.length - 1];
+                // FIXME: this is a hack to support create action, intended to
+                // expose the current routed path.  We need to rewrite the
+                // navigation service and router to expose a clear and minimal
+                // API for this.
+                openmct.router.path = objects.reverse();
 
                 openmct.layout.$refs.browseBar.domainObject = navigatedObject;
                 browseObject = navigatedObject;


### PR DESCRIPTION
Wires up the create menu with the old create actions and updates the grid/list views to listen for composition.

tweaks the list view sorting so that I can use a mixin for composition watching, but this isn't intended for reuse outside the plugin.