### PR TITLE
Emit refresh event when data cleared

### DIFF
--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -190,6 +190,7 @@ define([
         clearData() {
             this.filteredRows.clear();
             this.boundedRows.clear();
+            this.emit('refresh');
         }
 
         getColumnMapForObject(objectKeyString) {


### PR DESCRIPTION
This is necessary in order to force the table to be redrawn. Otherwise it waits until the next Vue tick which results in unexpected behavior with the Clear All Data action.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A
* Command line build passes? Y
* Changes have been smoke-tested? Y