### PR TITLE
Condition trigger

### DIFF
--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -68,6 +68,7 @@
                                         <input v-model="domainObject.configuration.name"
                                                class="t-condition-input__name"
                                                type="text"
+                                               :disabled="!telemetry.length"
                                         >
                                     </span>
                                 </li>
@@ -75,6 +76,7 @@
                                     <label>Output</label>
                                     <span class="controls">
                                         <select v-model="selectedOutputKey"
+                                                :disabled="!telemetry.length"
                                                 @change="checkInputValue"
                                         >
                                             <option value="">- Select Output -</option>

--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -103,7 +103,9 @@
                                     <li class="has-local-controls t-condition">
                                         <label>Match when</label>
                                         <span class="controls">
-                                            <select v-model="trigger">
+                                            <select v-model="domainObject.configuration.trigger"
+                                                    @change="persist"
+                                            >
                                                 <option value="all">all criteria are met</option>
                                                 <option value="any">any criteria are met</option>
                                             </select>
@@ -118,7 +120,7 @@
                                                :telemetry="telemetry"
                                                :criterion="criterion"
                                                :index="index"
-                                               :trigger="trigger"
+                                               :trigger="domainObject.configuration.trigger"
                                                @persist="persist"
                                     />
                                 </ul>
@@ -199,7 +201,6 @@ export default {
             domainObject: this.domainObject,
             currentCriteria: this.currentCriteria,
             expanded: true,
-            trigger: 'all',
             selectedOutputKey: '',
             stringOutputField: false,
             outputOptions: ['false', 'true', 'string']

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -38,19 +38,24 @@
         <div v-show="isEditing"
              class="help"
         >
-            <span>The first condition to match is the one that wins. Drag conditions to rearrange.</span>
+            <span v-if="!telemetryObjs.length">Drag telemetry into Condition Set in order to add or edit conditions.</span>
+            <span v-else>The first condition to match is the one that wins. Drag conditions to rearrange.</span>
         </div>
         <div class="holder add-condition-button-wrapper align-left">
             <button
                 v-show="isEditing"
                 id="addCondition"
                 class="c-cs-button c-cs-button--major add-condition-button"
+                :class="{ 'is-disabled': !telemetryObjs.length}"
+                :disabled="!telemetryObjs.length"
                 @click="addCondition"
             >
                 <span class="c-cs-button__label">Add Condition</span>
             </button>
         </div>
-        <div class="c-c condition-collection">
+        <div class="c-c__condition-collection"
+             :class="{ 'is-disabled': !telemetryObjs.length && isEditing}"
+        >
             <ul class="c-c__container-holder">
                 <li v-for="(conditionIdentifier, index) in conditionCollection"
                     :key="conditionIdentifier.key"

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -243,7 +243,7 @@ export default {
             const configurationTemplate = {
                 name: isDefault ? 'Default' : (isClone ? 'Copy of ' : '') + 'Unnamed Condition',
                 output: 'false',
-                trigger: 'any',
+                trigger: 'all',
                 criteria: isDefault ? [] : [{
                     telemetry: '',
                     operation: '',

--- a/src/plugins/condition/components/condition-set.scss
+++ b/src/plugins/condition/components/condition-set.scss
@@ -64,6 +64,10 @@ section {
     margin-top: 5px;
 }
 
+.c-c__condition-collection.is-disabled {
+    opacity: 0.5;
+}
+
 .widget-condition form {
     padding: 0.5em;
     display: flex;
@@ -91,6 +95,10 @@ section {
     font-weight: bold;
     color: #eee;
     border-radius: 6px;
+
+    &.is-disabled {
+        opacity: 0.5;
+    }
 }
 
 .c-cs__disclosure-triangle,

--- a/src/plugins/condition/components/inspector/ConditionalStylesView.vue
+++ b/src/plugins/condition/components/inspector/ConditionalStylesView.vue
@@ -1,0 +1,14 @@
+<template>
+<div>Conditional Styles inspector view</div>
+</template>
+
+<script>
+
+export default {
+    components: {
+    },
+    inject: [
+        'openmct'
+    ]
+}
+</script>

--- a/src/ui/inspector/Inspector.vue
+++ b/src/ui/inspector/Inspector.vue
@@ -1,22 +1,46 @@
 <template>
-<multipane
-    class="c-inspector"
-    type="vertical"
->
-    <pane class="c-inspector__properties">
-        <properties />
-        <location />
-        <inspector-views />
-    </pane>
-    <pane
-        v-if="isEditing && hasComposition"
-        class="c-inspector__elements"
-        handle="before"
-        label="Elements"
+<div class="c-inspector">
+    <div class="c-inspector__tabs"
     >
-        <elements />
-    </pane>
-</multipane>
+        <div v-if="showStyles"
+             class="c-inspector__tabs__holder">
+            <div v-for="tabbedView in tabbedViews"
+                 :key="tabbedView.key"
+                 class="c-inspector__tabs__header"
+                 @click="updateCurrentTab(tabbedView)"
+            >
+                <span class="c-inspector__tabs__label c-tab"
+                      :class="{'is-current': isCurrent(tabbedView)}"
+                >{{ tabbedView.name }}</span>
+            </div>
+        </div>
+        <div class="c-inspector__tabs__contents">
+            <multipane v-if="currentTabbedView.key === '__properties'"
+                       class="c-inspector"
+                       type="vertical"
+            >
+                <pane class="c-inspector__properties">
+                    <properties />
+                    <location />
+                    <inspector-views/>
+                </pane>
+                <pane
+                    v-if="isEditing && hasComposition"
+                    class="c-inspector__elements"
+                    handle="before"
+                    label="Elements"
+                >
+                    <elements />
+                </pane>
+            </multipane>
+            <pane v-else
+                  class="c-inspector__styles"
+            >
+                <styles-inspector-view/>
+            </pane>
+        </div>
+    </div>
+</div>
 </template>
 
 <script>
@@ -26,10 +50,14 @@ import Elements from './Elements.vue';
 import Location from './Location.vue';
 import Properties from './Properties.vue';
 import InspectorViews from './InspectorViews.vue';
+import _ from "lodash";
+import StylesInspectorView from "./StylesInspectorView.vue";
 
 export default {
     inject: ['openmct'],
     components: {
+        StylesInspectorView,
+        // StylesInspectorView,
         multipane,
         pane,
         Elements,
@@ -42,23 +70,56 @@ export default {
     },
     data() {
         return {
-            hasComposition: false
+            hasComposition: false,
+            showStyles: false,
+            tabbedViews: [{
+                key: '__properties',
+                name: 'Properties'
+            },{
+                key: '__styles',
+                name: 'Styles'
+            }],
+            currentTabbedView: {}
         }
     },
     mounted() {
-        this.openmct.selection.on('change', this.refreshComposition);
-        this.refreshComposition(this.openmct.selection.get());
+        this.excludeObjectTypes = ['folder', 'webPage', 'conditionSet'];
+        this.openmct.selection.on('change', this.updateInspectorViews);
     },
     destroyed() {
-        this.openmct.selection.off('change', this.refreshComposition);
+        this.openmct.selection.off('change', this.updateInspectorViews);
     },
     methods: {
+        updateInspectorViews(selection) {
+            this.refreshComposition(selection);
+            if (this.openmct.types.get('conditionSet')) {
+                this.refreshTabs(selection);
+            }
+        },
         refreshComposition(selection) {
             if (selection.length > 0 && selection[0].length > 0) {
                 let parentObject = selection[0][0].context.item;
 
                 this.hasComposition = !!(parentObject && this.openmct.composition.get(parentObject));
             }
+        },
+        refreshTabs(selection) {
+            if (selection.length > 0 && selection[0].length > 0) {
+                //layout items are not domain objects but should allow conditional styles
+                this.showStyles = selection[0][0].context.layoutItem;
+                let object = selection[0][0].context.item;
+                if (object) {
+                    let type = this.openmct.types.get(object.type);
+                    this.showStyles = (this.excludeObjectTypes.indexOf(object.type) < 0) && type.definition.creatable;
+                }
+                this.updateCurrentTab(this.tabbedViews[0]);
+            }
+        },
+        updateCurrentTab(view) {
+            this.currentTabbedView = view;
+        },
+        isCurrent(view) {
+            return _.isEqual(this.currentTabbedView, view)
         }
     }
 }

--- a/src/ui/inspector/InspectorViews.vue
+++ b/src/ui/inspector/InspectorViews.vue
@@ -30,11 +30,10 @@ export default {
                 });
                 this.$el.innerHTML = '';
             }
-
             this.selectedViews = this.openmct.inspectorViews.get(selection);
             this.selectedViews.forEach(selectedView => {
                 let viewContainer = document.createElement('div');
-                this.$el.append(viewContainer)
+                this.$el.append(viewContainer);
                 selectedView.show(viewContainer);
             });
         }

--- a/src/ui/inspector/StylesInspectorView.vue
+++ b/src/ui/inspector/StylesInspectorView.vue
@@ -1,0 +1,52 @@
+<template>
+<div></div>
+</template>
+
+<style>
+</style>
+
+<script>
+import ConditionalStylesView from '../../plugins/condition/components/inspector/ConditionalStylesView.vue';
+import Vue from 'vue';
+
+export default {
+    inject: ['openmct'],
+    data() {
+        return {
+            selection: []
+        }
+    },
+    mounted() {
+        this.openmct.selection.on('change', this.updateSelection);
+        this.updateSelection(this.openmct.selection.get());
+    },
+    destroyed() {
+        this.openmct.selection.off('change', this.updateSelection);
+    },
+    methods: {
+        updateSelection(selection) {
+            this.selection = selection;
+
+            if (this.component) {
+                this.component.$destroy();
+                this.component = undefined;
+                this.$el.innerHTML = '';
+            }
+
+            let viewContainer = document.createElement('div');
+            this.$el.append(viewContainer);
+            this.component = new Vue({
+                provide: {
+                    openmct: this.openmct
+                },
+                el: viewContainer,
+                components: {
+                    ConditionalStylesView
+                },
+                template: '<conditional-styles-view></conditional-styles-view>'
+            });
+
+        }
+    }
+}
+</script>

--- a/src/ui/inspector/inspector.scss
+++ b/src/ui/inspector/inspector.scss
@@ -1,4 +1,6 @@
 .c-inspector {
+    height: 100%;
+
     > [class*="__"] {
         min-height: 50px;
 
@@ -54,6 +56,44 @@
 
     .c-tree .grid-properties {
         margin-left: $treeItemIndent;
+    }
+
+    &__tabs {
+        $h: 20px;
+        @include abs();
+        display: flex;
+        flex-flow: column nowrap;
+
+        > * + * {
+            margin-top: $interiorMargin;
+        }
+
+        &__holder {
+            display: flex;
+            min-height: $h;
+
+            &__header {
+
+                &:before {
+                    margin-right: $interiorMarginSm;
+                    opacity: 0.7;
+                }
+            }
+        }
+
+        &__contents {
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+
+            &--hidden {
+                height: 1000px;
+                width: 1000px;
+                position: absolute;
+                left: -9999px;
+                top: -9999px;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Satisfies both requirements:
1) label preceding criteria rows beyond the first changes from "and when" for Match when all selection, and "or when" for Match when any.
2) output does not fire for criteria that are mutually exclusive.

Resolves issue: #2682