### PR TITLE
Only persist latest mutated model.

### DIFF
--- a/platform/commonUI/edit/src/services/TransactionManager.js
+++ b/platform/commonUI/edit/src/services/TransactionManager.js
@@ -78,7 +78,7 @@ define([], function () {
             };
         }
         /**
-         * Clear any existing persistence calls for object with given ID. This ensures only the most recent persistence 
+         * Clear any existing persistence calls for object with given ID. This ensures only the most recent persistence
          * call is executed. This should prevent stale objects being persisted and overwriting fresh ones.
          */
         if (this.isScheduled(id)) {

--- a/platform/commonUI/edit/src/services/TransactionManager.js
+++ b/platform/commonUI/edit/src/services/TransactionManager.js
@@ -77,14 +77,19 @@ define([], function () {
                 return promiseFn().then(nextFn);
             };
         }
-
-        if (!this.isScheduled(id)) {
-            this.clearTransactionFns[id] =
-                this.transactionService.addToTransaction(
-                    chain(onCommit, release),
-                    chain(onCancel, release)
-                );
+        /**
+         * Clear any existing persistence calls for object with given ID. This ensures only the most recent persistence 
+         * call is executed. This should prevent stale objects being persisted and overwriting fresh ones.
+         */
+        if (this.isScheduled(id)) {
+            this.clearTransactionsFor(id);
         }
+
+        this.clearTransactionFns[id] =
+            this.transactionService.addToTransaction(
+                chain(onCommit, release),
+                chain(onCancel, release)
+            );
     };
 
     /**

--- a/platform/commonUI/edit/test/services/TransactionManagerSpec.js
+++ b/platform/commonUI/edit/test/services/TransactionManagerSpec.js
@@ -97,7 +97,8 @@ define(
                     beforeEach(function () {
                         spyOn(manager, 'clearTransactionsFor');
                         manager.clearTransactionsFor.and.callThrough();
-                    })
+                    });
+
                     it("and clears pending calls if same object", function () {
                         manager.addToTransaction(
                             testId,
@@ -106,7 +107,7 @@ define(
                         );
                         expect(manager.clearTransactionsFor).toHaveBeenCalledWith(testId);
                     });
-    
+
                     it("and does not clear pending calls if different object", function () {
                         manager.addToTransaction(
                             'other-id',
@@ -118,8 +119,8 @@ define(
 
                     afterEach(function () {
                         expect(mockTransactionService.addToTransaction.calls.count()).toEqual(2);
-                    })
-                })
+                    });
+                });
 
                 it("does not remove callbacks from the transaction", function () {
                     expect(mockRemoves[0]).not.toHaveBeenCalled();

--- a/platform/commonUI/edit/test/services/TransactionManagerSpec.js
+++ b/platform/commonUI/edit/test/services/TransactionManagerSpec.js
@@ -93,25 +93,33 @@ define(
                     expect(mockOnCancel).toHaveBeenCalled();
                 });
 
-                it("ignores subsequent calls for the same object", function () {
-                    manager.addToTransaction(
-                        testId,
-                        jasmine.createSpy(),
-                        jasmine.createSpy()
-                    );
-                    expect(mockTransactionService.addToTransaction.calls.count())
-                        .toEqual(1);
-                });
+                describe("Adds callbacks to transaction", function () {
+                    beforeEach(function () {
+                        spyOn(manager, 'clearTransactionsFor');
+                        manager.clearTransactionsFor.and.callThrough();
+                    })
+                    it("and clears pending calls if same object", function () {
+                        manager.addToTransaction(
+                            testId,
+                            jasmine.createSpy(),
+                            jasmine.createSpy()
+                        );
+                        expect(manager.clearTransactionsFor).toHaveBeenCalledWith(testId);
+                    });
+    
+                    it("and does not clear pending calls if different object", function () {
+                        manager.addToTransaction(
+                            'other-id',
+                            jasmine.createSpy(),
+                            jasmine.createSpy()
+                        );
+                        expect(manager.clearTransactionsFor).not.toHaveBeenCalled();
+                    });
 
-                it("accepts subsequent calls for other objects", function () {
-                    manager.addToTransaction(
-                        'other-id',
-                        jasmine.createSpy(),
-                        jasmine.createSpy()
-                    );
-                    expect(mockTransactionService.addToTransaction.calls.count())
-                        .toEqual(2);
-                });
+                    afterEach(function () {
+                        expect(mockTransactionService.addToTransaction.calls.count()).toEqual(2);
+                    })
+                })
 
                 it("does not remove callbacks from the transaction", function () {
                     expect(mockRemoves[0]).not.toHaveBeenCalled();

--- a/platform/core/src/runs/TransactingMutationListener.js
+++ b/platform/core/src/runs/TransactingMutationListener.js
@@ -43,20 +43,10 @@ define([], function () {
         var mutationTopic = topic('mutation');
         mutationTopic.listen(function (domainObject) {
             var persistence = domainObject.getCapability('persistence');
-            var wasActive = transactionService.isActive();
             cacheService.put(domainObject.getId(), domainObject.getModel());
 
             if (hasChanged(domainObject)) {
-
-                if (!wasActive) {
-                    transactionService.startTransaction();
-                }
-
                 persistence.persist();
-
-                if (!wasActive) {
-                    transactionService.commit();
-                }
             }
         });
     }

--- a/platform/core/test/runs/TransactingMutationListenerSpec.js
+++ b/platform/core/test/runs/TransactingMutationListenerSpec.js
@@ -101,8 +101,8 @@ define(
                 mockModel.modified = mockModel.persisted;
 
                 mockMutationTopic.listen.calls.mostRecent()
-                    .args[0](mockDomainObject);                    
-                
+                    .args[0](mockDomainObject);
+
                 expect(mockPersistence.persist).not.toHaveBeenCalled();
             });
         });

--- a/platform/core/test/runs/TransactingMutationListenerSpec.js
+++ b/platform/core/test/runs/TransactingMutationListenerSpec.js
@@ -83,44 +83,27 @@ define(
                     .toHaveBeenCalledWith(jasmine.any(Function));
             });
 
-            [false, true].forEach(function (isActive) {
-                var verb = isActive ? "is" : "isn't";
+            it("calls persist if the model has changed", function () {
+                mockModel.persisted = Date.now();
 
-                function onlyWhenInactive(expectation) {
-                    return isActive ? expectation.not : expectation;
-                }
+                //Mark the model dirty by setting the mutated date later than the last persisted date.
+                mockModel.modified = mockModel.persisted + 1;
 
-                describe("when a transaction " + verb + " active", function () {
-                    var innerVerb = isActive ? "does" : "doesn't";
+                mockMutationTopic.listen.calls.mostRecent()
+                    .args[0](mockDomainObject);
 
-                    beforeEach(function () {
-                        mockTransactionService.isActive.and.returnValue(isActive);
-                    });
+                expect(mockPersistence.persist).toHaveBeenCalled();
+            });
 
-                    describe("and mutation occurs", function () {
-                        beforeEach(function () {
-                            mockMutationTopic.listen.calls.mostRecent()
-                                .args[0](mockDomainObject);
-                        });
+            it("does not call persist if the model has not changed", function () {
+                mockModel.persisted = Date.now();
 
+                mockModel.modified = mockModel.persisted;
 
-                        it(innerVerb + " start a new transaction", function () {
-                            onlyWhenInactive(
-                                expect(mockTransactionService.startTransaction)
-                            ).toHaveBeenCalled();
-                        });
-
-                        it("calls persist", function () {
-                            expect(mockPersistence.persist).toHaveBeenCalled();
-                        });
-
-                        it(innerVerb + " immediately commit", function () {
-                            onlyWhenInactive(
-                                expect(mockTransactionService.commit)
-                            ).toHaveBeenCalled();
-                        });
-                    });
-                });
+                mockMutationTopic.listen.calls.mostRecent()
+                    .args[0](mockDomainObject);                    
+                
+                expect(mockPersistence.persist).not.toHaveBeenCalled();
             });
         });
     }


### PR DESCRIPTION
Fixes #2277

Previously, [guard code in `TransactionManager`](https://github.com/nasa/openmct/compare/persist-latest?expand=1#diff-32c72e698ab122107a9cd49de97320deL81) would ensure that an object is only persisted once for a given transaction.

Changes introduced to bridge old and new API cause [a new version of a given object to be instantiated each time it's mutated](https://github.com/nasa/openmct/blob/master/src/adapter/services/LegacyObjectAPIInterceptor.js#L47). Due to [a closure referencing a stale object instance](https://github.com/nasa/openmct/blob/master/platform/persistence/queue/src/QueuingPersistenceCapability.js#L43), this resulted in a stale object being queued for persistence.

This change ensures that the object model being persisted is not stale by only committing the most recent persist call per object, rather than the oldest one.

To Do:
* [x] Update tests