### PR TITLE
Prevent self-composition in layouts

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -216,6 +216,19 @@ define([
     };
 
     /**
+     * Given any number of identifiers, will return true if they are all equal, otherwise false.
+     * @param {module:openmct.ObjectAPI~Identifier[]} identifiers
+     */
+    ObjectAPI.prototype.areIdsEqual = function (...identifiers) {
+        return identifiers.map(utils.parseKeyString)
+            .every(identifier => {
+                return identifier === identifiers[0] ||
+                    (identifier.namespace === identifiers[0].namespace &&
+                        identifier.key === identifiers[0].key);
+            });
+    }
+
+    /**
      * Uniquely identifies a domain object.
      *
      * @typedef Identifier

--- a/src/ui/components/ObjectLabel.vue
+++ b/src/ui/components/ObjectLabel.vue
@@ -66,6 +66,7 @@ export default {
         dragStart(event) {
             let navigatedObject = this.openmct.router.path[0];
             let serializedPath = JSON.stringify(this.objectPath);
+            let keyString = this.openmct.objects.makeKeyString(this.domainObject.identifier);
 
             /*
              * Cannot inspect data transfer objects on dragover/dragenter so impossible to determine composability at
@@ -78,6 +79,7 @@ export default {
             // serialize domain object anyway, because some views can drag-and-drop objects without composition 
             // (eg. notabook.)
             event.dataTransfer.setData("openmct/domain-object-path", serializedPath);
+            event.dataTransfer.setData(`openmct/domain-object/${keyString}`, this.domainObject);
         }
     }
 }


### PR DESCRIPTION
This prevents a layout from being added to itself.

Display layouts [define their own dragover behavior](https://github.com/nasa/openmct/compare/topic-core-refactor...no-self-composition?expand=1#diff-0bd189e6e0f41c38b19fc752fe4b96f4R273) to short cut the composition policy check that occurs as part of drag-and-drop composition. This change adds an additional check on dragover so that [the default behavior is only shortcut if the layout already contains the dragged object](https://github.com/nasa/openmct/compare/topic-core-refactor...no-self-composition?expand=1#diff-0bd189e6e0f41c38b19fc752fe4b96f4R281), otherwise the normal composition rules will apply. This supports duplication of telemetry points.

The w3c drag-and-drop API prevents inspection of dataTransfer items during dragOver, so this change also adds the dragged object's id to the dataTransfer 'type'.

This PR also adds a new `areSameId` method to the object API. This is intended to be used in place of keyString and direct identifier attribute comparisons going forward.