### PR TITLE
Add setData on dragStart for FF support

### DIFF
--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -31,6 +31,7 @@
                   :class="{ 'is-enabled': !domainObject.isDefault }"
                   :draggable="!domainObject.isDefault"
                   @dragstart="dragStart"
+                  @dragstop="dragStop"
                   @dragover.stop
             ></span>
             <span
@@ -245,6 +246,9 @@ export default {
             e.dataTransfer.effectAllowed = "copyMove";
             e.dataTransfer.setDragImage(e.target.closest('.c-c-container__container'), 0, 0);
             this.$emit('setMoveIndex', this.conditionIndex);
+        },
+        dragStop(e) {
+            e.dataTransfer.clearData();
         },
         destroy() {
         },

--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -236,6 +236,7 @@ export default {
             this.domainObject.configuration.criteria.push(criteriaObject);
         },
         dragStart(e) {
+            e.dataTransfer.setData('dragging', e.target); // required for FF to initiate drag
             e.dataTransfer.effectAllowed = "copyMove";
             e.dataTransfer.setDragImage(e.target.closest('.c-c-container__container'), 0, 0);
             this.$emit('setMoveIndex', this.conditionIndex);


### PR DESCRIPTION
FF requires that an element to be draggable must contain data. Added a call to dataTransfer.setData to dragStart method.