### PR TITLE
Minor table refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The Open MCT core platform",
   "dependencies": {},
   "devDependencies": {
+    "acorn": "6.2.0",
     "angular": "1.4.14",
     "angular-route": "1.4.14",
     "babel-eslint": "8.2.6",

--- a/src/plugins/displayLayout/plugin.js
+++ b/src/plugins/displayLayout/plugin.js
@@ -25,7 +25,7 @@ import Vue from 'vue'
 import objectUtils from '../../api/objects/object-utils.js'
 import DisplayLayoutType from './DisplayLayoutType.js'
 import DisplayLayoutToolbar from './DisplayLayoutToolbar.js'
-import AlphaNumericFormatViewProvider from './AlphaNumericFormatViewProvider.js'
+import AlphaNumericFormatViewProvider from './AlphanumericFormatViewProvider.js'
 
 export default function DisplayLayoutPlugin(options) {
     return function (openmct) {

--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -29,6 +29,7 @@
            title="Export This View's Data">
             <span class="c-button__label">Export As CSV</span>
         </button>
+        <slot name="buttons"></slot>
     </div>
     <div v-if="isDropTargetActive" class="c-telemetry-table__drop-target" :style="dropTargetStyle"></div>
     <!-- Headers table -->

--- a/src/styles-new/sass-base.scss
+++ b/src/styles-new/sass-base.scss
@@ -25,8 +25,8 @@
 // Do not include anything that renders to CSS!
 @import "constants";
 @import "constants-mobile.scss";
-//@import "constants-espresso"; // TEMP
-@import "constants-snow"; // TEMP
+@import "constants-espresso"; // TEMP
+//@import "constants-snow"; // TEMP
 //@import "constants-maelstrom";
 @import "mixins";
 @import "animations";

--- a/src/styles-new/sass-base.scss
+++ b/src/styles-new/sass-base.scss
@@ -25,8 +25,8 @@
 // Do not include anything that renders to CSS!
 @import "constants";
 @import "constants-mobile.scss";
-@import "constants-espresso"; // TEMP
-//@import "constants-snow"; // TEMP
+//@import "constants-espresso"; // TEMP
+@import "constants-snow"; // TEMP
 //@import "constants-maelstrom";
 @import "mixins";
 @import "animations";


### PR DESCRIPTION
This PR introduces some minor to tables and build dependencies refactors
* Open MCT tables now allow derived screens to insert custom buttons into the markup.
* New functions that allow derived screens to do custom processing of data on receipt
* Adds missing dependency that prevents building in new environments
* Fixed case error in import which prevents building in linux