### PR TITLE
Pending fixes for Grid and List Folder views

### DIFF
--- a/src/plugins/folderView/FolderGridView.js
+++ b/src/plugins/folderView/FolderGridView.js
@@ -30,7 +30,7 @@ define([
     function FolderGridView(openmct) {
         return {
             key: 'grid',
-            name: 'Grid Vue',
+            name: 'Grid View',
             cssClass: 'icon-thumbs-strip',
             canView: function (domainObject) {
                 return domainObject.type === 'folder';

--- a/src/plugins/folderView/FolderListView.js
+++ b/src/plugins/folderView/FolderListView.js
@@ -32,7 +32,7 @@ define([
     function FolderListView(openmct) {
         return {
             key: 'list-view',
-            name: 'List Vue',
+            name: 'List View',
             cssClass: 'icon-list-view',
             canView: function (domainObject) {
                 return domainObject.type === 'folder';

--- a/src/plugins/folderView/components/ListView.vue
+++ b/src/plugins/folderView/components/ListView.vue
@@ -42,8 +42,8 @@
                 </tr>
             </thead>
             <tbody>
-                <list-item v-for="(item,index) in sortedItems"
-                    :key="index"
+                <list-item v-for="item in sortedItems"
+                    :key="item.key"
                     :item="item"
                     :object-path="item.objectPath">
                 </list-item>

--- a/src/plugins/folderView/components/ListView.vue
+++ b/src/plugins/folderView/components/ListView.vue
@@ -43,6 +43,7 @@
             </thead>
             <tbody>
                 <list-item v-for="(item,index) in sortedItems"
+                    :key="index"
                     :item="item"
                     :object-path="item.objectPath">
                 </list-item>
@@ -99,9 +100,20 @@ export default {
     mixins: [compositionLoader],
     inject: ['domainObject', 'openmct'],
     data() {
+        let sortBy = 'model.name',
+            ascending = true,
+            persistedSortOrder = window.localStorage.getItem('list-sort-order');
+
+        if (persistedSortOrder) {
+            let parsed = JSON.parse(persistedSortOrder);
+
+            sortBy = parsed.sortBy;
+            ascending = parsed.ascending;
+        }
+
         return {
-            sortBy: 'model.name',
-            ascending: true
+            sortBy,
+            ascending
         };
     },
     computed: {
@@ -121,6 +133,17 @@ export default {
                 this.sortBy = field;
                 this.ascending = defaultDirection;
             }
+
+            window.localStorage
+                .setItem(
+                    'list-sort-order',
+                    JSON.stringify(
+                        {
+                            sortBy: this.sortBy,
+                            ascending: this.ascending
+                        }
+                    )
+                );
         }
     }
 }

--- a/src/plugins/folderView/components/ListView.vue
+++ b/src/plugins/folderView/components/ListView.vue
@@ -43,7 +43,7 @@
             </thead>
             <tbody>
                 <list-item v-for="item in sortedItems"
-                    :key="item.key"
+                    :key="item.objectKeyString"
                     :item="item"
                     :object-path="item.objectPath">
                 </list-item>
@@ -102,7 +102,7 @@ export default {
     data() {
         let sortBy = 'model.name',
             ascending = true,
-            persistedSortOrder = window.localStorage.getItem('list-sort-order');
+            persistedSortOrder = window.localStorage.getItem('openmct-listview-sort-order');
 
         if (persistedSortOrder) {
             let parsed = JSON.parse(persistedSortOrder);
@@ -136,7 +136,7 @@ export default {
 
             window.localStorage
                 .setItem(
-                    'list-sort-order',
+                    'openmct-listview-sort-order',
                     JSON.stringify(
                         {
                             sortBy: this.sortBy,

--- a/src/plugins/folderView/components/composition-loader.js
+++ b/src/plugins/folderView/components/composition-loader.js
@@ -35,7 +35,8 @@ export default {
                 model: child,
                 type: type.definition,
                 isAlias: this.domainObject.identifier.key !== child.location,
-                objectPath: [child].concat(openmct.router.path)
+                objectPath: [child].concat(this.openmct.router.path),
+                key: this.openmct.objects.makeKeyString(child.identifier)
             });
         },
         remove(identifier) {

--- a/src/plugins/folderView/components/composition-loader.js
+++ b/src/plugins/folderView/components/composition-loader.js
@@ -36,7 +36,7 @@ export default {
                 type: type.definition,
                 isAlias: this.domainObject.identifier.key !== child.location,
                 objectPath: [child].concat(this.openmct.router.path),
-                key: this.openmct.objects.makeKeyString(child.identifier)
+                objectKeyString: this.openmct.objects.makeKeyString(child.identifier)
             });
         },
         remove(identifier) {


### PR DESCRIPTION
## Grid View
- [x] Should be named "Grid View" instead of "Grid Vue"

 ## List View
- [x] Should be named "List View" instead of "List Vue"
- [x]  Column sort preference in list view is not persisted. Switching between grid and list view changes the sort order.
- [?]  Why show the empty table with sortable columns when the folder is empty? Perhaps a message to add content to the folder is more helpful. (Up for discussion)