### PR TITLE
[Import JSON] Support namespaces

### DIFF
--- a/platform/import-export/src/actions/ImportAsJSONAction.js
+++ b/platform/import-export/src/actions/ImportAsJSONAction.js
@@ -135,20 +135,17 @@ define(['zepto', '../../../../src/api/objects/object-utils.js'], function ($, ob
      *
      * @private
      */
-    ImportAsJSONAction.prototype.rewriteId = function (oldID, newID, tree) {
-        let newIdKeyString = this.openmct.objects.makeKeyString(newID);
-        let oldIdKeyString = this.openmct.objects.makeKeyString(oldID);
+    ImportAsJSONAction.prototype.rewriteId = function (oldId, newId, tree) {
+        let newIdKeyString = this.openmct.objects.makeKeyString(newId);
+        let oldIdKeyString = this.openmct.objects.makeKeyString(oldId);
         tree = JSON.stringify(tree).replace(new RegExp(oldIdKeyString, 'g'), newIdKeyString);
 
         return JSON.parse(tree, (key, value) => {
             if (Object.prototype.hasOwnProperty.call(value, 'key') &&
                 Object.prototype.hasOwnProperty.call(value, 'namespace') &&
-                value.key === oldID.key &&
-                value.namespace === oldID.namespace) {
-                return {
-                    namespace: newID.namespace,
-                    key: newID.key
-                }
+                value.key === oldId.key &&
+                value.namespace === oldId.namespace) {
+                return newId
             } else {
                 return value;
             }

--- a/platform/import-export/src/actions/ImportAsJSONAction.js
+++ b/platform/import-export/src/actions/ImportAsJSONAction.js
@@ -61,7 +61,9 @@ define(['zepto'], function ($) {
 
     ImportAsJSONAction.prototype.importObjectTree = function (objTree) {
         var parent = this.context.domainObject;
-        var tree = this.generateNewIdentifiers(objTree);
+        var namespace = parent.useCapability('adapter').identifier.namespace;
+
+        var tree = this.generateNewIdentifiers(objTree, namespace);
         var rootId = tree.rootId;
         var rootObj = this.instantiate(tree.openmct[rootId], rootId);
         var newStyleParent = parent.useCapability('adapter');
@@ -105,7 +107,6 @@ define(['zepto'], function ($) {
                 if (!tree[keystring] || seen.includes(keystring)) {
                     return;
                 }
-
                 newObj = this.instantiate(tree[keystring], keystring);
                 newObj.getCapability("location")
                     .setPrimaryLocation(tree[keystring].location);
@@ -114,10 +115,13 @@ define(['zepto'], function ($) {
         }
     };
 
-    ImportAsJSONAction.prototype.generateNewIdentifiers = function (tree) {
+    ImportAsJSONAction.prototype.generateNewIdentifiers = function (tree, namespace) {
         // For each domain object in the file, generate new ID, replace in tree
         Object.keys(tree.openmct).forEach(function (domainObjectId) {
-            var newId = this.identifierService.generate();
+            var newId = this.openmct.objects.makeKeyString({
+                namespace: namespace,
+                key: this.identifierService.generate()
+            });
             tree = this.rewriteId(domainObjectId, newId, tree);
         }, this);
         return tree;

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -73,7 +73,8 @@ define([
 ) {
     var bundleMap = {
         LocalStorage: 'platform/persistence/local',
-        MyItems: 'platform/features/my-items'
+        MyItems: 'platform/features/my-items',
+        CouchDB: 'platform/persistence/couch'
     };
 
     var plugins = _.mapValues(bundleMap, function (bundleName, pluginName) {


### PR DESCRIPTION
This fix adds support for namespaces as well as heterogenous identifier types to the Import as JSON plugin. Fixes 

1. Apply namespace of new parent object in all `namespace:key` style object identifiers.
2. Apply parent namespace and new key in all `identifier:{...}` style object identifiers.
3. Fixes the CouchDB plugin which was broken in TCR

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A
* Command line build passes? Y
* Changes have been smoke-tested? Y