### PR TITLE
Summary widget unsubscribe

### DIFF
--- a/src/plugins/summaryWidget/src/ConditionManager.js
+++ b/src/plugins/summaryWidget/src/ConditionManager.js
@@ -237,6 +237,7 @@ define ([
         });
         delete this.compositionObjs[objectId];
         this.subscriptions[objectId](); //unsubscribe from telemetry source
+        delete this.subscriptions[objectId];
         this.eventEmitter.emit('remove', identifier);
 
         if (_.isEmpty(this.compositionObjs)) {

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
@@ -43,7 +43,7 @@ define([
         return evaluator.requestLatest(options)
             .then(function (latestDatum) {
                 this.pool.release(evaluator);
-                return [latestDatum];
+                return latestDatum ? [latestDatum] : [];
             }.bind(this));
     };
 

--- a/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
+++ b/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
@@ -52,7 +52,10 @@ define([
             strategy: 'latest',
             size: 1
         }).then(function (results) {
-            if (this.destroyed || this.hasUpdated || this.renderTracker !== renderTracker) {
+            if (this.destroyed ||
+                this.hasUpdated ||
+                this.renderTracker !== renderTracker ||
+                results.length === 0) {
                 return;
             }
             this.updateState(results[results.length - 1]);


### PR DESCRIPTION
This fixes two issues in summary widgets:
- Subscription handle was not being cleaned up when an object was removed from a summary widget, which resulted in an error when the view was destroyed due to the view calling the subscriber twice.
- The summary widget telemetry provider would sometimes return an 'undefined' value, which would result in an error when rendering of the rule was attempted.