### PR TITLE
Condition clone name persistance

### DIFF
--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -68,6 +68,7 @@
                                         <input v-model="domainObject.configuration.name"
                                                class="t-condition-input__name"
                                                type="text"
+                                               @blur="persist"
                                         >
                                     </span>
                                 </li>

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -250,7 +250,6 @@ export default {
             let conditionObj = {
                 isDefault: isDefault,
                 type: 'condition',
-                name: isDefault ? 'Default' : (isClone ? 'Copy of ' : '') + 'Unnamed Condition',
                 identifier: {
                     namespace: this.domainObject.identifier.namespace,
                     key: uuid()


### PR DESCRIPTION
Found two issues. Input name field required a blur handler to call persist() and name property was duplicated as a property of condition and condition.configuration. Removed the top level property as it was not being used.

Resolves issue: Change of condition name not persisting #2676