### PR TITLE
Tree Performance Fixes

### DIFF
--- a/src/styles-new/_controls.scss
+++ b/src/styles-new/_controls.scss
@@ -148,8 +148,6 @@ button {
             display: block;
             font-family: symbolsfont;
             font-size: 1rem * $s;
-            transform-origin: center;
-            transition: $transOut;
         }
     }
 

--- a/src/ui/components/ObjectLabel.vue
+++ b/src/ui/components/ObjectLabel.vue
@@ -59,7 +59,8 @@ export default {
             default() {
                 return [];
             }
-        }
+        },
+        navigateToPath: String
     },
     data() {
         return {

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -211,7 +211,8 @@
                                 return {
                                     id: this.openmct.objects.makeKeyString(c.identifier),
                                     object: c,
-                                    objectPath: [c]
+                                    objectPath: [c],
+                                    navigateToParent: '/browse'
                             };
                         });
                     });

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -7,7 +7,8 @@
                           v-model="expanded">
             </view-control>
             <object-label :domainObject="node.object"
-                          :objectPath="node.objectPath">
+                          :objectPath="node.objectPath"
+                          :navigateToPath="navigateToPath">
             </object-label>
         </div>
         <ul v-if="expanded" class="c-tree">
@@ -36,13 +37,12 @@
             node: Object
         },
         data() {
-            this.pathToObject = this.buildPathString(this.node.objectPath);
-
+            this.navigateToPath = this.buildPathString(this.node.navigateToParent)
             return {
                 hasChildren: false,
                 isLoading: false,
                 loaded: false,
-                isNavigated: this.pathToObject === this.openmct.router.currentLocation.path,
+                isNavigated: this.navigateToPath === this.openmct.router.currentLocation.path,
                 children: [],
                 expanded: false
             }
@@ -103,7 +103,8 @@
                 this.children.push({
                     id: this.openmct.objects.makeKeyString(child.identifier),
                     object: child,
-                    objectPath: [child].concat(this.node.objectPath)
+                    objectPath: [child].concat(this.node.objectPath),
+                    navigateToParent: this.navigateToPath
                 });
             },
             removeChild(identifier) {
@@ -115,15 +116,13 @@
                 this.isLoading = false;
                 this.loaded = true;
             },
-            buildPathString(path) {
-                return '/browse/' + path.map(o => o && this.openmct.objects.makeKeyString(o.identifier))
-                    .reverse()
-                    .join('/');
+            buildPathString(parentPath) {
+                return [parentPath, this.openmct.objects.makeKeyString(this.node.object.identifier)].join('/');
             },
             highlightIfNavigated(newPath, oldPath){
-                if (newPath === this.pathToObject) {
+                if (newPath === this.navigateToPath) {
                     this.isNavigated = true;
-                } else if (oldPath === this.pathToObject) {
+                } else if (oldPath === this.navigateToPath) {
                     this.isNavigated = false;
                 }
             }

--- a/src/ui/mixins/object-link.js
+++ b/src/ui/mixins/object-link.js
@@ -13,6 +13,9 @@ export default {
             if (!this.objectPath.length) {
                 return;
             }
+            if (this.navigateToPath) {
+                return '#' + this.navigateToPath;
+            }
             return '#/browse/' + this.objectPath
                 .map(o => o && this.openmct.objects.makeKeyString(o.identifier))
                 .reverse()


### PR DESCRIPTION
Some small changes that improve tree performance

1. Removes the transition on the expand/collapse arrow 
2. Reduces the number of times that the navigation path to a tree object is recalculated.