### PR TITLE
Locked painterro version to 0.2.65. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "d3-time-format": "2.1.x",
     "express": "^4.13.1",
     "minimist": "^1.1.1",
-    "painterro": "^0.2.65",
+    "painterro": "0.2.65",
     "request": "^2.69.0",
     "vue": "^2.5.6"
   },


### PR DESCRIPTION
Fixes #2447

An issue with one of Painterro's dependencies (ismobilejs) was causing the RequireJS optimizer to bomb out during the optimization phase of the build. I've locked painterro to 0.2.65 for now in Master. This issue does not occur with Webpack, so the long term remediation here is to just get topic-core-refactor merged into Master.