### PR TITLE
Leave edit mode on navigation after removal

### DIFF
--- a/src/plugins/remove/RemoveAction.js
+++ b/src/plugins/remove/RemoveAction.js
@@ -85,6 +85,9 @@ export default class RemoveAction {
         );
 
         this.openmct.objects.mutate(parent, 'composition', composition);
+        if (this.openmct.editor.isEditing()) {
+            this.openmct.editor.save();
+        }
     }
 
     appliesTo(objectPath) {


### PR DESCRIPTION
When removing an object that is also the currently navigated object, or a parent of it, will result in navigation to the first remaining parent. In this case, the application should leave edit mode.