### PR TITLE
[Display Layout] Show field name as title for telemetry items

### DIFF
--- a/src/plugins/displayLayout/components/TelemetryView.vue
+++ b/src/plugins/displayLayout/components/TelemetryView.vue
@@ -29,6 +29,7 @@
         </div>
 
         <div v-if="showValue"
+              :title="fieldName"
               class="c-telemetry-view__value"
               :class="[telemetryClass]">
             <div class="c-telemetry-view__value-text">{{ telemetryValue }}</div>
@@ -93,6 +94,9 @@
                     color: alphanumeric.color,
                     fontSize: alphanumeric.size
                 }
+            },
+            fieldName() {
+                return this.valueMetadata.name;
             },
             valueMetadata() {
                 return this.metadata.value(this.item.config.alphanumeric.value);


### PR DESCRIPTION
Display a title for telemetry elements that identifies the chosen field type.