### PR TITLE
Support no filtering in tables

### DIFF
--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -87,7 +87,7 @@
                         ><span class="c-telemetry-table__headers__label">{{title}}</span>
                         </table-column-header>
                     </tr>
-                    <tr class="c-telemetry-table__headers__filter">
+                    <tr v-if="allowFiltering" class="c-telemetry-table__headers__filter">
                         <table-column-header
                             v-for="(title, key, headerIndex) in headers"
                             :key="key"


### PR DESCRIPTION
Applies a `v-if` if the `allowFiltering` flag is false. This used to work but was lost at some point.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A
* Command line build passes? Y
* Changes have been smoke-tested? Y