### PR TITLE
Conditionals fix trigger

### DIFF
--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -208,6 +208,12 @@ export default class ConditionClass extends EventEmitter {
         })
     }
 
+    handleConditionUpdated() {
+        // trigger an updated event so that consumers can react accordingly
+        this.evaluate();
+        this.emitEvent('conditionResultUpdated', {result: this.result});
+    }
+
     getCriteria() {
         return this.criteria;
     }
@@ -219,6 +225,10 @@ export default class ConditionClass extends EventEmitter {
             success = success && this.destroyCriterion(this.criteria[i].id);
         }
         return success;
+    }
+
+    evaluate() {
+        this.result = computeCondition(this.criteriaResults, this.trigger === TRIGGER.ALL);
     }
 
     emitEvent(eventName, data) {


### PR DESCRIPTION
Changing "Match when any'all" control in a condition caused an error to be thrown in condition.js on the call to this.handleConditionUpdated() in updateTrigger (funciton can't be found). Adding that function back in to the class caused same error for this.evaluate. Adding that method back to the class resolved the issue.

Resolves issue: #2714