### PR TITLE
Cancel editing bug

### DIFF
--- a/src/api/Editor.js
+++ b/src/api/Editor.js
@@ -79,9 +79,11 @@ export default class Editor extends EventEmitter {
      * @private
      */
     cancel() {
-        this.getTransactionService().cancel();
+        let cancelPromise = this.getTransactionService().cancel();
         this.editing = false;
         this.emit('isEditing', false);
+
+        return cancelPromise;
     }
 
     /**

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -118,9 +118,11 @@ const PLACEHOLDER_OBJECT = {};
                             label: 'Ok',
                             emphasis: true,
                             callback: () => {
-                                this.openmct.editor.cancel();
+                                this.openmct.editor.cancel().then(() => {
+                                    //refresh object view
+                                    this.openmct.layout.$refs.browseObject.show(this.domainObject, this.viewKey, false);
+                                });
                                 dialog.dismiss();
-                                this.openmct.layout.$refs.browseObject.updateView(false);
                             }
                         },
                         {
@@ -225,10 +227,18 @@ const PLACEHOLDER_OBJECT = {};
         },
         watch: {
             domainObject() {
-                console.log('Domain object updated!');
+                if (this.mutationObserver) {
+                    this.mutationObserver();
+                }
+                this.mutationObserver = this.openmct.objects.observe(this.domainObject, '*', (domainObject) => {
+                    this.domainObject = domainObject;
+                });
             }
         },
         beforeDestroy: function () {
+            if (this.mutationObserver) {
+                this.mutationObserver();
+            }
             document.removeEventListener('click', this.closeViewAndSaveMenu);
             window.removeEventListener('click', this.promptUserbeforeNavigatingAway);
         }

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -120,6 +120,7 @@ const PLACEHOLDER_OBJECT = {};
                             callback: () => {
                                 this.openmct.editor.cancel();
                                 dialog.dismiss();
+                                this.openmct.layout.$refs.browseObject.updateView(false);
                             }
                         },
                         {
@@ -221,6 +222,11 @@ const PLACEHOLDER_OBJECT = {};
             this.openmct.editor.on('isEditing', (isEditing) => {
                 this.isEditing = isEditing;
             });
+        },
+        watch: {
+            domainObject() {
+                console.log('Domain object updated!');
+            }
         },
         beforeDestroy: function () {
             document.removeEventListener('click', this.closeViewAndSaveMenu);


### PR DESCRIPTION
This fixes an issue where if composition changes were made to an object, and then cancelled, the object could in some cases return to a previous version of the object, not not necessarily the persisted version.

This change ensures that the object view is refreshed with the persisted model on cancellation.