### PR TITLE
Quick compatibility fix to support dismissing notifications from legacy notifications list overlay

### DIFF
--- a/platform/commonUI/dialog/res/templates/message.html
+++ b/platform/commonUI/dialog/res/templates/message.html
@@ -10,6 +10,16 @@
                          ng-show="ngModel.progressPerc !== undefined"></mct-include>
         </div>
         <div class="bottom-bar">
+            <a ng-repeat="dialogOption in ngModel.options"
+                class="s-button"
+                ng-click="dialogOption.callback()">
+                    {{dialogOption.label}}
+            </a>
+            <a class="s-button major"
+                ng-if="ngModel.primaryOption"
+                ng-click="ngModel.primaryOption.callback()">
+                    {{ngModel.primaryOption.label}}
+            </a>
         </div>
     </div>
 </div>

--- a/platform/commonUI/notification/src/NotificationIndicatorController.js
+++ b/platform/commonUI/notification/src/NotificationIndicatorController.js
@@ -43,12 +43,25 @@ define(
              * Launch a dialog showing a list of current notifications.
              */
             $scope.showNotificationsList = function () {
+                let notificationsList = openmct.notifications.notifications.map(notification => {
+                    if (notification.model.severity === 'alert' || notification.model.severity === 'info') {
+                        notification.model.primaryOption = {
+                            label: 'Dismiss',
+                            callback: () => {
+                                let currentIndex = notificationsList.indexOf(notification);
+                                notification.dismiss();
+                                notificationsList.splice(currentIndex, 1);
+                            }
+                        }
+                    }
+                    return notification;
+                })
                 dialogService.getDialogResponse('overlay-message-list', {
                     dialog: {
                         title: "Messages",
                         //Launch the message list dialog with the models
                         // from the notifications
-                        messages: openmct.notifications.notifications
+                        messages: notificationsList
                     }
                 });
 


### PR DESCRIPTION
This partially reverts a previous change that removed options from notifications as they were not being used. A side effect of this was to make notifications non-dismissible from the notifications list.