### PR TITLE
Misc Fixes 3

### DIFF
--- a/platform/commonUI/dialog/res/templates/notification-message.html
+++ b/platform/commonUI/dialog/res/templates/notification-message.html
@@ -9,17 +9,17 @@
                          ng-model="ngModel"
                          ng-show="ngModel.progressPerc !== undefined"></mct-include>
         </div>
-        <div class="c-overlay__button-bar">
-            <button ng-repeat="dialogOption in ngModel.options"
+    </div>
+    <div class="c-overlay__button-bar">
+        <button ng-repeat="dialogOption in ngModel.options"
                 class="c-button"
                 ng-click="dialogOption.callback()">
-                    {{dialogOption.label}}
-            </button>
-            <button class="c-button c-button--major"
+            {{dialogOption.label}}
+        </button>
+        <button class="c-button c-button--major"
                 ng-if="ngModel.primaryOption"
                 ng-click="ngModel.primaryOption.callback()">
-                    {{ngModel.primaryOption.label}}
-            </button>
-        </div>
+            {{ngModel.primaryOption.label}}
+        </button>
     </div>
 </div>

--- a/src/api/overlays/components/OverlayComponent.vue
+++ b/src/api/overlays/components/OverlayComponent.vue
@@ -92,6 +92,7 @@
             display: flex;
             flex-direction: column;
             flex: 1 1 auto;
+            height: 0; // Chrome 73 overflow bug fix
             overflow: auto;
             padding-right: $interiorMargin; // fend off scroll bar
         }

--- a/src/styles-new/_about.scss
+++ b/src/styles-new/_about.scss
@@ -54,10 +54,11 @@
 
     &:after {
         // App logo
-        top: 0;
-        right: 15%;
-        bottom: 0;
-        left: 15%;
+        $d: 25%;
+        top: $d;
+        right: $d;
+        bottom: $d;
+        left: $d;
     }
 }
 
@@ -75,12 +76,20 @@
 
     &__image,
     &__text {
-        height: 50%;
-        flex: 1 1 0;
+        flex: 1 1 auto;
+    }
+
+    &__image {
+        height: 35%;
     }
 
     &__text {
+        height: 65%;
         overflow: auto;
+        > * + * {
+            border-top: 1px solid $colorInteriorBorder;
+            margin-top: 1em;
+        }
     }
 
     &--licenses {
@@ -107,7 +116,7 @@
 
     h1, h2, h3 {
         font-weight: normal;
-        margin-bottom: 1em;
+        margin-bottom: .25em;
     }
 
     h1 {

--- a/src/styles-new/core.scss
+++ b/src/styles-new/core.scss
@@ -33,3 +33,4 @@
 @import "table";
 @import "legacy";
 @import "legacy-plots";
+@import "legacy-messages";

--- a/src/ui/layout/AboutDialog.vue
+++ b/src/ui/layout/AboutDialog.vue
@@ -1,23 +1,24 @@
 <template>
 <div class="c-about c-about--splash">
-    <div v-if="!branding.aboutHtml" class="c-about__image c-splash-image"></div>
-
+    <div class="c-about__image c-splash-image"></div>
     <div class="c-about__text s-text">
-        <div v-if="branding.aboutHtml" class="s-text l-content" v-html="branding.aboutHtml"></div>
-        <h1 class="l-title s-title">Open MCT</h1>
-        <div class="l-description s-description">
-	        <p>Open MCT, Copyright &copy; 2014-2019, United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All rights reserved.</p>
-	        <p>Open MCT is licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at <a target="_blank" href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.</p>
-	        <p>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</p>
-	        <p>Open MCT includes source code licensed under additional open source licenses. See the Open Source Licenses file included with this distribution or <a @click="showLicenses">click here for third party licensing information</a>.</p>
+        <div class="c-about__text__element" v-if="branding.aboutHtml" v-html="branding.aboutHtml"></div>
+        <div class="c-about__text__element">
+            <h1 class="l-title s-title">Open MCT</h1>
+            <div class="l-description s-description">
+                <p>Open MCT, Copyright &copy; 2014-2019, United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All rights reserved.</p>
+                <p>Open MCT is licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at <a target="_blank" href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>.</p>
+                <p>Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.</p>
+                <p>Open MCT includes source code licensed under additional open source licenses. See the Open Source Licenses file included with this distribution or <a @click="showLicenses">click here for third party licensing information</a>.</p>
+            </div>
+            <h2>Version Information</h2>
+            <ul class="t-info l-info s-info">
+                <li>Version: {{buildInfo.version || 'Unknown'}}</li>
+                <li>Build Date: {{buildInfo.buildDate || 'Unknown'}}</li>
+                <li>Revision: {{buildInfo.revision || 'Unknown'}}</li>
+                <li>Branch: {{buildInfo.branch || 'Unknown'}}</li>
+            </ul>
         </div>
-        <h2>Version Information</h2>
-        <ul class="t-info l-info s-info">
-            <li>Version: {{buildInfo.version || 'Unknown'}}</li>
-            <li>Build Date: {{buildInfo.buildDate || 'Unknown'}}</li>
-            <li>Revision: {{buildInfo.revision || 'Unknown'}}</li>
-            <li>Branch: {{buildInfo.branch || 'Unknown'}}</li>
-        </ul>
     </div>
 </div>
 </template>


### PR DESCRIPTION
Required by VISTA branch `fix-overflow-3` https://github.com/akhenry/VISTA/pull/46

### Changes
- Fix Chrome 73 bug in overlay __contents-main element;
- Fixed messages by including erroneously missing _legacy-messages.scss file;
- Better layout for messages in notification overlay list;
- Fix About screen for better compatibility with VISTA;
- Better logo sizing in About splash element;

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
