### PR TITLE
Remove duplicate policy

### DIFF
--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -181,6 +181,9 @@ define([
      */
     CompositionCollection.prototype.add = function (child, skipMutate) {
         if (!skipMutate) {
+            if (!this.publicAPI.composition.checkPolicy(this.domainObject, child)) {
+                throw `Object of type ${child.type} cannot be added to object of type ${this.domainObject.type}`;
+            }
             this.provider.add(this.domainObject, child.identifier);
         } else {
             this.emit('add', child);

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -75,9 +75,7 @@ define([
             throw new Error('Event not supported by composition: ' + event);
         }
         if (!this.mutationListener) {
-            this.mutationListener = this.publicAPI.objects.observe(this.domainObject, '*', (newDomainObject) => {
-                this.domainObject = newDomainObject;
-            })
+            this._synchronize();
         }
         if (this.provider.on && this.provider.off) {
             if (event === 'add') {
@@ -135,8 +133,7 @@ define([
         this.listeners[event].splice(index, 1);
         if (this.listeners[event].length === 0) {
             if (this.mutationListener) {
-                this.mutationListener();
-                delete this.mutationListener;
+                this._destroy();
             }
             // Remove provider listener if this is the last callback to
             // be removed.
@@ -273,6 +270,17 @@ define([
      */
     CompositionCollection.prototype.onProviderRemove = function (child) {
         this.remove(child, true);
+    };
+
+    CompositionCollection.prototype._synchronize = function () {
+        this.mutationListener = this.publicAPI.objects.observe(this.domainObject, '*', (newDomainObject) => {
+            this.domainObject = JSON.parse(JSON.stringify(newDomainObject));
+        });
+    };
+
+    CompositionCollection.prototype._destroy = function () {
+        this.mutationListener();
+        delete this.mutationListener;
     };
 
     /**

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -132,9 +132,8 @@ define([
 
         this.listeners[event].splice(index, 1);
         if (this.listeners[event].length === 0) {
-            if (this.mutationListener) {
-                this._destroy();
-            }
+            this._destroy();
+
             // Remove provider listener if this is the last callback to
             // be removed.
             if (this.provider.off && this.provider.on) {
@@ -281,8 +280,8 @@ define([
     CompositionCollection.prototype._destroy = function () {
         if (this.mutationListener) {
             this.mutationListener();
+            delete this.mutationListener;
         }
-        delete this.mutationListener;
     };
 
     /**

--- a/src/api/composition/CompositionCollection.js
+++ b/src/api/composition/CompositionCollection.js
@@ -279,7 +279,9 @@ define([
     };
 
     CompositionCollection.prototype._destroy = function () {
-        this.mutationListener();
+        if (this.mutationListener) {
+            this.mutationListener();
+        }
         delete this.mutationListener;
     };
 

--- a/src/api/composition/DefaultCompositionProvider.js
+++ b/src/api/composition/DefaultCompositionProvider.js
@@ -196,10 +196,8 @@ define([
      * @private
      */
     DefaultCompositionProvider.prototype.includes = function (parent, childId) {
-        return parent.composition.findIndex(composee => {
-            return composee.namespace === childId.namespace &&
-                composee.key === childId.key;
-        }) !== -1;
+        return parent.composition.findIndex(composee =>
+            this.publicAPI.objects.areIdsEqual(composee, childId)) !== -1;
     };
 
     DefaultCompositionProvider.prototype.reorder = function (domainObject, oldIndex, newIndex) {

--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -331,6 +331,7 @@
                 this.openmct.objects.mutate(this.internalDomainObject, path, value);
             },
             handleDrop($event) {
+                console.log('drop');
                 if (!$event.dataTransfer.types.includes('openmct/domain-object-path')) {
                     return;
                 }
@@ -457,6 +458,7 @@
                 this.layoutItems.forEach(this.trackItem);
             },
             addChild(child) {
+                console.log('compose');
                 let identifier = this.openmct.objects.makeKeyString(child.identifier);
                 if (this.isTelemetry(child)) {
                     if (!this.telemetryViewMap[identifier]) {

--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -331,7 +331,6 @@
                 this.openmct.objects.mutate(this.internalDomainObject, path, value);
             },
             handleDrop($event) {
-                console.log('drop');
                 if (!$event.dataTransfer.types.includes('openmct/domain-object-path')) {
                     return;
                 }
@@ -458,7 +457,6 @@
                 this.layoutItems.forEach(this.trackItem);
             },
             addChild(child) {
-                console.log('compose');
                 let identifier = this.openmct.objects.makeKeyString(child.identifier);
                 if (this.isTelemetry(child)) {
                     if (!this.telemetryViewMap[identifier]) {

--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -112,6 +112,10 @@ export default {
                 delete this.removeSelectable;
             }
 
+            if (this.composition) {
+                this.composition._destroy();
+            }
+
             this.currentObject = object;
             this.unlisten = this.openmct.objects.observe(this.currentObject, '*', (mutatedObject) => {
                 this.currentObject = mutatedObject;
@@ -119,6 +123,7 @@ export default {
 
             this.composition = this.openmct.composition.get(this.currentObject);
             if (this.composition) {
+                this.composition._synchronize();
                 this.loadComposition();
             }
 

--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -57,6 +57,10 @@ export default {
                 this.removeSelectable();
                 delete this.removeSelectable;
             }
+
+            if (this.composition) {
+                this.composition._destroy();
+            }
         },
         invokeEditModeHandler(editMode) {
             this.currentView.onEditModeChange(editMode);

--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -117,8 +117,16 @@ export default {
                 this.currentObject = mutatedObject;
             });
 
+            this.composition = this.openmct.composition.get(this.currentObject);
+            if (this.composition) {
+                this.loadComposition();
+            }
+
             this.viewKey = viewKey;
             this.updateView(immediatelySelect);
+        },
+        loadComposition() {
+            return this.composition.load();
         },
         getSelectionContext() {
             if (this.currentView.getSelectionContext) {
@@ -133,10 +141,12 @@ export default {
             }
         },
         addObjectToParent(event) {
-            if (this.hasComposableDomainObject(event)) {
+            if (this.hasComposableDomainObject(event) && this.composition) {
                 let composableDomainObject = this.getComposableDomainObject(event);
-                this.currentObject.composition.push(composableDomainObject.identifier);
-                this.openmct.objects.mutate(this.currentObject, 'composition', this.currentObject.composition);
+                this.loadComposition().then(() => {
+                    this.composition.add(composableDomainObject);
+                });
+
                 event.preventDefault();
                 event.stopPropagation();
             }
@@ -155,6 +165,7 @@ export default {
         editIfEditable(event) {
             let provider = this.getViewProvider();
             if (provider && 
+                provider.canEdit &&
                 provider.canEdit(this.currentObject) &&
                 !this.openmct.editor.isEditing()) {
                     this.openmct.editor.edit();

--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -34,10 +34,10 @@ export default {
         this.currentObject = this.object;
         this.updateView();
         this.$el.addEventListener('dragover', this.onDragOver);
-        this.$el.addEventListener('drop', this.addObjectToParent);
         this.$el.addEventListener('drop', this.editIfEditable, {
             capture: true
         });
+        this.$el.addEventListener('drop', this.addObjectToParent);
     },
     methods: {
         clear() {


### PR DESCRIPTION
Addresses bug where objects could not be duplicated to same location
* Removes policy preventing composition containing duplicates. 
* Duplicate composition is prevented separately, via a check in the DefaultCompositionProvider. This and the above change bring TCR into line with how Master functions.
* Implements `add` in the composition API