### PR TITLE
By default add new frame to end of container

### DIFF
--- a/src/plugins/flexibleLayout/components/flexibleLayout.vue
+++ b/src/plugins/flexibleLayout/components/flexibleLayout.vue
@@ -232,18 +232,16 @@ export default {
             this.newFrameLocation = [containerIndex, insertFrameIndex];
         },
         addFrame(domainObject) {
-            if (this.newFrameLocation.length) {
-                let containerIndex = this.newFrameLocation[0],
-                    frameIndex = this.newFrameLocation[1],
-                    frame = new Frame(domainObject.identifier),
-                    container = this.containers[containerIndex];
+            let containerIndex = this.newFrameLocation.length ? this.newFrameLocation[0] : 0;
+            let container = this.containers[containerIndex];
+            let frameIndex = this.newFrameLocation.length ? this.newFrameLocation[1] : container.frames.length;
+            let frame = new Frame(domainObject.identifier);
 
-                container.frames.splice(frameIndex + 1, 0, frame);
-                sizeItems(container.frames, frame);
+            container.frames.splice(frameIndex + 1, 0, frame);
+            sizeItems(container.frames, frame);
 
-                this.newFrameLocation = [];
-                this.persist(containerIndex);
-            }
+            this.newFrameLocation = [];
+            this.persist(containerIndex);
         },
         deleteFrame(frameId) {
             let container = this.containers


### PR DESCRIPTION
## Overview
Fixes #2602

In flexible layouts, dragging an object onto another object, and not a valid drop zone, resulted in object not getting added to layout but being added to composition.

Fix by adding default behavior - if drop zone not specified, add to layout at end of container.

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |
