### PR TITLE
Plots issues for 4.1.1

### DIFF
--- a/src/plugins/plot/src/configuration/Collection.js
+++ b/src/plugins/plot/src/configuration/Collection.js
@@ -113,13 +113,21 @@ define([
         );
     };
 
-    Collection.prototype.remove = function (model) {
-        var index = this.indexOf(model);
-        if (index === -1) {
-            throw new Error('model not found in collection.');
+    Collection.prototype.remove = function (model, identifier) {
+        var index;
+
+        if (!model) {
+            index = _.findIndex(this.models, function (m) {
+                return _.isEqual(m.domainObject.identifier, identifier);
+            });
+        } else {
+            index = this.indexOf(model);
+            if (index === -1) {
+                throw new Error('model not found in collection.');
+            }
+            this.emit('remove', model, index);
         }
         this.models.splice(index, 1);
-        this.emit('remove', model, index);
     };
 
     Collection.prototype.destroy = function (model) {

--- a/src/plugins/plot/src/configuration/Collection.js
+++ b/src/plugins/plot/src/configuration/Collection.js
@@ -113,19 +113,11 @@ define([
         );
     };
 
-    Collection.prototype.remove = function (model, identifier) {
-        var index;
+    Collection.prototype.remove = function (model) {
+        var index = this.indexOf(model);
 
-        if (!model) {
-            index = _.findIndex(this.models, function (m) {
-                return _.isEqual(m.domainObject.identifier, identifier);
-            });
-            model = this.models[index];
-        } else {
-            index = this.indexOf(model);
-            if (index === -1) {
-                throw new Error('model not found in collection.');
-            }
+        if (index === -1) {
+            throw new Error('model not found in collection.');
         }
 
         this.emit('remove', model, index);

--- a/src/plugins/plot/src/configuration/Collection.js
+++ b/src/plugins/plot/src/configuration/Collection.js
@@ -120,13 +120,15 @@ define([
             index = _.findIndex(this.models, function (m) {
                 return _.isEqual(m.domainObject.identifier, identifier);
             });
+            model = this.models[index];
         } else {
             index = this.indexOf(model);
             if (index === -1) {
                 throw new Error('model not found in collection.');
             }
-            this.emit('remove', model, index);
         }
+
+        this.emit('remove', model, index);
         this.models.splice(index, 1);
     };
 

--- a/src/plugins/plot/src/configuration/SeriesCollection.js
+++ b/src/plugins/plot/src/configuration/SeriesCollection.js
@@ -103,7 +103,7 @@ define([
                 var index = _.findIndex(plotObject.configuration.series, function (s) {
                     return _.isEqual(identifier, s.identifier);
                 });
-                this.remove(this.at(index));
+                this.remove(this.at(index), identifier);
                 // Because this is triggered by a composition change, we have
                 // to defer mutation of our plot object, otherwise we might
                 // mutate an outdated version of the plotObject.

--- a/src/plugins/plot/src/configuration/SeriesCollection.js
+++ b/src/plugins/plot/src/configuration/SeriesCollection.js
@@ -109,6 +109,10 @@ define([
                     return _.isEqual(m.domainObject.identifier, identifier);
                 });
 
+                /*
+                    when cancelling out of edit mode, the config store and domain object are out of sync
+                    thus it is necesarry to check both and remove the models that are no longer in composition
+                */
                 if (persistedIndex === -1) {
                     this.remove(this.at(configIndex));
                 } else {

--- a/src/plugins/plot/src/configuration/SeriesCollection.js
+++ b/src/plugins/plot/src/configuration/SeriesCollection.js
@@ -97,6 +97,24 @@ define([
                 filters: filters
             }));
         },
+        remove: function (model, identifier) {
+            var index;
+
+            if (!model) {
+                index = _.findIndex(this.models, function (m) {
+                    return _.isEqual(m.domainObject.identifier, identifier);
+                });
+                model = this.models[index];
+            } else {
+                index = this.indexOf(model);
+                if (index === -1) {
+                    throw new Error('model not found in collection.');
+                }
+            }
+
+            this.emit('remove', model, index);
+            this.models.splice(index, 1);
+        },
         removeTelemetryObject: function (identifier) {
             var plotObject = this.plot.get('domainObject');
             if (plotObject.type === 'telemetry.plot.overlay') {

--- a/src/plugins/plot/src/configuration/configStore.js
+++ b/src/plugins/plot/src/configuration/configStore.js
@@ -25,23 +25,11 @@ define([
 
     function ConfigStore() {
         this.store = {};
-        this.tracking = {};
     }
 
-    ConfigStore.prototype.track = function (id) {
-        if (!this.tracking[id]) {
-            this.tracking[id] = 0;
-        }
-        this.tracking[id] += 1;
-    };
-
-    ConfigStore.prototype.untrack = function (id) {
-        this.tracking[id] -= 1;
-        if (this.tracking[id] <= 0) {
-            delete this.tracking[id];
-            this.store[id].destroy();
-            delete this.store[id];
-        }
+    ConfigStore.prototype.deleteStore = function (id) {
+        this.store[id].destroy();
+        delete this.store[id];
     };
 
     ConfigStore.prototype.add = function (id, config) {

--- a/src/plugins/plot/src/inspector/PlotOptionsController.js
+++ b/src/plugins/plot/src/inspector/PlotOptionsController.js
@@ -49,8 +49,6 @@ define([
     };
 
     PlotOptionsController.prototype.destroy = function () {
-        configStore.untrack(this.configId);
-
         this.stopListening();
         this.unlisten();
     };
@@ -61,7 +59,7 @@ define([
             this.$timeout(this.setUpScope.bind(this));
             return;
         }
-        configStore.track(this.configId);
+
         this.config = this.$scope.config = config;
         this.$scope.plotSeries = [];
 

--- a/src/plugins/plot/src/inspector/PlotOptionsController.js
+++ b/src/plugins/plot/src/inspector/PlotOptionsController.js
@@ -49,7 +49,10 @@ define([
     };
 
     PlotOptionsController.prototype.destroy = function () {
+        //untrack twice to offset strange timing issue
         configStore.untrack(this.configId);
+        configStore.untrack(this.configId);
+
         this.stopListening();
         this.unlisten();
     };

--- a/src/plugins/plot/src/inspector/PlotOptionsController.js
+++ b/src/plugins/plot/src/inspector/PlotOptionsController.js
@@ -49,8 +49,6 @@ define([
     };
 
     PlotOptionsController.prototype.destroy = function () {
-        //untrack twice to offset strange timing issue
-        configStore.untrack(this.configId);
         configStore.untrack(this.configId);
 
         this.stopListening();

--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -282,11 +282,19 @@ define([
     };
 
     MCTPlotController.prototype.zoom = function (zoomDirection, zoomFactor) {
+        var currentXaxis = this.$scope.xAxis.get('displayRange'),
+            currentYaxis = this.$scope.yAxis.get('displayRange');
+
+        // when there is no plot data, the ranges can be undefined
+        // in which case we should not perform zoom
+        if (!currentXaxis || !currentYaxis) {
+            return;
+        }
+
         this.freeze();
         this.trackHistory();
-        var currentXaxis = this.$scope.xAxis.get('displayRange'),
-            currentYaxis = this.$scope.yAxis.get('displayRange'),
-            xAxisDist= (currentXaxis.max - currentXaxis.min) * zoomFactor,
+
+        var xAxisDist= (currentXaxis.max - currentXaxis.min) * zoomFactor,
             yAxisDist = (currentYaxis.max - currentYaxis.min) * zoomFactor;
 
         if (zoomDirection === 'in') {
@@ -325,6 +333,8 @@ define([
         let xDisplayRange = this.$scope.xAxis.get('displayRange'),
             yDisplayRange = this.$scope.yAxis.get('displayRange');
 
+        // when there is no plot data, the ranges can be undefined
+        // in which case we should not perform zoom
         if (!xDisplayRange || !yDisplayRange) {
             return;
         }

--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -322,12 +322,17 @@ define([
             return;
         }
 
+        let xDisplayRange = this.$scope.xAxis.get('displayRange'),
+            yDisplayRange = this.$scope.yAxis.get('displayRange');
+
+        if (!xDisplayRange || !yDisplayRange) {
+            return;
+        }
+
         this.freeze();
         window.clearTimeout(this.stillZooming);
 
-        let xDisplayRange = this.$scope.xAxis.get('displayRange'),
-            yDisplayRange = this.$scope.yAxis.get('displayRange'),
-            xAxisDist = (xDisplayRange.max - xDisplayRange.min),
+        let xAxisDist = (xDisplayRange.max - xDisplayRange.min),
             yAxisDist = (yDisplayRange.max - yDisplayRange.min),
             xDistMouseToMax = xDisplayRange.max - this.positionOverPlot.x,
             xDistMouseToMin = this.positionOverPlot.x - xDisplayRange.min,

--- a/src/plugins/plot/src/telemetry/PlotController.js
+++ b/src/plugins/plot/src/telemetry/PlotController.js
@@ -148,7 +148,6 @@ define([
             });
             configStore.add(configId, config);
         }
-        configStore.track(configId);
         return config;
     };
 
@@ -157,7 +156,8 @@ define([
     };
 
     PlotController.prototype.destroy = function () {
-        configStore.untrack(this.config.id);
+        configStore.deleteStore(this.config.id);
+
         this.stopListening();
         if (this.checkForSize) {
             clearInterval(this.checkForSize);


### PR DESCRIPTION
1. Fixes bug where plots were not getting discarded properly.
2. Fixes issue where user can zoom into plots when there is no plot rendered, which was causing errors. 