### PR TITLE
[Summary Widget] support enum fields

### DIFF
--- a/src/plugins/summaryWidget/src/Condition.js
+++ b/src/plugins/summaryWidget/src/Condition.js
@@ -25,8 +25,6 @@ define([
      * @param {ConditionManager} conditionManager A ConditionManager instance for populating
      *                                            selects with configuration data
      */
-    const SELECT_VALUE_OPTION = '- Select value -';
-
     function Condition(conditionConfig, index, conditionManager) {
         eventHelpers.extend(this);
         this.config = conditionConfig;

--- a/src/plugins/summaryWidget/src/Condition.js
+++ b/src/plugins/summaryWidget/src/Condition.js
@@ -71,10 +71,9 @@ define([
          * @private
          */
         function onValueInput(event) {
-            let elem = event.target;
-            let numberValue = Number(elem.value);
-            let value = isNaN(numberValue) ? elem.value : numberValue;
-            let inputIndex = self.valueInputs.indexOf(elem);
+            var elem = event.target,
+                value = (isNaN(elem.valueAsNumber) ? elem.value : elem.valueAsNumber),
+                inputIndex = self.valueInputs.indexOf(elem);
 
             self.eventEmitter.emit('change', {
                 value: value,

--- a/src/plugins/summaryWidget/src/Condition.js
+++ b/src/plugins/summaryWidget/src/Condition.js
@@ -72,7 +72,7 @@ define([
          */
         function onValueInput(event) {
             var elem = event.target,
-                value = (isNaN(elem.valueAsNumber) ? elem.value : elem.valueAsNumber),
+                value = isNaN(Number(elem.value)) ? elem.value : Number(elem.value),
                 inputIndex = self.valueInputs.indexOf(elem);
 
             self.eventEmitter.emit('change', {
@@ -166,7 +166,9 @@ define([
 
     /**
      * When an operation is selected, create the appropriate value inputs
-     * and add them to the view
+     * and add them to the view. If an operation is of type enum, create
+     * a drop-down menu instead.
+     *
      * @param {string} operation The key of currently selected operation
      */
     Condition.prototype.generateValueInputs = function (operation) {
@@ -175,21 +177,23 @@ define([
             inputCount,
             inputType,
             newInput,
-            index = 0;
+            index = 0,
+            emitChange = false;
 
         inputArea.html('');
         this.valueInputs = [];
+        this.config.values = [];
 
         if (evaluator.getInputCount(operation)) {
             inputCount = evaluator.getInputCount(operation);
             inputType = evaluator.getInputType(operation);
+
             while (index < inputCount) {
                 if (inputType === 'select') {
                     newInput = $('<select>' + this.generateSelectOptions() + '</select>');
+                    emitChange = true;
                 } else {
-                    if (!this.config.values[index]) {
-                        this.config.values[index] = (inputType === 'number' ? 0 : '');
-                    }
+                    this.config.values[index] = inputType === 'number' ? 0 : '';
                     newInput = $('<input type = "' + inputType + '" value = "' + this.config.values[index] + '"> </input>');
                 }
 
@@ -197,12 +201,20 @@ define([
                 inputArea.append(newInput);
                 index += 1;
             }
+
+            if (emitChange) {
+                this.eventEmitter.emit('change', {
+                    value: Number(newInput[0].options[0].value),
+                    property: 'values[0]',
+                    index: this.index
+                });
+            }
         }
     };
 
     Condition.prototype.generateSelectOptions = function () {
         let telemetryMetadata = this.conditionManager.getTelemetryMetadata(this.config.object);
-        let options = '<option value="">' + SELECT_VALUE_OPTION + '</option>';
+        let options = '';
         telemetryMetadata[this.config.key].enumerations.forEach(enumeration => {
             options += '<option value="' + enumeration.value + '">'+ enumeration.string + '</option>';
         });

--- a/src/plugins/summaryWidget/src/ConditionEvaluator.js
+++ b/src/plugins/summaryWidget/src/ConditionEvaluator.js
@@ -36,7 +36,7 @@ define([], function () {
         this.inputValidators = {
             number: this.validateNumberInput,
             string: this.validateStringInput,
-            enum: this.validateStringInput
+            enum: this.validateNumberInput
         };
 
         /**
@@ -300,13 +300,11 @@ define([], function () {
                             condition.operation, condition.values);
                         conditionDefined = true;
                     } catch (e) {
-                        // console.log('malformed condition');
                         //ignore malformed condition
                     }
                 }
 
                 if (conditionDefined) {
-                    console.log("conditionDefined", "conditionValue", conditionValue);
                     active = (mode === 'all' && !firstRuleEvaluated ? true : active);
                     firstRuleEvaluated = true;
                     if (mode === 'any') {
@@ -329,7 +327,6 @@ define([], function () {
      * @return {boolean} The value of this condition
      */
     ConditionEvaluator.prototype.executeCondition = function (object, key, operation, values) {
-        console.log('subscriptionCache', this.subscriptionCache, "key", key, "values", values);
         var cache = (this.useTestCache ? this.testCache : this.subscriptionCache),
             telemetryValue,
             op,
@@ -337,7 +334,8 @@ define([], function () {
             validator;
 
         if (cache[object] && typeof cache[object][key] !== 'undefined') {
-            telemetryValue = [cache[object][key]];
+            let value = cache[object][key];
+            telemetryValue = [isNaN(Number(value)) ? value : Number(value)];
         }
 
         op = this.operations[operation] && this.operations[operation].operation;

--- a/src/plugins/summaryWidget/src/ConditionEvaluator.js
+++ b/src/plugins/summaryWidget/src/ConditionEvaluator.js
@@ -36,7 +36,7 @@ define([], function () {
         this.inputValidators = {
             number: this.validateNumberInput,
             string: this.validateStringInput,
-            enum: this.validateNumberInput
+            enum: this.validateStringInput
         };
 
         /**
@@ -222,7 +222,7 @@ define([], function () {
             },
             enumValueIs: {
                 operation: function (input) {
-                    return typeof input[0] === input[1];
+                    return input[0] === input[1];
                 },
                 text: 'is',
                 appliesTo: ['enum'],
@@ -233,7 +233,7 @@ define([], function () {
             },
             enumValueIsNot: {
                 operation: function (input) {
-                    return typeof input[0] !== input[1];
+                    return input[0] !== input[1];
                 },
                 text: 'is not',
                 appliesTo: ['enum'],
@@ -300,12 +300,13 @@ define([], function () {
                             condition.operation, condition.values);
                         conditionDefined = true;
                     } catch (e) {
-                        console.log('malformed condition');
+                        // console.log('malformed condition');
                         //ignore malformed condition
                     }
                 }
 
                 if (conditionDefined) {
+                    console.log("conditionDefined", "conditionValue", conditionValue);
                     active = (mode === 'all' && !firstRuleEvaluated ? true : active);
                     firstRuleEvaluated = true;
                     if (mode === 'any') {

--- a/src/plugins/summaryWidget/src/ConditionEvaluator.js
+++ b/src/plugins/summaryWidget/src/ConditionEvaluator.js
@@ -228,7 +228,7 @@ define([], function () {
                 appliesTo: ['enum'],
                 inputCount: 1,
                 getDescription: function (values) {
-                    return ' is ' + values[0];
+                    return ' == ' + values[0];
                 }
             },
             enumValueIsNot: {
@@ -239,7 +239,7 @@ define([], function () {
                 appliesTo: ['enum'],
                 inputCount: 1,
                 getDescription: function (values) {
-                    return ' is not ' + values[0];
+                    return ' != ' + values[0];
                 }
             }
         };

--- a/src/plugins/summaryWidget/src/ConditionManager.js
+++ b/src/plugins/summaryWidget/src/ConditionManager.js
@@ -130,7 +130,9 @@ define ([
         this.telemetryTypesById[objectId] = {};
         Object.values(this.telemetryMetadataById[objectId]).forEach(function (valueMetadata) {
             var type;
-            if (valueMetadata.hints.hasOwnProperty('range')) {
+            if (valueMetadata.enumerations !== undefined) {
+                type = 'enum';
+            } else if (valueMetadata.hints.hasOwnProperty('range')) {
                 type = 'number';
             } else if (valueMetadata.hints.hasOwnProperty('domain')) {
                 type = 'number';
@@ -164,6 +166,7 @@ define ([
      * @private
      */
     ConditionManager.prototype.handleSubscriptionCallback = function (objId, datum) {
+        console.log('objId', objId, 'datum', datum);
         this.subscriptionCache[objId] = datum;
         this.eventEmitter.emit('receiveTelemetry');
     };
@@ -236,6 +239,7 @@ define ([
                 id.namespace === identifier.namespace;
         });
         delete this.compositionObjs[objectId];
+        delete this.subscriptionCache[objectId];
         this.subscriptions[objectId](); //unsubscribe from telemetry source
         delete this.subscriptions[objectId];
         this.eventEmitter.emit('remove', identifier);

--- a/src/plugins/summaryWidget/src/ConditionManager.js
+++ b/src/plugins/summaryWidget/src/ConditionManager.js
@@ -165,10 +165,16 @@ define ([
      * @param {datum} datum The new data from the telemetry source
      * @private
      */
-    ConditionManager.prototype.handleSubscriptionCallback = function (objId, datum) {
-        console.log('objId', objId, 'datum', datum);
-        this.subscriptionCache[objId] = datum;
+    ConditionManager.prototype.handleSubscriptionCallback = function (objId, telemetryDatum) {
+        this.subscriptionCache[objId] = this.createNormalizedDatum(objId, telemetryDatum);
         this.eventEmitter.emit('receiveTelemetry');
+    };
+
+    ConditionManager.prototype.createNormalizedDatum = function (objId, telemetryDatum) {
+        return Object.values(this.telemetryMetadataById[objId]).reduce((normalizedDatum, metadatum) => {
+            normalizedDatum[metadatum.key] = telemetryDatum[metadatum.source];
+            return normalizedDatum;
+        }, {});
     };
 
     /**

--- a/src/plugins/summaryWidget/src/input/OperationSelect.js
+++ b/src/plugins/summaryWidget/src/input/OperationSelect.js
@@ -110,9 +110,11 @@ define([
 
         type = self.manager.getTelemetryPropertyType(self.config.object, key);
 
-        self.operationKeys = operations.filter(function (operation) {
-            return self.evaluator.operationAppliesTo(operation, type);
-        });
+        if (type !== undefined) {
+            self.operationKeys = operations.filter(function (operation) {
+                return self.evaluator.operationAppliesTo(operation, type);
+            });
+        }
     };
 
     OperationSelect.prototype.destroy = function () {

--- a/src/plugins/summaryWidget/src/telemetry/operations.js
+++ b/src/plugins/summaryWidget/src/telemetry/operations.js
@@ -193,7 +193,7 @@ define([
         },
         enumValueIs: {
             operation: function (input) {
-                return typeof input[0] === input[1];
+                return input[0] === input[1];
             },
             text: 'is',
             appliesTo: ['enum'],
@@ -204,7 +204,7 @@ define([
         },
         enumValueIsNot: {
             operation: function (input) {
-                return typeof input[0] !== input[1];
+                return input[0] !== input[1];
             },
             text: 'is not',
             appliesTo: ['enum'],

--- a/src/plugins/summaryWidget/src/telemetry/operations.js
+++ b/src/plugins/summaryWidget/src/telemetry/operations.js
@@ -199,7 +199,7 @@ define([
             appliesTo: ['enum'],
             inputCount: 1,
             getDescription: function (values) {
-                return ' is ' + values[0];
+                return ' == ' + values[0];
             }
         },
         enumValueIsNot: {
@@ -210,7 +210,7 @@ define([
             appliesTo: ['enum'],
             inputCount: 1,
             getDescription: function (values) {
-                return ' is not ' + values[0];
+                return ' != ' + values[0];
             }
         }
     };

--- a/src/plugins/summaryWidget/src/telemetry/operations.js
+++ b/src/plugins/summaryWidget/src/telemetry/operations.js
@@ -174,7 +174,7 @@ define([
                 return typeof input[0] === 'undefined';
             },
             text: 'is undefined',
-            appliesTo: ['string', 'number'],
+            appliesTo: ['string', 'number', 'enum'],
             inputCount: 0,
             getDescription: function () {
                 return ' is undefined';
@@ -185,10 +185,32 @@ define([
                 return typeof input[0] !== 'undefined';
             },
             text: 'is defined',
-            appliesTo: ['string', 'number'],
+            appliesTo: ['string', 'number', 'enum'],
             inputCount: 0,
             getDescription: function () {
                 return ' is defined';
+            }
+        },
+        enumValueIs: {
+            operation: function (input) {
+                return typeof input[0] === input[1];
+            },
+            text: 'is',
+            appliesTo: ['enum'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' is ' + values[0];
+            }
+        },
+        enumValueIsNot: {
+            operation: function (input) {
+                return typeof input[0] !== input[1];
+            },
+            text: 'is not',
+            appliesTo: ['enum'],
+            inputCount: 1,
+            getDescription: function (values) {
+                return ' is not ' + values[0];
             }
         }
     };


### PR DESCRIPTION
Displays a drop-down menu with available options when an enum field is selected in a condition. 

Fixes an existing issue where condition didn't get evaluated properly when operation was switched from `isDefined` to something like `equalTo` and back to `isDefined`. 

Also, fixes issue #2405.  