### PR TITLE
Create rather than update new objects in JSON import

### DIFF
--- a/platform/import-export/src/actions/ImportAsJSONAction.js
+++ b/platform/import-export/src/actions/ImportAsJSONAction.js
@@ -64,7 +64,11 @@ define(['zepto', '../../../../src/api/objects/object-utils.js'], function ($, ob
 
         var tree = this.generateNewIdentifiers(objTree, namespace);
         var rootId = tree.rootId;
-        var rootObj = this.instantiate(tree.openmct[rootId], rootId);
+
+        var rootModel = tree.openmct[rootId];
+        delete rootModel.persisted;
+
+        var rootObj = this.instantiate(rootModel, rootId);
         var newStyleParent = parent.useCapability('adapter');
         var newStyleRootObj = rootObj.useCapability('adapter');
 
@@ -106,7 +110,10 @@ define(['zepto', '../../../../src/api/objects/object-utils.js'], function ($, ob
                 if (!tree[keystring] || seen.includes(keystring)) {
                     return;
                 }
-                newObj = this.instantiate(tree[keystring], keystring);
+                let newModel = tree[keystring];
+                delete newModel.persisted;
+
+                newObj = this.instantiate(newModel, keystring);
                 newObj.getCapability("location")
                     .setPrimaryLocation(tree[keystring].location);
                 this.deepInstantiate(newObj, tree, seen);


### PR DESCRIPTION
* Removes the `persisted` timestamp from new models on JSON import. The presence of this timestamp was causing objects to be created rather than updated in persistence providers.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes? N/A
* Command line build passes? N/A
* Changes have been smoke-tested? Y