### PR TITLE
Remove deprecation warnings

### DIFF
--- a/platform/commonUI/edit/src/capabilities/EditorCapability.js
+++ b/platform/commonUI/edit/src/capabilities/EditorCapability.js
@@ -64,7 +64,6 @@ define(
          * @returns boolean
          */
         EditorCapability.prototype.inEditContext = function () {
-            console.warn('DEPRECATION WARNING: isEditing checks must be done via openmct.editor.');
             return this.openmct.editor.isEditing();
         };
 
@@ -74,7 +73,6 @@ define(
          * @returns {*}
          */
         EditorCapability.prototype.isEditContextRoot = function () {
-            console.warn('DEPRECATION WARNING: isEditing checks must be done via openmct.editor.');
             return this.openmct.editor.isEditing();
         };
 


### PR DESCRIPTION
This is causing excessive warnings in plots making debugging difficult.

The issue stems from the fact that the markup for plots includes a check to see if the object is being edited that involves a function call, so it is checked on every digest. The `TickerService` associated with clocks causes digests to happen at one second intervals.