### PR TITLE
Default routing

### DIFF
--- a/src/MCT.js
+++ b/src/MCT.js
@@ -352,7 +352,7 @@ define([
         legacyRegistry.enable('adapter');
 
         this.router.route(/^\/$/, () => {
-            this.router.setPath('/browse/mine');
+            this.router.setPath('/browse/');
         });
 
         /**


### PR DESCRIPTION
This restores the previous default behavior of Open MCT when no explicit object path is defined - that is, it will navigate to the last root object.

This removes the hard-coded default route of 'mine', which will only work in deployments where the 'My Items' plugin is installed.