### PR TITLE
Force digest on compilation of overlay template

### DIFF
--- a/platform/commonUI/dialog/src/OverlayService.js
+++ b/platform/commonUI/dialog/src/OverlayService.js
@@ -92,13 +92,13 @@ define(
             scope.overlay = overlayModel;
             scope.key = key;
             scope.typeClass = typeClass || 't-dialog';
-
-            // Create the overlay element and add it to the document's body
-            element = this.$compile(TEMPLATE)(scope);
-            
-            // Append so that most recent dialog is last in DOM. This means the most recent dialog will be on top when
-            // multiple overlays with the same z-index are active.
-            this.findBody().append(element);
+            scope.$apply(() => {
+                // Create the overlay element and add it to the document's body
+                element = this.$compile(TEMPLATE)(scope);
+                // Append so that most recent dialog is last in DOM. This means the most recent dialog will be on top when
+                // multiple overlays with the same z-index are active.
+                this.findBody().append(element);
+            })
 
             return {
                 dismiss: dismiss


### PR DESCRIPTION
Should prevent uncompiled templates from briefly appearing when properties dialogs are displayed.