### PR TITLE
Fix legacy tables

### DIFF
--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -142,6 +142,7 @@
             // Wraps __headers table
             flex: 0 0 auto;
             overflow: hidden;
+            background: $colorTabHeaderBg;
         }
 
         /******************************* TABLES */


### PR DESCRIPTION
### Changes
- Extremely minor style tweak to support legacy mct-tables in VISTA; required by VISTA branch `legacy-mct-table`

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y