### PR TITLE
[Plots] Sending duplicate fetch requests when filters are initialized

### DIFF
--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -377,13 +377,17 @@ define([
          * @public
          */
         updateFiltersAndRefresh: function (updatedFilters) {
-            this.filters = updatedFilters;
-            this.reset();
-            if (this.unsubscribe) {
-                this.unsubscribe();
-                delete this.unsubscribe;
+            if (this.filters) {
+                this.filters = updatedFilters;
+                this.reset();
+                if (this.unsubscribe) {
+                    this.unsubscribe();
+                    delete this.unsubscribe;
+                }
+                this.fetch();
+            } else {
+                this.filters = updatedFilters;
             }
-            this.fetch();
         }
     });
 


### PR DESCRIPTION
When telemetry points with filter metadata are added to overlay plots, plots will send a request for historical telemetry (which is fine), but then filters will be initialized causing a mutation on the domainObject and will trigger another request for telemetry. This causes issues when multiple telemetry points are added to overlay plots, plots will request *2 for every telemetry point. This PR fixes this issue. 

## Author Checklist
Changes address original issue? Y
Unit tests included and/or updated with changes? N/A
Command line build passes? Y
Changes have been smoke-tested? Y

