### PR TITLE
Grid and List View Fixes

### DIFF
--- a/platform/core/bundle.js
+++ b/platform/core/bundle.js
@@ -239,6 +239,10 @@ define([
                     "description": "Create folders to organize other objects or links to objects.",
                     "priority": 1000,
                     "model": {
+                        "configuration": {
+                            "sortBy": "model.name",
+                            "ascending": true
+                        },
                         "composition": []
                     }
                 },

--- a/platform/features/my-items/bundle.js
+++ b/platform/features/my-items/bundle.js
@@ -42,6 +42,10 @@ define([
                         "name": "My Items",
                         "type": "folder",
                         "composition": [],
+                        "configuration": {
+                            "sortBy": "model.name",
+                            "ascending": true
+                        },
                         "location": "ROOT"
                     }
                 }

--- a/src/plugins/folderView/FolderGridView.js
+++ b/src/plugins/folderView/FolderGridView.js
@@ -30,7 +30,7 @@ define([
     function FolderGridView(openmct) {
         return {
             key: 'grid',
-            name: 'Grid Vue',
+            name: 'Grid View',
             cssClass: 'icon-thumbs-strip',
             canView: function (domainObject) {
                 return domainObject.type === 'folder';

--- a/src/plugins/folderView/FolderListView.js
+++ b/src/plugins/folderView/FolderListView.js
@@ -32,7 +32,7 @@ define([
     function FolderListView(openmct) {
         return {
             key: 'list-view',
-            name: 'List Vue',
+            name: 'List View',
             cssClass: 'icon-list-view',
             canView: function (domainObject) {
                 return domainObject.type === 'folder';

--- a/src/plugins/folderView/components/ListView.vue
+++ b/src/plugins/folderView/components/ListView.vue
@@ -43,6 +43,7 @@
             </thead>
             <tbody>
                 <list-item v-for="(item,index) in sortedItems"
+                    :key="index"
                     :item="item"
                     :object-path="item.objectPath">
                 </list-item>
@@ -99,9 +100,17 @@ export default {
     mixins: [compositionLoader],
     inject: ['domainObject', 'openmct'],
     data() {
+        let sortBy = 'model.name',
+            ascending = true;
+        
+        if (this.domainObject.configuration) {
+            sortBy = this.domainObject.configuration.sortBy;
+            ascending = this.domainObject.configuration.ascending;
+        }
+
         return {
-            sortBy: 'model.name',
-            ascending: true
+            sortBy,
+            ascending
         };
     },
     computed: {
@@ -121,6 +130,17 @@ export default {
                 this.sortBy = field;
                 this.ascending = defaultDirection;
             }
+
+            this.openmct
+                .objects
+                .mutate(
+                    this.domainObject,
+                    'configuration',
+                    {
+                        sortBy: this.sortBy,
+                        ascending: this.ascending
+                    }
+                );
         }
     }
 }


### PR DESCRIPTION
## Items (grid) View
- [x]  Should be named "Grid View" instead of "Grid Vue"

## List View 
- [x] Should be named "List View" instead of "List Vue"
- [x]  Column sort preference in list view is not persisted. Switching between grid and list view changes the sort order.
- [ ]  Why show the empty table with sortable columns when the folder is empty? Perhaps a message to add content to the folder is more helpful. - Up for discussion. 