### PR TITLE
[Filters] various bugs in telemetry table filters

### DIFF
--- a/src/plugins/filters/components/FilterObject.vue
+++ b/src/plugins/filters/components/FilterObject.vue
@@ -63,7 +63,13 @@ export default {
 
             if (filterValue && filterValue[comparator]) {
                 if (value === false) {
-                    filterValue[comparator] = filterValue[comparator].filter(v => v !== valueName);
+                    let filteredValueName = filterValue[comparator].filter(v => v !== valueName);
+
+                    if (filteredValueName.length === 0) {
+                        delete this.updatedFilters[key];
+                    } else {
+                        filterValue[comparator] = filteredValueName;
+                    }
                 } else {
                     filterValue[comparator].push(valueName);
                 }

--- a/src/plugins/filters/components/FiltersView.vue
+++ b/src/plugins/filters/components/FiltersView.vue
@@ -59,14 +59,18 @@ export default {
         removeChildren(identifier) {
             let keyString = this.openmct.objects.makeKeyString(identifier);
             this.$delete(this.children, keyString);
-            this.persistFilters(keyString);
+            delete this.persistedFilters[keyString];
+            this.mutateConfigurationFilters();
         },
         persistFilters(keyString, userSelects) {
             this.persistedFilters[keyString] = userSelects;
-            this.openmct.objects.mutate(this.providedObject, 'configuration.filters', this.persistedFilters);
+            this.mutateConfigurationFilters();
         },
         updatePersistedFilters(filters) {
             this.persistedFilters = filters;
+        },
+        mutateConfigurationFilters() {
+            this.openmct.objects.mutate(this.providedObject, 'configuration.filters', this.persistedFilters);
         }
     },
     mounted(){

--- a/src/plugins/telemetryTable/components/TelemetryFilterIndicator.vue
+++ b/src/plugins/telemetryTable/components/TelemetryFilterIndicator.vue
@@ -81,7 +81,7 @@
                     domainObjects.forEach(telemetryObject => {
                         let keyString= this.openmct.objects.makeKeyString(telemetryObject.identifier);
                         let filters = this.telemetryFilters[keyString];
-                        this.domainObjectsKeyString[keyString] = '';
+                        this.domainObjectsKeyString.add(keyString);
 
                         if (filters !== undefined) {
                             let metadataValues = this.openmct.telemetry.getMetadata(telemetryObject).values();
@@ -113,7 +113,7 @@
                     }
                 });
 
-                if (mixed === false && _.size(this.telemetryFilters) !== _.size(this.domainObjectsKeyString)) {
+                if (mixed === false && _.size(this.telemetryFilters) !== this.domainObjectsKeyString.length) {
                     mixed = true;
                 }
 
@@ -136,7 +136,7 @@
             },
             addChildren(child) {
                 let keyString = this.openmct.objects.makeKeyString(child.identifier);
-                this.domainObjectsKeyString[keyString] = '';
+                this.domainObjectsKeyString.delete(keyString);
                 this.checkFiltersForMixedValues();
                 this.setLabels();
             },
@@ -147,7 +147,7 @@
         },
         mounted() {
             let filters = this.table.configuration.getConfiguration().filters || {};
-            this.domainObjectsKeyString = {};
+            this.domainObjectsKeyString = new Set();
             this.composition = this.openmct.composition.get(this.table.configuration.domainObject);
 
             if (this.composition) {

--- a/src/plugins/telemetryTable/components/TelemetryFilterIndicator.vue
+++ b/src/plugins/telemetryTable/components/TelemetryFilterIndicator.vue
@@ -116,7 +116,7 @@
 
                 // If the filtered telemetry is not mixed at this point, check the number of available objects
                 // with the number of filtered telemetry. If they are not equal, the filters must be mixed.
-                if (mixed === false && _.size(this.filteredTelemetry) !== this.telemetryKeyStrings.length) {
+                if (mixed === false && _.size(this.filteredTelemetry) !== this.telemetryKeyStrings.size) {
                     mixed = true;
                 }
 
@@ -134,18 +134,21 @@
             updateFilters(filters) {
                 this.filteredTelemetry = JSON.parse(JSON.stringify(filters));
                 this.setFilterNames();
-                this.checkFiltersForMixedValues();
-                this.setLabels();
+                this.updateIndicatorLabel();
             },
             addChildren(child) {
                 let keyString = this.openmct.objects.makeKeyString(child.identifier);
                 this.telemetryKeyStrings.add(keyString);
-                this.checkFiltersForMixedValues();
-                this.setLabels();
+                this.updateIndicatorLabel();
             },
             removeChildren(identifier) {
                 let keyString = this.openmct.objects.makeKeyString(identifier);
                 this.telemetryKeyStrings.delete(keyString);
+                this.updateIndicatorLabel();
+            },
+            updateIndicatorLabel() {
+                this.checkFiltersForMixedValues();
+                this.setLabels();
             }
         },
         mounted() {

--- a/src/plugins/telemetryTable/components/TelemetryFilterIndicator.vue
+++ b/src/plugins/telemetryTable/components/TelemetryFilterIndicator.vue
@@ -76,9 +76,8 @@
             },
             setFilterNames() {
                 let names = [];
-                let composition = this.openmct.composition.get(this.table.configuration.domainObject);
 
-                composition && composition.load().then((domainObjects) => {
+                this.composition && this.composition.load().then((domainObjects) => {
                     domainObjects.forEach(telemetryObject => {
                         let keyString= this.openmct.objects.makeKeyString(telemetryObject.identifier);
                         let filters = this.telemetryFilters[keyString];


### PR DESCRIPTION
- Update the filters object properly when both checkboxes are deselected.
- Check composition before loading to prevent typeError when viewing a telemetry object as a table.
- Modify logic for mixed filters so that when a new object is added to the table the indicator's label  updates correctly. Also, fixes a case where the Mixed label was not updated correctly when a filter was set initially.