### PR TITLE
VISTA Fixes 4

### DIFF
--- a/src/plugins/filters/components/GlobalFilters.vue
+++ b/src/plugins/filters/components/GlobalFilters.vue
@@ -53,6 +53,7 @@
         &__filter-indicator {
             color: $colorFilter;
             width: 1.2em; // Set width explicitly for layout reasons: will either have class icon-filter, or none.
+            flex: 0 0 auto;
         }
     }
 </style>

--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -261,7 +261,12 @@
                 height: 18px; // Needed when a row has empty values in its cells
 
                 &.is-selected {
-                    background-color: $colorSelectedBg;
+                    background-color: $colorSelectedBg !important;
+                    color: $colorSelectedFg !important;
+                    td {
+                        background: none !important;
+                        color: inherit !important;
+                    }
                 }
             }
 

--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -271,6 +271,15 @@ input[type=number]::-webkit-outer-spin-button {
     }
 }
 
+input[type=number].c-input-number--no-spinners {
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+    -moz-appearance: textfield;
+}
+
 .c-labeled-input {
     // An input used in the Toolbar
     // Assumes label is before the input

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -630,6 +630,8 @@ body.mobile.phone {
 .c-sw-rule {
     &__grippy-wrapper {
         $d: 8px;
+        flex: 0 0 auto;
+        cursor: move;
         width: $d; height: $d;
         transform: translateY(-1px);
     }

--- a/src/styles/_legacy.scss
+++ b/src/styles/_legacy.scss
@@ -483,6 +483,7 @@ body.mobile.phone {
     .widget-edit-holder {
         display: flex; // Overrides `display: none` during Browse mode
         flex: 1 1 auto;
+        overflow: hidden;
 
         .flex-accordion-holder {
             // Needed because otherwise accordion elements "creep" when contents expand and contract


### PR DESCRIPTION
A number of UI-related fixes to handle issues found during VISTA testing.

### Changes
- Fixed `is-selected` styling so that it overrides table row EVR, limit styling;
- Fix indent in Global filters UI: #2488;
- Fix Summary Widget grippys #2494;
- Fix Summary Widget overflow problem: #2495;
- Added new `c-input-number--no-spinners` class for https://github.jpl.nasa.gov/MissionControl/vista/issues/673. This is required to support a fix for that issue.

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y