### PR TITLE
[Startup] Stop using -h for aliasing --host

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@
 
     // Defaults
     options.port = options.port || options.p || 8080;
-    options.host = options.host || options.h || 'localhost'
+    options.host = options.host || 'localhost'
     options.directory = options.directory || options.D || '.';
     ['include', 'exclude', 'i', 'x'].forEach(function (opt) {
         options[opt] = options[opt] || [];
@@ -34,10 +34,11 @@
     if (options.help || options.h) {
         console.log("\nUsage: node app.js [options]\n");
         console.log("Options:");
-        console.log("  --help, -h               Show this message.");
-        console.log("  --port, -p <number>      Specify port.");
-        console.log("  --include, -i <bundle>   Include the specified bundle.");
-        console.log("  --exclude, -x <bundle>   Exclude the specified bundle.");
+        console.log("  --help, -h                 Show this message.");
+        console.log("  --port, -p <number>        Specify port.");
+        console.log("  --host <host>              Specify host to listen on.");
+        console.log("  --include, -i <bundle>     Include the specified bundle.");
+        console.log("  --exclude, -x <bundle>     Exclude the specified bundle.");
         console.log("  --directory, -D <bundle>   Serve files from specified directory.");
         console.log("");
         process.exit(0);


### PR DESCRIPTION
This solves #2543 and includes documentation for the `--host` flag in the help dialog.

## Author Checklist
- [x] Changes address original issue?
- [ ] Unit tests included and/or updated with changes? N/A
- [x] Command line build passes?
- [x] Changes have been smoke-tested?