### PR TITLE
[Plugins] LAD Tables plugin should not be installed by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
         }));
         openmct.install(openmct.plugins.SummaryWidget());
         openmct.install(openmct.plugins.Notebook());
+        openmct.install(openmct.plugins.LADTable());
         openmct.install(openmct.plugins.Filters(['table', 'telemetry.plot.overlay']));
         openmct.install(openmct.plugins.ObjectMigration());
         openmct.install(openmct.plugins.ClearData(['table', 'telemetry.plot.overlay', 'telemetry.plot.stacked']));

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -259,7 +259,6 @@ define([
         this.install(this.plugins.FolderView());
         this.install(this.plugins.Tabs());
         this.install(this.plugins.FlexibleLayout());
-        this.install(this.plugins.LADTable());
         this.install(this.plugins.GoToOriginalAction());
 
         if (typeof BUILD_CONSTANTS !== 'undefined') {


### PR DESCRIPTION
## Fix for issue #2453
remove LADTables from default registry to optionally installed in index.html