### PR TITLE
Fixes #2604: Use relative paths for scss imports

### DIFF
--- a/src/plugins/themes/espresso-theme.scss
+++ b/src/plugins/themes/espresso-theme.scss
@@ -1,22 +1,22 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-espresso";
+@import "../../styles/constants-espresso";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/layout";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/layout";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";

--- a/src/plugins/themes/maelstrom-theme.scss
+++ b/src/plugins/themes/maelstrom-theme.scss
@@ -1,22 +1,22 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-maelstrom";
+@import "../../styles/constants-maelstrom";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/layout";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/layout";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";

--- a/src/plugins/themes/snow-theme.scss
+++ b/src/plugins/themes/snow-theme.scss
@@ -1,22 +1,22 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-snow";
+@import "../../styles/constants-snow";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/layout";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/layout";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";


### PR DESCRIPTION
# Author Checklist

- [x] Changes address original issue?
- [ ] Unit tests included and/or updated with changes?
- [x] Command line build passes?
- [ ] Changes have been smoke-tested?

# Reviewer Checklist

- [ ] Changes appear to address issue?
- [ ] Appropriate unit tests included?
- [ ] Code style and in-line documentation are appropriate?
- [ ] Commit messages meet standards?

Problem manifests itself on Windows systems where openmct is pulled in as npm dependency. The `npm prepare` calls `npm run build:prod` that ends up failing in a way described in original ticket #2604 . Problem is with `~source` reference in scss scripts. Looks like Windows system builds do not resolve it correctly and require relative paths instead. Using relative paths seems to not harm Linux builds.

I am not sure it is testable without adding Windows environment to your Circle CI config. I did test it separately by making 2 versions of sample project, one using [current openmct master](https://travis-ci.org/Srokap/openmct-example/builds/651223519) and other using [my branch](https://travis-ci.org/Srokap/openmct-example/builds/651223607) this PR is based of.