### PR TITLE
[Conditions] Use latest incoming telemetry timestamp for providing telemetry

### DIFF
--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -191,15 +191,12 @@ export default class ConditionClass extends EventEmitter {
 
     handleCriterionResult(eventData) {
         const id = eventData.id;
-        const conditionData = eventData.data;
 
         if (this.findCriterion(id)) {
             this.criteriaResults[id] = eventData.data.result;
         }
 
-        this.handleConditionUpdated();
-        // conditionData.result = computeCondition(this.criteriaResults, this.trigger === TRIGGER.ALL);
-        // this.emitEvent('conditionResultUpdated', conditionData);
+        this.handleConditionUpdated(eventData.data);
     }
 
     subscribe() {
@@ -209,10 +206,12 @@ export default class ConditionClass extends EventEmitter {
         })
     }
 
-    handleConditionUpdated() {
+    handleConditionUpdated(datum) {
         // trigger an updated event so that consumers can react accordingly
         this.evaluate();
-        this.emitEvent('conditionResultUpdated', {result: this.result});
+        this.emitEvent('conditionResultUpdated',
+            Object.assign({}, datum, { result: this.result })
+        );
     }
 
     getCriteria() {

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -192,13 +192,14 @@ export default class ConditionClass extends EventEmitter {
     handleCriterionResult(eventData) {
         const id = eventData.id;
         const conditionData = eventData.data;
-        
+
         if (this.findCriterion(id)) {
             this.criteriaResults[id] = eventData.data.result;
         }
 
-        conditionData.result = computeCondition(this.criteriaResults, this.trigger === TRIGGER.ALL);
-        this.emitEvent('conditionResultUpdated', conditionData);
+        this.handleConditionUpdated();
+        // conditionData.result = computeCondition(this.criteriaResults, this.trigger === TRIGGER.ALL);
+        // this.emitEvent('conditionResultUpdated', conditionData);
     }
 
     subscribe() {
@@ -206,6 +207,12 @@ export default class ConditionClass extends EventEmitter {
         this.criteria.forEach((criterion) => {
             criterion.subscribe();
         })
+    }
+
+    handleConditionUpdated() {
+        // trigger an updated event so that consumers can react accordingly
+        this.evaluate();
+        this.emitEvent('conditionResultUpdated', {result: this.result});
     }
 
     getCriteria() {
@@ -219,6 +226,10 @@ export default class ConditionClass extends EventEmitter {
             success = success && this.destroyCriterion(this.criteria[i].id);
         }
         return success;
+    }
+
+    evaluate() {
+        this.result = computeCondition(this.criteriaResults, this.trigger === TRIGGER.ALL);
     }
 
     emitEvent(eventName, data) {

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -29,6 +29,8 @@ export default class ConditionManager extends EventEmitter {
         super();
         this.domainObject = domainObject;
         this.openmct = openmct;
+        this.timeAPI = this.openmct.time;
+        this.latestTimestamp = {};
         this.instantiate = this.openmct.$injector.get('instantiate');
         this.initialize();
     }
@@ -213,6 +215,7 @@ export default class ConditionManager extends EventEmitter {
             if (this.findConditionById(idAsString)) {
                 this.conditionResults[idAsString] = resultObj.data.result;
             }
+            this.updateTimestamp(resultObj.data);
         }
 
         for (let i = 0; i < conditionCollection.length - 1; i++) {
@@ -226,15 +229,25 @@ export default class ConditionManager extends EventEmitter {
 
         this.openmct.objects.get(currentConditionIdentifier).then((obj) => {
             this.emit('conditionSetResultUpdated',
-                Object.assign({},
-                    resultObj ? resultObj.data : {},
+                Object.assign(
                     {
                         output: obj.configuration.output,
                         id: this.domainObject.identifier,
                         conditionId: currentConditionIdentifier
-                    }
+                    },
+                    this.latestTimestamp
                 )
             )
+        });
+    }
+
+    updateTimestamp(timestamp) {
+        this.timeAPI.getAllTimeSystems().forEach(timeSystem => {
+            if (!this.latestTimestamp[timeSystem.key]
+                || timestamp[timeSystem.key] > this.latestTimestamp[timeSystem.key]
+            ) {
+                this.latestTimestamp[timeSystem.key] = timestamp[timeSystem.key];
+            }
         });
     }
 

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -56,12 +56,14 @@ export default class TelemetryCriterion extends EventEmitter {
     }
 
     handleSubscription(data) {
-        const datum = {};
-        const timeSystemKey = this.timeAPI.timeSystem().key;
-
-        datum.result = this.computeResult(data);
-        if (data && data[timeSystemKey]) {
-            datum[timeSystemKey] = data[timeSystemKey]
+        const datum = {
+            result: this.computeResult(data)
+        };
+        if (data) {
+            // TODO check back to see if we should format times here
+            this.timeAPI.getAllTimeSystems().forEach(timeSystem => {
+                datum[timeSystem.key] = data[timeSystem.key]
+            });
         }
 
         this.emitEvent('criterionResultUpdated', datum);

--- a/src/plugins/condition/criterion/TelemetryCriterionSpec.js
+++ b/src/plugins/condition/criterion/TelemetryCriterionSpec.js
@@ -63,10 +63,11 @@ describe("The telemetry criterion", function () {
         openmct.telemetry.getMetadata.and.returnValue(testTelemetryObject.telemetry.values);
 
         openmct.time = jasmine.createSpyObj('timeAPI',
-            ['timeSystem', 'bounds']
+            ['timeSystem', 'bounds', 'getAllTimeSystems']
         );
         openmct.time.timeSystem.and.returnValue({key: 'system'});
         openmct.time.bounds.and.returnValue({start: 0, end: 1});
+        openmct.time.getAllTimeSystems.and.returnValue([{key: 'system'}]);
 
         testCriterionDefinition = {
             id: 'test-criterion-id',


### PR DESCRIPTION
## Overview
- latest timestamp is updated with each incoming telemetry datum
- use latest available timestamp for providing telemetry with each new condition calculation
  - on new incoming telemetry datum
  - on changes to condition configuration (ie. removing criteria)
- historical requests to be done in separate PR

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | Y |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |