### PR TITLE
[Import-Export] Enable plugin path

### DIFF
--- a/platform/import-export/bundle.js
+++ b/platform/import-export/bundle.js
@@ -72,6 +72,8 @@ define([
                     ]
                 }
             });
+
+            openmct.legacyRegistry.enable('platform/import-export');
         };
     };
 });


### PR DESCRIPTION
Since making it a default plugin, we needed to enable the plugin from legacyRegistry as well. 

