### PR TITLE
[Summary Widget] Use installed time system's name...

### DIFF
--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -23,6 +23,7 @@
 define([
     'lodash',
     './utcTimeSystem/plugin',
+    './localTimeSystem/plugin',
     '../../example/generator/plugin',
     './autoflow/AutoflowTabularPlugin',
     './timeConductor/plugin',
@@ -46,6 +47,7 @@ define([
 ], function (
     _,
     UTCTimeSystem,
+    LocalTimeSystem,
     GeneratorPlugin,
     AutoflowPlugin,
     TimeConductorPlugin,
@@ -81,6 +83,7 @@ define([
     });
 
     plugins.UTCTimeSystem = UTCTimeSystem;
+    plugins.LocalTimeSystem = LocalTimeSystem;
 
     plugins.ImportExport = ImportExport;
 

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -38,7 +38,7 @@ define([
         return this.openmct.time.getAllTimeSystems().map(function (ts, i) {
             return {
                 key: ts.key,
-                name: 'UTC',
+                name: ts.name,
                 format: ts.timeFormat,
                 hints: {
                     domain: i
@@ -64,7 +64,7 @@ define([
             // Generally safe assumption is that we have one domain per timeSystem.
             values: this.getDomains().concat([
                 {
-                    name: 'state',
+                    name: 'State',
                     key: 'state',
                     source: 'ruleIndex',
                     format: 'enum',


### PR DESCRIPTION
...instead of naming all 'UTC'.

Also, capitalize 'Status' and add local time system to the 'plugins' object.

