### PR TITLE
[Summary Widget] Adding a rule without setting anything in the rule causes error #2401

### DIFF
--- a/src/plugins/summaryWidget/src/SummaryWidget.js
+++ b/src/plugins/summaryWidget/src/SummaryWidget.js
@@ -252,8 +252,8 @@ define([
         ruleOrder.push(ruleId);
         this.domainObject.configuration.ruleOrder = ruleOrder;
 
-        this.updateDomainObject();
         this.initRule(ruleId, 'Rule');
+        this.updateDomainObject();
         this.refreshRules();
     };
 
@@ -281,8 +281,8 @@ define([
         ruleOrder.splice(ruleOrder.indexOf(sourceRuleId) + 1, 0, ruleId);
         this.domainObject.configuration.ruleOrder = ruleOrder;
         this.domainObject.configuration.ruleConfigById[ruleId] = sourceConfig;
-        this.updateDomainObject();
         this.initRule(ruleId, sourceConfig.name);
+        this.updateDomainObject();
         this.refreshRules();
     };
 


### PR DESCRIPTION
TODO:
- [x] fix SummaryWidgetSpec (will skip this for now)

1. SummaryWidget.updateDomainObject triggers action to 'SummaryWidgetEvaluator.updateRules'
2. but domainObject.configuration.ruleConfigById[ruleId] is undefined
3. which actually adds in SummaryWidget.initRule.

So basically step 2 and 3 order is incorrect.