### PR TITLE
Enable theming using plugins in development mode

### DIFF
--- a/src/plugins/themes/installTheme.js
+++ b/src/plugins/themes/installTheme.js
@@ -1,18 +1,33 @@
+import snowTheme from '../../plugins/themes/snow-theme.scss';
+import espressoTheme from '../../plugins/themes/espresso-theme.scss';
+import maelstromTheme from '../../plugins/themes/maelstrom-theme.scss';
+
+const themes = {
+    snow: snowTheme,
+    espresso: espressoTheme,
+    maelstrom: maelstromTheme
+}
+
 const dataAttribute = 'theme';
 
 export const installTheme = (openmct, themeName) => {
-    const currentTheme = document.querySelector(`link[data-${dataAttribute}]`);
-    if (currentTheme) {
-        currentTheme.remove();
-    }
-
-    const newTheme = document.createElement('link');
-    newTheme.setAttribute('rel', 'stylesheet');
-
     // eslint-disable-next-line no-undef
-    const href = `${openmct.getAssetPath()}${__OPENMCT_ROOT_RELATIVE__}${themeName}Theme.css`;
-    newTheme.setAttribute('href', href);
-    newTheme.dataset[dataAttribute] = themeName;
+    if (__OPENMCT_USE_STYLE_LOADER__) {
+        themes[themeName].use();
+    } else {
+        const currentTheme = document.querySelector(`link[data-${dataAttribute}]`);
+        if (currentTheme) {
+            currentTheme.remove();
+        }
 
-    document.head.appendChild(newTheme);
+        const newTheme = document.createElement('link');
+        newTheme.setAttribute('rel', 'stylesheet');
+
+        // eslint-disable-next-line no-undef
+        const href = `${openmct.getAssetPath()}${__OPENMCT_ROOT_RELATIVE__}${themeName}Theme.css`;
+        newTheme.setAttribute('href', href);
+        newTheme.dataset[dataAttribute] = themeName;
+
+        document.head.appendChild(newTheme);
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,8 @@ const webpackConfig = {
             __OPENMCT_BUILD_DATE__: `'${new Date()}'`,
             __OPENMCT_REVISION__: `'${gitRevision}'`,
             __OPENMCT_BUILD_BRANCH__: `'${gitBranch}'`,
-            __OPENMCT_ROOT_RELATIVE__: `'${devMode ? 'dist/' : ''}'`
+            __OPENMCT_ROOT_RELATIVE__: `'${devMode ? 'dist/' : ''}'`,
+            __OPENMCT_USE_STYLE_LOADER__: `'${devMode}'`
         }),
         new VueLoaderPlugin(),
         new MiniCssExtractPlugin({
@@ -76,7 +77,12 @@ const webpackConfig = {
             {
                 test: /\.(sc|sa|c)ss$/,
                 use: [
-                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: devMode ? 'style-loader': MiniCssExtractPlugin.loader,
+                        options: {
+                            injectType: 'lazyStyleTag'
+                        }
+                    },
                     'css-loader',
                     'fast-sass-loader'
                 ]


### PR DESCRIPTION
## Overview
Use style-loader for theming in dev
* use style-loader style tag injection instead of css in development

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |

## Instructions
* Add one of the following to index.html to change theme
```
openmct.install(openmct.plugins.Snow());
openmct.install(openmct.plugins.Espresso());
openmct.install(openmct.plugins.Maelstrom());
```
* Refresh page to see changes