### PR TITLE
[Navigation Tree] save current state of navigation tree

### DIFF
--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -113,7 +113,6 @@ export default {
         this.openmct.router.on('change:path', this.highlightIfNavigated);
 
         this.getLocalStorageExpanded();
-        this.getLocalStorageNavigated();
     },
     beforeDestroy() {
         /****
@@ -159,15 +158,6 @@ export default {
             } else if (oldPath === this.navigateToPath) {
                 this.navigated = false;
             }
-            this.setLocalStorageNavigated(newPath);
-        },
-        getLocalStorageNavigated() {
-            const navigated = localStorage.getItem(LOCAL_STORAGE_KEY__TREE_NAVIGATED);
-            this.navigated = navigated && JSON.parse(navigated) === this.navigateToPath;
-        },
-        // on path change, store the path string of the new navigated/highlighted path to localstorage
-        setLocalStorageNavigated(path) {
-            localStorage.setItem(LOCAL_STORAGE_KEY__TREE_NAVIGATED, JSON.stringify(path));
         },
         getLocalStorageExpanded() {
             let expandedPaths = localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED);

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -165,6 +165,7 @@ export default {
             const navigated = localStorage.getItem(LOCAL_STORAGE_KEY__TREE_NAVIGATED);
             this.navigated = navigated && JSON.parse(navigated) === this.navigateToPath;
         },
+        // on path change, store the path string of the new navigated/highlighted path to localstorage
         setLocalStorageNavigated(path) {
             localStorage.setItem(LOCAL_STORAGE_KEY__TREE_NAVIGATED, JSON.stringify(path));
         },
@@ -176,6 +177,7 @@ export default {
                 this.expanded = expandedPaths.includes(this.navigateToPath);
             }
         },
+        // expanded nodes/paths are stored in local storage as an array
         setLocalStorageExpanded() {
             let expandedPaths = localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED);
             expandedPaths = expandedPaths ? JSON.parse(expandedPaths) : [];

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -40,7 +40,6 @@
 import viewControl from '../components/viewControl.vue';
 import ObjectLabel from '../components/ObjectLabel.vue';
 
-const LOCAL_STORAGE_KEY__TREE_NAVIGATED = 'mct-tree-navigated';
 const LOCAL_STORAGE_KEY__TREE_EXPANDED = 'mct-tree-expanded';
 
 export default {


### PR DESCRIPTION
## Overview
Provide persistence to the user's current state in the object navigation tree. On page load/refresh, the initial state will be the last state the navigation tree was in.
- Save expanded state to local storage
- Save navigated state to local storage

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |