### PR TITLE
Only switch into edit mode if view is editable

### DIFF
--- a/src/api/Editor.js
+++ b/src/api/Editor.js
@@ -28,11 +28,6 @@ export default class Editor extends EventEmitter {
         super();
         this.editing = false;
         this.openmct = openmct;
-        document.addEventListener('drop', (event) => {
-            if (!this.isEditing()) {
-                this.edit();
-            }
-        }, {capture: true});
     }
 
     /**


### PR DESCRIPTION
Change to drag-and-drop to edit logic -
1. Moved from Editor API to objectView so that it has access to the current view provider
2. Checks if current view is editable.