### PR TITLE
Improve table performance

### DIFF
--- a/src/plugins/telemetryTable/components/table-cell.vue
+++ b/src/plugins/telemetryTable/components/table-cell.vue
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 <template>
-    <td @click="selectCell($event.currentTarget, columnKey)">{{formattedValue}}</td>
+    <td @click="selectCell($event.currentTarget, columnKey)" :title="formattedValue">{{formattedValue}}</td>
 </template>
 <script>
 export default {

--- a/src/plugins/telemetryTable/components/table-row.vue
+++ b/src/plugins/telemetryTable/components/table-row.vue
@@ -32,7 +32,6 @@
         :is="componentList[key]"
         :columnKey="key"
         :style="columnWidths[key] === undefined ? {} : { width: columnWidths[key] + 'px', 'max-width': columnWidths[key] + 'px'}"
-        :title="formattedRow[key]"
         :class="[cellLimitClasses[key], selectableColumns[key] ? 'is-selectable' : '']"
         :objectPath="objectPath"
         :row="row">
@@ -60,7 +59,6 @@ export default {
     data: function () {
         return {
             rowTop: (this.rowOffset + this.rowIndex) * this.rowHeight + 'px',
-            formattedRow: this.row.getFormattedDatum(this.headers),
             rowClass: this.row.getRowClass(),
             cellLimitClasses: this.row.getCellLimitClasses(),
             componentList: Object.keys(this.headers).reduce((components, header) => {
@@ -116,7 +114,6 @@ export default {
             this.rowTop = (rowOffset + this.rowIndex) * this.rowHeight + 'px';
         },
         formatRow: function (row) {
-            this.formattedRow = row.getFormattedDatum(this.headers);
             this.rowClass = row.getRowClass();
             this.cellLimitClasses = row.getCellLimitClasses();
         },


### PR DESCRIPTION
A recent change to tables had increased CPU utilization by ~10 percentage points above 4.1 performance in the testing scenario I tried (SWG @ 10Hz).

Implemented a small improvement which brings performance back into line with 4.1. Basically there a an extra formatting step being performed that was no longer necessary.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A
* Command line build passes? Y
* Changes have been smoke-tested? Y