### PR TITLE
do not return null unsubscribe function

### DIFF
--- a/src/adapter/runs/LegacyTelemetryProvider.js
+++ b/src/adapter/runs/LegacyTelemetryProvider.js
@@ -137,8 +137,7 @@ define([
         function callbackWrapper(series) {
             callback(createDatum(domainObject, metadata, series, series.getPointCount() - 1));
         }
-
-        return capability.subscribe(callbackWrapper, request);
+        return capability.subscribe(callbackWrapper, request) || function () {};
     };
 
     LegacyTelemetryProvider.prototype.supportsLimits = function (domainObject) {


### PR DESCRIPTION
A small fix that addresses an issue with legacy telemetry providers. If no legacy telemetry service available, return noop unsubscribe function.