### PR TITLE
Plot y axis label fix

### DIFF
--- a/src/plugins/plot/res/templates/mct-plot.html
+++ b/src/plugins/plot/res/templates/mct-plot.html
@@ -124,7 +124,7 @@
                          ng-model="yAxisLabel" ng-change="plot.toggleYAxisLabel(yAxisLabel, yKeyOptions, series[0])">
                     <option ng-repeat="option in yKeyOptions"
                             value="{{option.name}}"
-                            ng-selected="option.name == yAxisLabel">
+                            ng-selected="option.name === yAxisLabel">
                         {{option.name}}
                     </option>
                 </select>
@@ -177,7 +177,7 @@
                 <div class="gl-plot__local-controls h-local-controls h-local-controls--overlay-content c-local-controls--show-on-hover">
                     <div class="c-button-set c-button-set--strip-h">
                         <button class="c-button icon-minus"
-                                ng-click="plot.toggleYAxis()"
+                                ng-click="plot.zoom('out', 0.2)"
                                 title="Zoom out">
                         </button>
                         <button class="c-button icon-plus"

--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -107,6 +107,7 @@ define([
         this.listenTo(this.$scope, 'plot:reinitializeCanvas', this.initCanvas, this);
         this.listenTo(this.config.xAxis, 'change:displayRange', this.onXAxisChange, this);
         this.listenTo(this.config.yAxis, 'change:displayRange', this.onYAxisChange, this);
+        this.listenTo(this.config.yAxis, 'change:yAxisLabel')
 
         this.setUpYAxisOptions();
     };
@@ -123,6 +124,14 @@ define([
                         key: o.key
                     };
                 });
+
+            //  set yAxisLabel if none is set yet
+            if (this.$scope.yAxisLabel === 'none') {
+                let yKey = this.$scope.series[0].model.yKey,
+                    yKeyModel = this.$scope.yKeyOptions.filter(o => o.key === yKey)[0];
+
+                this.$scope.yAxisLabel = yKeyModel.name;
+            }
         } else {
             this.$scope.yKeyOptions = undefined;
         }

--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -107,7 +107,6 @@ define([
         this.listenTo(this.$scope, 'plot:reinitializeCanvas', this.initCanvas, this);
         this.listenTo(this.config.xAxis, 'change:displayRange', this.onXAxisChange, this);
         this.listenTo(this.config.yAxis, 'change:displayRange', this.onYAxisChange, this);
-        this.listenTo(this.config.yAxis, 'change:yAxisLabel')
 
         this.setUpYAxisOptions();
     };


### PR DESCRIPTION
1. In some instances, the y axis label was not populated, causing the label to show up as 'none'.
2. A regression caused the zoom out button to call a wrong function. 

