### PR TITLE
Change domain-object event transfer data to domain-object-path

### DIFF
--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -177,13 +177,13 @@
                 this.openmct.objects.mutate(this.internalDomainObject, path, value);
             },
             handleDrop($event) {
-                if (!$event.dataTransfer.types.includes('openmct/domain-object')) {
+                if (!$event.dataTransfer.types.includes('openmct/domain-object-path')) {
                     return;
                 }
 
                 $event.preventDefault();
 
-                let domainObject = JSON.parse($event.dataTransfer.getData('openmct/domain-object'));
+                let domainObject = JSON.parse($event.dataTransfer.getData('openmct/domain-object-path'))[0];
                 let elementRect = this.$el.getBoundingClientRect();
                 let droppedObjectPosition = [
                     Math.floor(($event.pageX - elementRect.left) / this.gridSize[0]),

--- a/src/plugins/flexibleLayout/components/container.vue
+++ b/src/plugins/flexibleLayout/components/container.vue
@@ -100,7 +100,7 @@ export default {
     },
     methods: {
         allowDrop(event, index) {
-            if (event.dataTransfer.getData('openmct/domain-object')) {
+            if (event.dataTransfer.types.includes('openmct/domain-object-path')) {
                 return true;
             }
             let frameId = event.dataTransfer.getData('frameid'),
@@ -124,9 +124,9 @@ export default {
             }
         },
         moveOrCreateFrame(insertIndex, event) {
-            if (event.dataTransfer.types.includes('openmct/domain-object')) {
+            if (event.dataTransfer.types.includes('openmct/domain-object-path')) {
                 // create frame using domain object
-                let domainObject = JSON.parse(event.dataTransfer.getData('openmct/domain-object'));
+                let domainObject = JSON.parse(event.dataTransfer.getData('openmct/domain-object-path'))[0];
                 this.$emit(
                     'create-frame',
                     this.index,

--- a/src/plugins/notebook/src/controllers/EntryController.js
+++ b/src/plugins/notebook/src/controllers/EntryController.js
@@ -107,10 +107,10 @@ function (
 
     EntryController.prototype.dropOnEntry = function (entryid, event) {
 
-        var data = event.dataTransfer.getData('openmct/domain-object');
+        var data = event.dataTransfer.getData('openmct/domain-object-path');
 
         if (data) {
-            var selectedObject = JSON.parse(data),
+            var selectedObject = JSON.parse(data)[0],
                 selectedObjectId = selectedObject.identifier.key,
                 cssClass = this.openmct.types.get(selectedObject.type),
                 entryPos = this.entryPosById(entryid),

--- a/src/plugins/notebook/src/controllers/NotebookController.js
+++ b/src/plugins/notebook/src/controllers/NotebookController.js
@@ -120,8 +120,8 @@ function (
         var date = Date.now(),
             embed;
 
-        if (event.dataTransfer && event.dataTransfer.getData('openmct/domain-object')) {
-            var selectedObject = JSON.parse(event.dataTransfer.getData('openmct/domain-object')),
+        if (event.dataTransfer && event.dataTransfer.getData('openmct/domain-object-path')) {
+            var selectedObject = JSON.parse(event.dataTransfer.getData('openmct/domain-object-path'))[0],
                 selectedObjectId = selectedObject.identifier.key,
                 cssClass = this.openmct.types.get(selectedObject.type);
 

--- a/src/plugins/tabs/components/tabs.vue
+++ b/src/plugins/tabs/components/tabs.vue
@@ -147,7 +147,7 @@ export default {
             this.setCurrentTab = true;
         },
         dragstart (e) {
-            if (e.dataTransfer.getData('openmct/domain-object')) {
+            if (e.dataTransfer.types.includes('openmct/domain-object-path')) {
                 this.isDragging = true;
             }
         },

--- a/src/ui/components/ObjectLabel.vue
+++ b/src/ui/components/ObjectLabel.vue
@@ -65,11 +65,19 @@ export default {
         },
         dragStart(event) {
             let navigatedObject = this.openmct.router.path[0];
-            let serializedObject = JSON.stringify(this.observedObject);
+            let serializedPath = JSON.stringify(this.objectPath);
+
+            /*
+             * Cannot inspect data transfer objects on dragover/dragenter so impossible to determine composability at
+             * that point. If dragged object can be composed by navigated object, then indicate with presence of 
+             * 'composable-domain-object' in data transfer
+             */
             if (this.openmct.composition.checkPolicy(navigatedObject, this.observedObject)) {
-                event.dataTransfer.setData("openmct/composable-domain-object", serializedObject);
+                event.dataTransfer.setData("openmct/composable-domain-object", JSON.stringify(this.domainObject));
             }
-            event.dataTransfer.setData("openmct/domain-object", serializedObject);
+            // serialize domain object anyway, because some views can drag-and-drop objects without composition 
+            // (eg. notabook.)
+            event.dataTransfer.setData("openmct/domain-object-path", serializedPath);
         }
     }
 }


### PR DESCRIPTION
Drag and drop events now serialize the object path instead of the object. The serialized object path is now available on the event data transfer object as `domain-object-path` which replaces the previous `domain-object`.

Also changes boolean usage of `event.dataTransfer.getData(...)` to use the more appropriate `event.dataTransfer.getData.types.includes(...)` instead