### PR TITLE
[Display Layout] Show Imagery as Imagery when added to a layout

### DIFF
--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -269,7 +269,8 @@
             },
             isTelemetry(domainObject) {
                 if (this.openmct.telemetry.isTelemetryObject(domainObject)
-                    && domainObject.type !== 'summary-widget') {
+                    && domainObject.type !== 'summary-widget'
+                    && domainObject.type !== 'example.imagery') {
                     return true;
                 } else {
                     return false;


### PR DESCRIPTION
Update isTelemetry logic to ignore Imagery so that when added to a layout, it appears as Imagery and not alphanumeric.