### PR TITLE
Retain scrolltop on resize

### DIFF
--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -588,13 +588,18 @@ export default {
             let el = this.$el;
             let width = el.clientWidth;
             let height = el.clientHeight;
+            let scrollTop = this.scrollable.scrollTop;
 
             this.resizePollHandle = setInterval(() => {
                 if ((el.clientWidth !== width || el.clientHeight !== height) && this.isAutosizeEnabled) {
                     this.calculateTableSize();
+                    // On some resize events scrollTop is reset to 0. Possibly due to a transition we're using?
+                    // Need to preserve scroll position in this case.
+                    this.scrollable.scrollTop = scrollTop;
                     width = el.clientWidth;
                     height = el.clientHeight;
                 }
+                scrollTop = this.scrollable.scrollTop;
             }, RESIZE_POLL_INTERVAL);
         },
 


### PR DESCRIPTION
Fixes an issue with tables where rows would disappear in two situations -
1. When a table in a display layout was viewed large
2. When a table in a flexible layout column that was then reordered.

Issue is because these two events, for whatever reason, sometimes result in the table's 'scrolltop' being reset to 0 without a scroll event being triggered. Tables rely on scroll events to draw the correct rows.

Fix is to retain scrollTop on resize.