### PR TITLE
Reset selection on cancel

### DIFF
--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -121,7 +121,7 @@ const PLACEHOLDER_OBJECT = {};
                             callback: () => {
                                 this.openmct.editor.cancel().then(() => {
                                     //refresh object view
-                                    this.openmct.layout.$refs.browseObject.show(this.domainObject, this.viewKey, false);
+                                    this.openmct.layout.$refs.browseObject.show(this.domainObject, this.viewKey, true);
                                 });
                                 dialog.dismiss();
                             }


### PR DESCRIPTION
This fixes an issue in flex layouts with selecting something previously deleted and then restored via cancellation of editing.