### PR TITLE
Remove wait spinners when error occurs in tables

### DIFF
--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -143,6 +143,7 @@ define([
 
                     let telemetryRows = telemetryData.map(datum => new TelemetryTableRow(datum, columnMap, keyString, limitEvaluator));
                     this.boundedRows.add(telemetryRows);
+                }).finally(() => {
                     this.decrementOutstandingRequests();
                 });
         }


### PR DESCRIPTION
Makes tables a little more resilient to errors in the telemetry adapter. Will cancel the loading spinner if promise is rejected.