### PR TITLE
Consistent composition order

### DIFF
--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -177,7 +177,11 @@ define([
     CompositionCollection.prototype.load = function () {
         return this.provider.load(this.domainObject)
             .then(function (children) {
-                return Promise.all(children.map(this.onProviderAdd, this));
+                return Promise.all(children.map((c) => this.publicAPI.objects.get(c)));
+            }.bind(this))
+            .then(function (childObjects) {
+                childObjects.forEach(c => this.add(c, true));
+                return childObjects;
             }.bind(this))
             .then(function (children) {
                 this.emit('load');

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -177,10 +177,14 @@ define([
     CompositionCollection.prototype.load = function () {
         return this.provider.load(this.domainObject)
             .then(function (children) {
-                return Promise.all(children.map((c) => this.publicAPI.objects.get(c)));
+                return Promise.all(children.map(function (c) {
+                    return this.publicAPI.objects.get(c);
+                }, this));
             }.bind(this))
             .then(function (childObjects) {
-                childObjects.forEach(c => this.add(c, true));
+                childObjects.forEach(function (c) {
+                    this.add(c, true);
+                }, this);
                 return childObjects;
             }.bind(this))
             .then(function (children) {


### PR DESCRIPTION
Ensures that composition loads in a consistent order.  Cherry picks a change from topic-core-refactor and converts it to legacy JS for support in master build.

This fixes a bug reported by users via email: stacked plots don't always load in the same order.  The composition collection does not guarantee that loading will occur in a consistent order (different objects can take longer to load than others).

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y