### PR TITLE
Toolbar issues in Flexible layout

### DIFF
--- a/src/plugins/flexibleLayout/components/flexibleLayout.vue
+++ b/src/plugins/flexibleLayout/components/flexibleLayout.vue
@@ -571,8 +571,7 @@ export default {
             });
         },
         setSelectionToParent() {
-             let currentSelection = this.openmct.selection.selected;
-             this.openmct.selection.select(currentSelection.slice(1));
+            this.$el.click();
         },
         allowContainerDrop(event, index) {
             if (!event.dataTransfer.types.includes('containerid')) {

--- a/src/plugins/flexibleLayout/components/frame.vue
+++ b/src/plugins/flexibleLayout/components/frame.vue
@@ -79,12 +79,14 @@ export default {
         },
         setSelection() {
             this.$nextTick(function () {
-                let childContext = this.$refs.objectFrame.getSelectionContext();
-                childContext.item = this.domainObject;
-                childContext.type = 'frame';
-                childContext.frameId = this.frame.id;
-                this.unsubscribeSelection = this.openmct.selection.selectable(
-                    this.$refs.frame, childContext, false);
+                if (this.$refs && this.$refs.objectFrame) {
+                    let childContext = this.$refs.objectFrame.getSelectionContext();
+                    childContext.item = this.domainObject;
+                    childContext.type = 'frame';
+                    childContext.frameId = this.frame.id;
+                    this.unsubscribeSelection = this.openmct.selection.selectable(
+                        this.$refs.frame, childContext, false);
+                }
             });
         },
         initDrag(event) {

--- a/src/plugins/flexibleLayout/toolbarProvider.js
+++ b/src/plugins/flexibleLayout/toolbarProvider.js
@@ -46,9 +46,7 @@ function ToolbarProvider(openmct) {
                 separator;
 
             separator = {
-                control: "separator",
-                domainObject: primary.context.item,
-                key: "separator"
+                control: "separator"
             };
 
             toggleContainer = {
@@ -203,7 +201,7 @@ function ToolbarProvider(openmct) {
             let toolbar = [
                 toggleContainer,
                 addContainer,
-                toggleFrame ? separator: undefined,
+                toggleFrame ? separator : undefined,
                 toggleFrame,
                 deleteFrame || deleteContainer ? separator : undefined,
                 deleteFrame,


### PR DESCRIPTION
- Modify toolbar to support items with no applicableSelectedItems property.
- Remove calls to Selection API's private methods and click the element directly instead. 
