### PR TITLE
Issue 2472 Disable selection in layouts when previewing

### DIFF
--- a/src/plugins/flexibleLayout/components/container.vue
+++ b/src/plugins/flexibleLayout/components/container.vue
@@ -194,7 +194,9 @@ export default {
         this.unsubscribeSelection = this.openmct.selection.selectable(this.$el, context, false);
     },
     beforeDestroy() {
-        this.unsubscribeSelection();
+        if (this.unsubscribeSelection) {
+            this.unsubscribeSelection();
+        }
     }
 }
 </script>

--- a/src/plugins/flexibleLayout/components/container.vue
+++ b/src/plugins/flexibleLayout/components/container.vue
@@ -194,9 +194,7 @@ export default {
         this.unsubscribeSelection = this.openmct.selection.selectable(this.$el, context, false);
     },
     beforeDestroy() {
-        if (this.unsubscribeSelection) {
-            this.unsubscribeSelection();
-        }
+        this.unsubscribeSelection();
     }
 }
 </script>

--- a/src/selection/Selection.js
+++ b/src/selection/Selection.js
@@ -169,6 +169,17 @@ define(
         /**
          * @private
          */
+        Selection.prototype.isSelectable = function (selectable) {
+            if (!selectable || !selectable.element) {
+                return false
+            }
+
+            return !!selectable.element.closest('[data-selectable]');
+        };
+
+        /**
+         * @private
+         */
         Selection.prototype.capture = function (selectable) {
             let capturingContainsSelectable = this.capturing && this.capturing.includes(selectable);
 
@@ -211,8 +222,14 @@ define(
                 context: context,
                 element: element
             };
+
+            if (!this.isSelectable(selectable)) {
+                return;
+            }
+
             var capture = this.capture.bind(this, selectable);
             var selectCapture = this.selectCapture.bind(this, selectable);
+
             element.addEventListener('click', capture, true);
             element.addEventListener('click', selectCapture);
 

--- a/src/selection/Selection.js
+++ b/src/selection/Selection.js
@@ -169,12 +169,12 @@ define(
         /**
          * @private
          */
-        Selection.prototype.isSelectable = function (selectable) {
-            if (!selectable || !selectable.element) {
+        Selection.prototype.isSelectable = function (element) {
+            if (!element) {
                 return false;
             }
 
-            return !!selectable.element.closest('[data-selectable]');
+            return !!element.closest('[data-selectable]');
         };
 
         /**
@@ -223,8 +223,8 @@ define(
                 element: element
             };
 
-            if (!this.isSelectable(selectable)) {
-                return;
+            if (!this.isSelectable(element)) {
+                return () => {};
             }
 
             var capture = this.capture.bind(this, selectable);

--- a/src/selection/Selection.js
+++ b/src/selection/Selection.js
@@ -171,7 +171,7 @@ define(
          */
         Selection.prototype.isSelectable = function (selectable) {
             if (!selectable || !selectable.element) {
-                return false
+                return false;
             }
 
             return !!selectable.element.closest('[data-selectable]');

--- a/src/ui/layout/Layout.vue
+++ b/src/ui/layout/Layout.vue
@@ -39,7 +39,9 @@
                 <toolbar v-if="toolbar" class="l-shell__toolbar"></toolbar>
                 <object-view class="l-shell__main-container"
                              ref="browseObject"
-                             :showEditView="true">
+                             :showEditView="true"
+                             data-selectable
+                             >
                 </object-view>
                 <component class="l-shell__time-conductor"
                     :is="conductorComponent">


### PR DESCRIPTION
Fixes
https://github.com/nasa/openmct/tree/issue-2472

Change
Elements can be selectable or not depending on view context, ie. selectable during layout view but not selectable in preview view. Change to make selectable explicit, by adding the data-attribute 'data-selectable' to layouts in which elements can be selected. Selectable click event handlers will not be attached to elements that are not in selectable layouts.

Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? No existing unit tests
Command line build passes? Yes
Changes have been smoke-tested? Yes