### PR TITLE
Fix various table bugs

### DIFF
--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -60,6 +60,7 @@ define([
 
             this.createTableRowCollections();
             openmct.time.on('bounds', this.refreshData);
+            openmct.time.on('timeSystem', this.refreshData);
         }
 
         initialize() {
@@ -166,6 +167,7 @@ define([
             if (!isTick) {
                 this.filteredRows.clear();
                 this.boundedRows.clear();
+                this.boundedRows.sortByTimeSystem(this.openmct.time.timeSystem());
                 this.telemetryObjects.forEach(this.requestDataFor);
             }
         }
@@ -213,6 +215,7 @@ define([
             this.filteredRows.destroy();
             Object.keys(this.subscriptions).forEach(this.unsubscribe, this);
             this.openmct.time.off('bounds', this.refreshData);
+            this.openmct.time.on('timeSystem', this.refreshData);
             if (this.filterObserver) {
                 this.filterObserver();
             }

--- a/src/plugins/telemetryTable/collections/BoundedTableRowCollection.js
+++ b/src/plugins/telemetryTable/collections/BoundedTableRowCollection.js
@@ -41,7 +41,6 @@ define(
                 this.bounds = this.bounds.bind(this)
 
                 this.sortByTimeSystem(openmct.time.timeSystem());
-                openmct.time.on('timeSystem', this.sortByTimeSystem);
 
                 this.lastBounds = openmct.time.bounds();
                 openmct.time.on('bounds', this.bounds);
@@ -51,8 +50,8 @@ define(
                 // Insert into either in-bounds array, or the future buffer.
                 // Data in the future buffer will be re-evaluated for possible 
                 // insertion on next bounds change
-                let beforeStartOfBounds = item.datum[this.sortOptions.key] < this.lastBounds.start;
-                let afterEndOfBounds = item.datum[this.sortOptions.key] > this.lastBounds.end;
+                let beforeStartOfBounds = this.parseTime(item.datum[this.sortOptions.key]) < this.lastBounds.start;
+                let afterEndOfBounds = this.parseTime(item.datum[this.sortOptions.key]) > this.lastBounds.end;
 
                 if (!afterEndOfBounds && !beforeStartOfBounds) {
                     return super.addOne(item);
@@ -64,6 +63,12 @@ define(
 
             sortByTimeSystem(timeSystem) {
                 this.sortBy({key: timeSystem.key, direction: 'asc'});
+                let formatter = this.openmct.telemetry.getValueFormatter({
+                    key: timeSystem.key,
+                    source: timeSystem.key,
+                    format: timeSystem.timeFormat
+                });
+                this.parseTime = formatter.parse.bind(formatter);
                 this.futureBuffer.sortBy({key: timeSystem.key, direction: 'asc'});
             }
 
@@ -131,7 +136,6 @@ define(
             }
 
             destroy() {
-                this.openmct.time.off('timeSystem', this.sortByTimeSystem);
                 this.openmct.time.off('bounds', this.bounds);
             }
         }

--- a/src/plugins/telemetryTable/collections/SortedTableRowCollection.js
+++ b/src/plugins/telemetryTable/collections/SortedTableRowCollection.js
@@ -127,7 +127,8 @@ define(
                     if (testRowValue > lastValue) {
                         return this.rows.length;
                     } else if (testRowValue === lastValue) {
-                        return this.rows.length - 1;
+                        // Maintain stable sort
+                        return this.rows.length;
                     } else if (testRowValue <= firstValue) {
                         return 0;
                     } else {
@@ -141,7 +142,8 @@ define(
                     } else if (testRowValue < lastValue) {
                         return this.rows.length;
                     } else if (testRowValue === lastValue) {
-                        return this.rows.length - 1;
+                        // Maintain stable sort
+                        return this.rows.length;
                     } else {
                         // Use a custom comparison function to support descending sort.
                         return lodashFunction(rows, testRow, (thisRow) => {


### PR DESCRIPTION
* Maintain stable sort (VISTA DEFECT-590)
* Parse telemetry date values to raw values before comparing them to bounds. There was a problem in VISTA where dates are represented as strings. Bounds are always a number, so this was resulting in invalid comparisons.
* Re-fetch historical data on time system change.