### PR TITLE
Filters vs MinMax bug fix

### DIFF
--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -140,9 +140,14 @@ define([
          * @returns {Promise}
          */
         fetch: function (options) {
-            const strategy = options && options.shouldNotUseMinMax ? undefined : 'minMax';
+            let strategy;
+
+            if (this.model.interpolate !== 'none') {
+                strategy = 'minMax';
+            }
 
             options = _.extend({}, { size: 1000, strategy, filters: this.filters }, options || {});
+
             if (!this.unsubscribe) {
                 this.unsubscribe = this.openmct
                     .telemetry
@@ -373,19 +378,6 @@ define([
          */
         updateFiltersAndRefresh: function (updatedFilters) {
             this.filters = updatedFilters;
-            this.reset();
-            if (this.unsubscribe) {
-                this.unsubscribe();
-                delete this.unsubscribe;
-            }
-            this.fetch();
-        },
-
-        /**
-         * Clears the plot series, unsubscribes and resubscribes
-         * @public
-         */
-        refresh: function () {
             this.reset();
             if (this.unsubscribe) {
                 this.unsubscribe();

--- a/src/plugins/plot/src/telemetry/PlotController.js
+++ b/src/plugins/plot/src/telemetry/PlotController.js
@@ -102,8 +102,7 @@ define([
         this.startLoading();
         var options = {
             size: this.$element[0].offsetWidth,
-            domain: this.config.xAxis.get('key'),
-            shouldNotUseMinMax: this.shouldNotUseMinMax(series)
+            domain: this.config.xAxis.get('key')
         };
 
         series.load(options)
@@ -159,10 +158,6 @@ define([
             configStore.add(configId, config);
         }
         return config;
-    };
-
-    PlotController.prototype.shouldNotUseMinMax = function (series) {
-        return series.model.interpolate === 'none';
     };
 
     PlotController.prototype.onTimeSystemChange = function (timeSystem) {


### PR DESCRIPTION
Moved the check for linestyle to plot series. This allows us to override the strategy directly in the fetch function if linestyle is none. 

TODO - In VISTA, we will have to make a change that will override strategy when filters are being used (most of the logic is there already). Conversation with @akhenry - We should not force usage of minmax in openmct when using filters. Because telemetry providers have access to filters, which they can use to make a decision. But in the case of plot line styles, we have to force a strategy through openmct. 