### PR TITLE
[Plot] Remove x-axis tick ellipses

### DIFF
--- a/platform/commonUI/general/res/sass/plots/_plots-main.scss
+++ b/platform/commonUI/general/res/sass/plots/_plots-main.scss
@@ -268,7 +268,6 @@
 
 .gl-plot-tick,
 .tick-label {
-    @include reverseEllipsis();
     font-size: 0.7rem;
     position: absolute;
     &.gl-plot-x-tick-label,

--- a/src/plugins/plot/res/templates/mct-plot.html
+++ b/src/plugins/plot/res/templates/mct-plot.html
@@ -193,7 +193,7 @@
                               left: (100 * (tick.value - min) / interval) + '%'
                           }"
                           ng-title=":: tick.fullText || tick.text">
-                         {{:: tick.text | reverse}}
+                         {{:: tick.text }}
                      </div>
                 </mct-ticks>
 


### PR DESCRIPTION
Remove ellipses from x-axis ticks and reversal of tick text.  This
allows PNG export to export ticks correctly instead of reversed.

Fixes #2177

# Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A, issue exists for backfill
3. Command line build passes? Y
4. Changes have been smoke-tested? Y