### PR TITLE
[SNAPSHOT]: add translation for undo in notebook

### DIFF
--- a/platform/features/notebook/src/actions/AnnotateSnapshot.js
+++ b/platform/features/notebook/src/actions/AnnotateSnapshot.js
@@ -88,7 +88,7 @@ define(
                                 tools: {
                                     undo: 'Undo'
                                 }
-                            },
+                            }
                         },
                         saveHandler: function (image, done) {
                             if (save) {

--- a/platform/features/notebook/src/actions/AnnotateSnapshot.js
+++ b/platform/features/notebook/src/actions/AnnotateSnapshot.js
@@ -84,8 +84,11 @@ define(
                                 lineWidth: 'Size',
                                 textColor: 'Color',
                                 fontSize: 'Size',
-                                fontStyle: 'Style'
-                            }
+                                fontStyle: 'Style',
+                                tools: {
+                                    undo: 'Undo'
+                                }
+                            },
                         },
                         saveHandler: function (image, done) {
                             if (save) {


### PR DESCRIPTION
#1970

<img width="1680" alt="Skjermbilde 2019-04-11 kl  14 04 37" src="https://user-images.githubusercontent.com/16735925/55955891-e761af80-5c62-11e9-9e29-7822d81a4015.png">

Toolbox for undo isn't translated by default so we add them manually https://github.com/ivictbor/painterro/blob/a30be9ebc22b9f8bfd1929e4a9c8b837b87b66df/langs/en.lang.js#L42-L59

# Author Checklist
Changes address original issue?
Yes

# Unit tests included and/or updated with changes?
N/A

# Command line build passes?
Yes

# Changes have been smoke-tested?
Yes

