### PR TITLE
Legacy dialogs fix

### DIFF
--- a/platform/commonUI/dialog/bundle.js
+++ b/platform/commonUI/dialog/bundle.js
@@ -28,6 +28,7 @@ define([
     "./res/templates/dialog.html",
     "./res/templates/overlay-blocking-message.html",
     "./res/templates/message.html",
+    "./res/templates/notification-message.html",
     "./res/templates/overlay-message-list.html",
     "./res/templates/overlay.html",
     'legacyRegistry'
@@ -39,6 +40,7 @@ define([
     dialogTemplate,
     overlayBlockingMessageTemplate,
     messageTemplate,
+    notificationMessageTemplate,
     overlayMessageListTemplate,
     overlayTemplate,
     legacyRegistry
@@ -87,6 +89,10 @@ define([
                 {
                     "key": "message",
                     "template": messageTemplate
+                },
+                {
+                    "key": "notification-message",
+                    "template": notificationMessageTemplate
                 },
                 {
                     "key": "overlay-message-list",

--- a/platform/commonUI/dialog/res/templates/message.html
+++ b/platform/commonUI/dialog/res/templates/message.html
@@ -2,23 +2,30 @@
      ng-class="'message-severity-' + ngModel.severity">
     <div class="w-message-contents">
         <div class="top-bar">
-            <div class="title">{{ngModel.message}}</div>
+            <div class="title">{{ngModel.title}}</div>
+        </div>
+        <div class="hint" ng-hide="ngModel.hint === undefined">
+            {{ngModel.hint}}
+            <span ng-if="ngModel.timestamp !== undefined">[{{ngModel.timestamp}}]</span>
         </div>
         <div class="message-body">
+            <div class="message-action">
+                {{ngModel.actionText}}
+            </div>
             <mct-include key="'progress-bar'"
                          ng-model="ngModel"
-                         ng-show="ngModel.progressPerc !== undefined"></mct-include>
+                         ng-show="ngModel.progress !== undefined || ngModel.unknownProgress"></mct-include>
         </div>
         <div class="bottom-bar">
             <a ng-repeat="dialogOption in ngModel.options"
-                class="s-button"
-                ng-click="dialogOption.callback()">
-                    {{dialogOption.label}}
+               class="s-button"
+               ng-click="dialogOption.callback()">
+                {{dialogOption.label}}
             </a>
             <a class="s-button major"
-                ng-if="ngModel.primaryOption"
-                ng-click="ngModel.primaryOption.callback()">
-                    {{ngModel.primaryOption.label}}
+               ng-if="ngModel.primaryOption"
+               ng-click="ngModel.primaryOption.callback()">
+                {{ngModel.primaryOption.label}}
             </a>
         </div>
     </div>

--- a/platform/commonUI/dialog/res/templates/notification-message.html
+++ b/platform/commonUI/dialog/res/templates/notification-message.html
@@ -1,0 +1,25 @@
+<div class="l-message"
+     ng-class="'message-severity-' + ngModel.severity">
+    <div class="w-message-contents">
+        <div class="top-bar">
+            <div class="title">{{ngModel.message}}</div>
+        </div>
+        <div class="message-body">
+            <mct-include key="'progress-bar'"
+                         ng-model="ngModel"
+                         ng-show="ngModel.progressPerc !== undefined"></mct-include>
+        </div>
+        <div class="bottom-bar">
+            <a ng-repeat="dialogOption in ngModel.options"
+                class="s-button"
+                ng-click="dialogOption.callback()">
+                    {{dialogOption.label}}
+            </a>
+            <a class="s-button major"
+                ng-if="ngModel.primaryOption"
+                ng-click="ngModel.primaryOption.callback()">
+                    {{ngModel.primaryOption.label}}
+            </a>
+        </div>
+    </div>
+</div>

--- a/platform/commonUI/dialog/res/templates/overlay-message-list.html
+++ b/platform/commonUI/dialog/res/templates/overlay-message-list.html
@@ -9,7 +9,7 @@
         <div class="w-messages">
             <mct-include
                 ng-repeat="msg in ngModel.dialog.messages | orderBy: '-'"
-                key="'message'" ng-model="msg.model"></mct-include>
+                key="'notification-message'" ng-model="msg.model"></mct-include>
         </div>
         <div class="bottom-bar">
             <a ng-repeat="dialogAction in ngModel.dialog.actions"


### PR DESCRIPTION
Legacy dialogs were broken by a previous change for notifications. The problem occurred because both notifications and dialogs were sharing an Angular template - [message.html](https://github.com/nasa/openmct/blob/topic-core-refactor/platform/commonUI/dialog/res/templates/message.html). This template [had been updated due to notification model changes](https://github.com/nasa/openmct/commit/6f1b5b4ae36af1b8bed84ace7a3f6a9aa0651ab8#diff-47312eef541e28ca00f5a22e616629d0), which broke legacy dialogs. For now I have just split message.html into two templates - one for notifications and one for dialog messages, which has been reverted to the old version of the template.