### PR TITLE
Do not use Object.create() with Vueified objects

### DIFF
--- a/platform/commonUI/edit/src/actions/PropertiesDialog.js
+++ b/platform/commonUI/edit/src/actions/PropertiesDialog.js
@@ -49,7 +49,7 @@ define(
                     name: "Properties",
                     rows: this.properties.map(function (property, index) {
                         // Property definition is same as form row definition
-                        var row = Object.create(property.getDefinition());
+                        var row = JSON.parse(JSON.stringify(property.getDefinition()));
                         row.key = index;
                         return row;
                     }).filter(function (row) {

--- a/platform/commonUI/edit/src/creation/CreateWizard.js
+++ b/platform/commonUI/edit/src/creation/CreateWizard.js
@@ -66,7 +66,7 @@ define(
                 name: "Properties",
                 rows: this.properties.map(function (property, index) {
                     // Property definition is same as form row definition
-                    var row = Object.create(property.getDefinition());
+                    var row = JSON.parse(JSON.stringify(property.getDefinition()));
 
                     // Use index as the key into the formValue;
                     // this correlates to the indexing provided by


### PR DESCRIPTION
This was causing Datasets to not persist URLs sometimes. It resulted in a HORRIBLE bug whereby sometimes object type definition keys would be overwritten with an index, resulting in properties defined in a properties dialog being saved on the object using an index instead of a key.

`Object.create` creates a new object instance and sets the prototype to the object passed in. With basic objects with properties this works fine, overwriting properties values (such as `key`) overwrites it on the child, and not on the prototype object (the original object).

With a Vueified object, you're actually calling a setter function when you set a value. These setter functions are defined on the parent object and inherited by any children. So, the code below was calling Vue reactive handling which seemed to result in `key` being set to an index in the Type property passed in, as well as the local copy being used by the dialogs, resulting in properties being stored using an index as a key, instead of the key itself.