### PR TITLE
Save and Finish blocking modal dialog Refactor and Styles #2500

### DIFF
--- a/platform/commonUI/edit/src/actions/SaveInProgressDialog.js
+++ b/platform/commonUI/edit/src/actions/SaveInProgressDialog.js
@@ -6,7 +6,7 @@ define([], function () {
 
     SaveInProgressDialog.prototype.show = function () {
         this.dialog = this.dialogService.showBlockingMessage({
-            title: "Saving...",
+            title: "Saving",
             hint: "Do not navigate away from this page or close this browser tab while this message is displayed.",
             unknownProgress: true,
             severity: "info",

--- a/src/api/overlays/ProgressDialog.js
+++ b/src/api/overlays/ProgressDialog.js
@@ -1,25 +1,33 @@
 import ProgressComponent from '../../ui/components/ProgressBar.vue';
+import DialogComponent from './components/DialogComponent.vue';
 import Overlay from './Overlay';
 import Vue from 'vue';
 
 var component;
 
 class ProgressDialog extends Overlay {
-    constructor({progressPerc, progressText, ...options}) {
-
+    constructor({iconClass, message, title, hint, timestamp, progressPerc,  progressText, ...options}) {
         component = new Vue({
+            provide: {
+                iconClass,
+                message,
+                title,
+                hint,
+                timestamp
+            },
             components: {
+                DialogComponent: DialogComponent,
                 ProgressComponent: ProgressComponent
             },
             data() {
                 return {
                     model: {
                         progressPerc: progressPerc || 0,
-                        progressText: progressText
+                        progressText: progressText,
                     }
                 }
             },
-            template: '<progress-component :model="model"></progress-component>'
+            template: '<dialog-component><progress-component :model="model"></progress-component></dialog-component>'
         }).$mount();
 
         super({

--- a/src/api/overlays/ProgressDialog.js
+++ b/src/api/overlays/ProgressDialog.js
@@ -1,12 +1,11 @@
-import ProgressComponent from '../../ui/components/ProgressBar.vue';
-import DialogComponent from './components/DialogComponent.vue';
+import ProgressDialogComponent from './components/ProgressDialogComponent.vue';
 import Overlay from './Overlay';
 import Vue from 'vue';
 
 var component;
 
 class ProgressDialog extends Overlay {
-    constructor({iconClass, message, title, hint, timestamp, progressPerc,  progressText, ...options}) {
+    constructor({progressPerc, progressText, iconClass, message, title, hint, timestamp, ...options}) {
         component = new Vue({
             provide: {
                 iconClass,
@@ -16,18 +15,17 @@ class ProgressDialog extends Overlay {
                 timestamp
             },
             components: {
-                DialogComponent: DialogComponent,
-                ProgressComponent: ProgressComponent
+                ProgressDialogComponent: ProgressDialogComponent
             },
             data() {
                 return {
                     model: {
                         progressPerc: progressPerc || 0,
-                        progressText: progressText,
+                        progressText
                     }
                 }
             },
-            template: '<dialog-component><progress-component :model="model"></progress-component></dialog-component>'
+            template: '<progress-dialog-component :model="model"></progress-dialog-component>'
         }).$mount();
 
         super({

--- a/src/api/overlays/components/DialogComponent.vue
+++ b/src/api/overlays/components/DialogComponent.vue
@@ -45,7 +45,7 @@
 
         &__icon {
             // Holds a background SVG graphic
-            $s: 50px;
+            $s: 80px;
             flex: 0 0 auto;
             min-width: $s;
             min-height: $s;
@@ -62,9 +62,13 @@
         }
 
         // __text elements
-        &__title,
         &__action-text {
-            font-size: 1.2em; // TEMP
+            font-size: 1.2em;
+        }
+
+        &__title {
+            font-size: 1.5em;
+            font-weight: bold;
         }
 
         &--simple {

--- a/src/api/overlays/components/DialogComponent.vue
+++ b/src/api/overlays/components/DialogComponent.vue
@@ -20,6 +20,7 @@
                  v-if="message">
                 {{message}}
             </div>
+            <slot></slot>
         </div>
     </div>
 </template>

--- a/src/api/overlays/components/ProgressDialogComponent.vue
+++ b/src/api/overlays/components/ProgressDialogComponent.vue
@@ -1,0 +1,22 @@
+<template>
+    <dialog-component>
+        <progress-component :model="model"></progress-component>
+    </dialog-component>
+</template>
+
+<style lang="scss">
+</style>
+
+<script>
+import ProgressComponent from '../../../ui/components/ProgressBar.vue';
+import DialogComponent from './DialogComponent.vue';
+
+export default {
+    components: {
+        DialogComponent: DialogComponent,
+        ProgressComponent: ProgressComponent,
+    },
+    inject:['iconClass', 'title', 'hint', 'timestamp', 'message'],
+    props:['model']
+}
+</script>

--- a/src/ui/components/ProgressBar.vue
+++ b/src/ui/components/ProgressBar.vue
@@ -2,13 +2,13 @@
     <div class="c-progress-bar">
         <div class="c-progress-bar__holder">
             <div class="c-progress-bar__bar"
-                 :class="{'--indeterminate': model.progressPerc === 'unknown' }"
+                 :class="{'--indeterminate': model.progressPerc === 'unknown'}"
                  :style="`width: ${model.progressPerc}%;`">
             </div>
         </div>
         <div class="c-progress-bar__text"
              v-if="model.progressText !== undefined">
-            <span v-if="model.progressPerc > 0">{{model.progressPerc}}% complete. </span>
+            <span v-if="model.progressPerc > 0">{{model.progressPerc}}% complete.</span>
             {{model.progressText}}
         </div>
     </div>

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -129,17 +129,20 @@ const PLACEHOLDER_OBJECT = {};
             saveAndFinishEditing() {
                 let dialog = this.openmct.overlays.progressDialog({
                     progressPerc: 'unknown',
-                    progressText: 'Saving...',
+                    message: 'Do not navigate away from this page or close this browser tab while this message is displayed.',
+                    iconClass: 'info',
+                    title: 'Saving...',
                 });
 
-                return this.openmct.editor.save().then(()=> {
-                    dialog.dismiss();
-                    this.openmct.notifications.info('Save successful');
-                }).catch((error) => {
-                    dialog.dismiss();
-                    this.openmct.notifications.error('Error saving objects');
-                    console.error(error);
-                });
+                return this.openmct.editor.save()
+                    .then(()=> {
+                        dialog.dismiss();
+                        this.openmct.notifications.info('Save successful');
+                    }).catch((error) => {
+                        dialog.dismiss();
+                        this.openmct.notifications.error('Error saving objects');
+                        console.error(error);
+                    });
             },
             saveAndContinueEditing() {
                 this.saveAndFinishEditing().then(() => {

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -131,7 +131,7 @@ const PLACEHOLDER_OBJECT = {};
                     progressPerc: 'unknown',
                     message: 'Do not navigate away from this page or close this browser tab while this message is displayed.',
                     iconClass: 'info',
-                    title: 'Saving...',
+                    title: 'Saving',
                 });
 
                 return this.openmct.editor.save()


### PR DESCRIPTION
TODOs:
- [x] **Refactor**: Modify ProgressDialog to use DialogComponent and ProgressBar
- [x] **Check for regression**: `this.openmct.overlays.progressDialog` is also used in `NotificationBanner.vue` (2nd image)
- [x] **Styles**: Add correct styles to modal

![Screen Shot 2019-09-19 at 3 17 59 PM](https://user-images.githubusercontent.com/1292612/65285469-664ff380-daf1-11e9-80b5-ae651452ed72.png)

![Screen Shot 2019-10-31 at 3 20 41 PM](https://user-images.githubusercontent.com/1292612/67990235-8b587b80-fbf2-11e9-9e33-2064a19a2c5d.png)