### PR TITLE
Fixes scrolling messages overflow problem

### DIFF
--- a/src/api/overlays/components/OverlayComponent.vue
+++ b/src/api/overlays/components/OverlayComponent.vue
@@ -69,6 +69,7 @@
             flex: 1 1 auto;
             display: flex;
             flex-direction: column;
+            overflow: hidden;
         }
 
         &__top-bar {


### PR DESCRIPTION
Was able to reproduce in Open / TCR with example notifications, and verified fix with same. Needed for VISTA issue 635. Tested in Chrome and Firefox.

### Reproduction
1. In Open, add 'example/notifications' and run.
1. Create a bunch of notifications, then view Messages overlay dialog.
1. Note: no overflow problem.

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
