### PR TITLE
More robust routing

### DIFF
--- a/src/ui/router/ApplicationRouter.js
+++ b/src/ui/router/ApplicationRouter.js
@@ -60,6 +60,10 @@ class ApplicationRouter extends EventEmitter {
     }
 
     handleLocationChange(pathString) {
+        if (pathString[0] !== '/') {
+            pathString = '/' + pathString
+        }
+
         let url = new URL(
             pathString,
             `${location.protocol}//${location.host}${location.pathname}`


### PR DESCRIPTION
Routing failed completely if deployed to anything other the root of a webserver. This was all down to a missing '/' in the router code that seems to be getting stripped by the location-bar library.