### PR TITLE
Mutate correct path for plot range

### DIFF
--- a/src/plugins/plot/src/inspector/PlotYAxisFormController.js
+++ b/src/plugins/plot/src/inspector/PlotYAxisFormController.js
@@ -46,7 +46,7 @@ define([
             },
             {
                 modelProp: 'range',
-                objectPath: 'form.yAxis.range',
+                objectPath: 'configuration.yAxis.range',
                 coerce: function coerceRange(range) {
                     if (!range) {
                         return {


### PR DESCRIPTION
Mutate correct path on object for axis range.  Fixes #2182.

This was a mistake in earlier plot refactors, I confirmed that all other properties were properly migrated.  

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A, issue exists for backfill
3. Command line build passes? Y
4. Changes have been smoke-tested? Y