### PR TITLE
Condition disable adding or editing conditions without telemetry

### DIFF
--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -68,6 +68,7 @@
                                         <input v-model="domainObject.configuration.name"
                                                class="t-condition-input__name"
                                                type="text"
+                                               :disabled="!telemetry.length"
                                         >
                                     </span>
                                 </li>
@@ -75,6 +76,7 @@
                                     <label>Output</label>
                                     <span class="controls">
                                         <select v-model="selectedOutputKey"
+                                                :disabled="!telemetry.length"
                                                 @change="checkInputValue"
                                         >
                                             <option value="">- Select Output -</option>

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -38,19 +38,24 @@
         <div v-show="isEditing"
              class="help"
         >
-            <span>The first condition to match is the one that wins. Drag conditions to rearrange.</span>
+            <span v-if="!telemetryObjs.length">Drag telemetry into Condition Set in order to add or edit conditions.</span>
+            <span v-else>The first condition to match is the one that wins. Drag conditions to rearrange.</span>
         </div>
         <div class="holder add-condition-button-wrapper align-left">
             <button
                 v-show="isEditing"
                 id="addCondition"
                 class="c-cs-button c-cs-button--major add-condition-button"
+                :class="{ 'is-disabled': !telemetryObjs.length}"
+                :disabled="!telemetryObjs.length"
                 @click="addCondition"
             >
                 <span class="c-cs-button__label">Add Condition</span>
             </button>
         </div>
-        <div class="c-c condition-collection">
+        <div class="c-c__condition-collection"
+             :class="{ 'is-disabled': !telemetryObjs.length && isEditing}"
+        >
             <ul class="c-c__container-holder">
                 <li v-for="(conditionIdentifier, index) in conditionCollection"
                     :key="conditionIdentifier.key"

--- a/src/plugins/condition/components/condition-set.scss
+++ b/src/plugins/condition/components/condition-set.scss
@@ -64,6 +64,10 @@ section {
     margin-top: 5px;
 }
 
+.c-c__condition-collection.is-disabled {
+    opacity: 0.5;
+}
+
 .widget-condition form {
     padding: 0.5em;
     display: flex;
@@ -91,6 +95,10 @@ section {
     font-weight: bold;
     color: #eee;
     border-radius: 6px;
+
+    &.is-disabled {
+        opacity: 0.5;
+    }
 }
 
 .c-cs__disclosure-triangle,


### PR DESCRIPTION
Added disabled prop to Add Condition button and default condition input fields. Added is-disabled class to button and condition collection. When telemetry is added disabled prop evaluates false and class is removed. Instructions note is also conditional.

Resolves issue: #2681
