### PR TITLE
Latest telemetry subscriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,17 @@
                 openmct.install(openmct.plugins.UTCTimeSystem());
                 openmct.install(openmct.plugins.ImportExport());
                 openmct.install(openmct.plugins.AutoflowView({
-                    type: "telemetry.panel"
+                    type: "view.autoflow"
                 }));
+                openmct.types.addType("view.autoflow", {
+                    key: "view.autoflow",
+                    name: "Autoflow",
+                    creatable: true,
+                    initialize: function (model) {
+                        model.composition = [];
+                        return model
+                    }
+                });
                 openmct.install(openmct.plugins.Conductor({
                     menuOptions: [
                         {

--- a/src/api/telemetry/latestValueSubscription.js
+++ b/src/api/telemetry/latestValueSubscription.js
@@ -1,0 +1,161 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open openmct is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open openmct includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+define([
+
+], function (
+
+) {
+
+    /**
+     * Subscribe to receive the latest telemetry value for a given domain
+     * object. The callback will be called whenever newer data is received from
+     * a realtime provider.  If a LAD provider is available, Open MCT will use
+     * it to provide an initial value for the latest data subscriber.
+     *
+     * Using this method will ensure that you only receive telemetry values in
+     * order, according to the current time system.  If openmct receives a new
+     * telemetry value from a provider that occurs out of order, i.e. the
+     * timestamp is less than the last received timestamp, then it will discard
+     * the message instead of notifying the callback.  In a telemetry system
+     * where data may be processed out of order, this guarantees that the end
+     * user is always viewing the latest data.
+     *
+     * If the user changes the time system, Open MCT will attempt to provide
+     * a new value from the LAD data provider and continue to provide new values
+     * via realtime providers.
+     *
+     * @param {module:openmct.DomainObject} domainObject the object
+     *        which has associated telemetry
+     * @param {Function} callback the callback to invoke with new data, as
+     *        it becomes available
+     * @returns {Function} a function which may be called to terminate
+     *          the subscription
+     */
+    function latestValueSubscription(
+        domainObject,
+        callback,
+        telemetryAPI,
+        openmct
+    ) {
+        var latestDatum;
+        var pendingRealtimeDatum;
+        var currentRequest = 0;
+        var metadata = telemetryAPI.getMetadata(domainObject);
+        var formatters = telemetryAPI.getFormatMap(metadata);
+        var timeFormatter;
+        var active = true;
+        var restrictToBounds = false;
+
+        function isLater(a, b) {
+            return !timeFormatter || timeFormatter.parse(a) > timeFormatter.parse(b);
+        }
+
+        function applyBoundsFilter(datum) {
+            if (!restrictToBounds || !timeFormatter) {
+                callback(datum);
+                return;
+            }
+            var timestamp = timeFormatter.parse(datum);
+            var bounds = openmct.time.bounds();
+            if (timestamp >= bounds.start && timestamp <= bounds.end) {
+                callback(datum);
+            }
+        }
+
+        function updateClock(clock) {
+            // We restrict to bounds if there is no clock (aka fixed mode) to
+            // prevent users from seeing data they don't expect.
+            restrictToBounds = !clock;
+        }
+
+        function callbackIfLatest(datum) {
+            if (!active) {
+                return; // prevent LAD notify after unsubscribe.
+            }
+            // If we don't have latest data, store datum for later processing.
+            if (typeof latestDatum === 'undefined') {
+                if (typeof pendingRealtimeDatum === 'undefined' ||
+                    isLater(datum, pendingRealtimeDatum)) {
+
+                    pendingRealtimeDatum = datum;
+                }
+                return;
+            }
+            // If there is no latest data, or datum is latest, then notify
+            // subscriber.
+            if (latestDatum === false || isLater(datum, latestDatum)) {
+                latestDatum = datum;
+                applyBoundsFilter(datum);
+            }
+        }
+
+        function updateTimeSystem(timeSystem) {
+            // Reset subscription state, request new latest data and wait for
+            // response before filtering lad data.
+            latestDatum = undefined;
+            pendingRealtimeDatum = undefined;
+            timeFormatter = formatters[timeSystem.key];
+
+            currentRequest++;
+            var thisRequest = currentRequest;
+            telemetryAPI.request(domainObject, {strategy: 'latest', size: 1})
+                .then(function (results) {
+                    return results[results.length - 1];
+                }, function (error) {
+                    return undefined;
+                })
+                .then(function (datum) {
+                    if (currentRequest !== thisRequest) {
+                        return; // prevent race.
+                    }
+                    if (!datum) {
+                        latestDatum = false;
+                    } else {
+                        latestDatum = datum;
+                        applyBoundsFilter(datum);
+                    }
+                    if (pendingRealtimeDatum) {
+                        callbackIfLatest(pendingRealtimeDatum);
+                        pendingRealtimeDatum = undefined;
+                    }
+                });
+        }
+
+        openmct.time.on('clock', updateClock);
+        openmct.time.on('timeSystem', updateTimeSystem);
+        var internalUnsubscribe = telemetryAPI.subscribe(domainObject, callbackIfLatest);
+
+        updateClock(openmct.time.clock());
+        updateTimeSystem(openmct.time.timeSystem());
+
+        return function unsubscribe() {
+            active = false;
+            internalUnsubscribe();
+            openmct.time.off('clock', updateClock);
+            openmct.time.off('timeSystem', updateTimeSystem);
+        }
+    };
+
+
+
+    return latestValueSubscription
+});

--- a/src/api/telemetry/latestValueSubscription.js
+++ b/src/api/telemetry/latestValueSubscription.js
@@ -140,8 +140,16 @@ define([
                 });
         }
 
+        function reloadInFixedMode(bounds, isTick) {
+            if (isTick || openmct.time.clock()) {
+                return;
+            }
+            updateTimeSystem(openmct.time.timeSystem());
+        }
+
         openmct.time.on('clock', updateClock);
         openmct.time.on('timeSystem', updateTimeSystem);
+        openmct.time.on('bounds', reloadInFixedMode);
         var internalUnsubscribe = telemetryAPI.subscribe(domainObject, callbackIfLatest);
 
         updateClock(openmct.time.clock());
@@ -152,6 +160,7 @@ define([
             internalUnsubscribe();
             openmct.time.off('clock', updateClock);
             openmct.time.off('timeSystem', updateTimeSystem);
+            openmct.time.off('bounds', reloadInFixedMode);
         }
     };
 

--- a/src/api/telemetry/latestValueSubscriptionSpec.js
+++ b/src/api/telemetry/latestValueSubscriptionSpec.js
@@ -1,0 +1,73 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open openmct is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open openmct includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+define([
+
+], function (
+
+) {
+
+    describe("latestValueSubscription", function () {
+
+
+        beforeEach(function () {
+
+        });
+
+        /** TODO:
+         * test lad response inside bounds, outside bounds, no response.
+         * test realtime should wait until lad response (all cases);
+         * realtime should only notify if later than latest (or no latest).
+         *
+         * timesystem change should clear and re-request LAD.
+         * clock change should enable/disable bounds filtering.
+         * non-tick bounds change should clear and
+         *
+         *
+         * should receive lad response
+         * should receive realtime if later than lad.
+         * should receive lad response (unless outside)
+         * subscriptions should wait for lad response
+         *
+        */
+        describe("no clock (AKA fixed)", function () {
+            describe("nominal LAD response", function () {
+
+            });
+            describe("out of bounds LAD response", function () {
+
+            });
+            describe("no LAD response", function () {
+
+            });
+        });
+
+        describe("with clock (AKA realtime)", function () {
+            describe("nominal LAD response", function () {
+
+            });
+            describe("no LAD response", function () {
+
+            });
+        });
+    });
+
+});

--- a/src/plugins/autoflow/AutoflowTabularPluginSpec.js
+++ b/src/plugins/autoflow/AutoflowTabularPluginSpec.js
@@ -41,8 +41,7 @@ define([
             spyOn(mockmct.telemetry, 'getMetadata');
             spyOn(mockmct.telemetry, 'getValueFormatter');
             spyOn(mockmct.telemetry, 'limitEvaluator');
-            spyOn(mockmct.telemetry, 'request');
-            spyOn(mockmct.telemetry, 'subscribe');
+            spyOn(mockmct.telemetry, 'latest');
 
             var plugin = new AutoflowTabularPlugin({ type: testType });
             plugin(mockmct);
@@ -140,14 +139,10 @@ define([
                         return mockFormatter;
                     });
                     mockmct.telemetry.limitEvaluator.and.returnValue(mockEvaluator);
-                    mockmct.telemetry.subscribe.and.callFake(function (obj, callback) {
+                    mockmct.telemetry.latest.and.callFake(function (obj, callback) {
                         var key = obj.identifier.key;
                         callbacks[key] = callback;
                         return mockUnsubscribes[key];
-                    });
-                    mockmct.telemetry.request.and.callFake(function (obj, request) {
-                        var key = obj.identifier.key;
-                        return Promise.resolve([testHistories[key]]);
                     });
                     mockMetadata.valuesForHints.and.callFake(function (hints) {
                         return [{ hint: hints[0] }];
@@ -229,19 +224,6 @@ define([
                 it("subscribes to all child objects", function () {
                     testKeys.forEach(function (key) {
                         expect(callbacks[key]).toEqual(jasmine.any(Function));
-                    });
-                });
-
-                it("displays historical telemetry", function () {
-                    function rowTextDefined() {
-                        return $(testContainer).find(".l-autoflow-item").filter(".r").text() !== "";
-                    }
-                    return domObserver.when(rowTextDefined).then(function () {
-                        testKeys.forEach(function (key, index) {
-                            var datum = testHistories[key];
-                            var $cell = $(testContainer).find(".l-autoflow-row").eq(index).find(".r");
-                            expect($cell.text()).toEqual(String(datum.range));
-                        });
                     });
                 });
 

--- a/src/plugins/autoflow/AutoflowTabularRowController.js
+++ b/src/plugins/autoflow/AutoflowTabularRowController.js
@@ -66,19 +66,10 @@ define([], function () {
      * Activate this controller; begin listening for changes.
      */
     AutoflowTabularRowController.prototype.activate = function () {
-        this.unsubscribe = this.openmct.telemetry.subscribe(
+        this.unsubscribe = this.openmct.telemetry.latest(
             this.domainObject,
             this.updateRowData.bind(this)
         );
-
-        this.openmct.telemetry.request(
-            this.domainObject,
-            { size: 1 }
-        ).then(function (history) {
-            if (!this.initialized && history.length > 0) {
-                this.updateRowData(history[history.length - 1]);
-            }
-        }.bind(this));
     };
 
     /**


### PR DESCRIPTION
Adds new method for telemetry consumers, `openmct.telemetry.latest(domainObject, callback)`.  It works similarly to subscribe, except that it jumps through some hoops to ensure that it never provides a datum that would be "incorrect" for the given time settings.  It also takes care of making LAD requests for data so that single value displays only have to deal with subscriptions.

This should simplify the code necessary to implement displays that only show the latest telemetry value (e.g. fixed position, lad table, summary widget, autoflow tabular).  Additionally, it will prevent these displays from deceiving users when a telemetry server ingests data out of order, while not changing time-window displays (plots, tables) which already properly handle out of order data.

Using latest, developers will:

* always receive the latest available data from the available LAD and Realtime telemetry providers.
* always receive the latest available data after a user-initiated bounds change or timeSystem change.
* never receive a datum that is "earlier" than the last datum received.
* never receive a datum outside current time bounds **_when the conductor is in fixed mode_**

note: developers should still clear any existing telemetry display on a timeSystem change.

This is not yet ready for review, still finalizing specs.