### PR TITLE
Fixes some issues relating to removal of objects

### DIFF
--- a/src/plugins/filters/components/FiltersView.vue
+++ b/src/plugins/filters/components/FiltersView.vue
@@ -23,17 +23,18 @@ export default {
         FilterObject
     },
     inject: [
-        'openmct',
-        'providedObject'
+        'openmct'
     ],
     data() {
+        let providedObject = this.openmct.selection.get()[0][0].context.item;
         let persistedFilters = {};
 
-        if (this.providedObject.configuration && this.providedObject.configuration.filters) {
-            persistedFilters = this.providedObject.configuration.filters;
+        if (providedObject.configuration && providedObject.configuration.filters) {
+            persistedFilters = providedObject.configuration.filters;
         }
 
         return {
+            providedObject,
             persistedFilters,
             children: {}
         }
@@ -73,13 +74,14 @@ export default {
         this.composition.on('add', this.addChildren);
         this.composition.on('remove', this.removeChildren);
         this.composition.load();
-
         this.unobserve = this.openmct.objects.observe(this.providedObject, 'configuration.filters', this.updatePersistedFilters);
+        this.unobserveAllMutation = this.openmct.objects.observe(this.providedObject, '*', (mutatedObject) => this.providedObject = mutatedObject);
     },
     beforeDestroy() {
         this.composition.off('add', this.addChildren);
         this.composition.off('remove', this.removeChildren);
         this.unobserve();
+        this.unobserveAllMutation();
     }
 }
 </script>

--- a/src/plugins/filters/filtersInspectorViewProvider.js
+++ b/src/plugins/filters/filtersInspectorViewProvider.js
@@ -42,14 +42,11 @@ define([
             },
             view: function (selection) {
                 let component;
-                let providedObject = selection[0][0].context.item;
-
                 return {
                     show: function (element) {
                         component = new Vue({
                             provide: {
-                                openmct,
-                                providedObject
+                                openmct
                             },
                             components: {
                                 FiltersView: FiltersView.default

--- a/src/plugins/remove/RemoveAction.js
+++ b/src/plugins/remove/RemoveAction.js
@@ -85,7 +85,8 @@ export default class RemoveAction {
         );
 
         this.openmct.objects.mutate(parent, 'composition', composition);
-        if (this.openmct.editor.isEditing()) {
+
+        if (this.inNavigationPath(child) && this.openmct.editor.isEditing()) {
             this.openmct.editor.save();
         }
     }

--- a/src/plugins/remove/RemoveAction.js
+++ b/src/plugins/remove/RemoveAction.js
@@ -85,6 +85,9 @@ export default class RemoveAction {
         );
 
         this.openmct.objects.mutate(parent, 'composition', composition);
+        if (this.openmct.editor.isEditing()) {
+            this.openmct.editor.save();
+        }
     }
 
     appliesTo(objectPath) {

--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -137,6 +137,10 @@ define([
             let requestOptions = this.buildOptionsFromConfiguration(telemetryObject);
             return this.openmct.telemetry.request(telemetryObject, requestOptions)
                 .then(telemetryData => {
+                    //Check that telemetry object has not been removed since telemetry was requested.
+                    if (!this.telemetryObjects.includes(telemetryObject)) {
+                        return;
+                    }
                     let keyString = this.openmct.objects.makeKeyString(telemetryObject.identifier);
                     let columnMap = this.getColumnMapForObject(keyString);
                     let limitEvaluator = this.openmct.telemetry.limitEvaluator(telemetryObject);
@@ -194,6 +198,10 @@ define([
             let limitEvaluator = this.openmct.telemetry.limitEvaluator(telemetryObject);
 
             this.subscriptions[keyString] = this.openmct.telemetry.subscribe(telemetryObject, (datum) => {
+                //Check that telemetry object has not been removed since telemetry was requested.
+                if (!this.telemetryObjects.includes(telemetryObject)) {
+                    return;
+                }
                 this.boundedRows.add(new TelemetryTableRow(datum, columnMap, keyString, limitEvaluator));
             }, subscribeOptions);
         }


### PR DESCRIPTION
* If removing the currently navigated object, leave edit mode (by saving changes)
* Filter view should not mutate domain object with out of date object model. This causes erroneous composition events.
* Fixes a race condition in TelemetryTables where a child can be removed in between when telemetry is requested, and when it is received.