### PR TITLE
Fixed scss files to work on Windows

### DIFF
--- a/src/plugins/themes/espresso-theme.scss
+++ b/src/plugins/themes/espresso-theme.scss
@@ -1,22 +1,22 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-espresso";
+@import "../../styles/constants-espresso";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/layout";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/layout";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";

--- a/src/plugins/themes/maelstrom-theme.scss
+++ b/src/plugins/themes/maelstrom-theme.scss
@@ -1,22 +1,22 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-maelstrom";
+@import "../../styles/constants-maelstrom";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/layout";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/layout";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";

--- a/src/plugins/themes/snow-theme.scss
+++ b/src/plugins/themes/snow-theme.scss
@@ -1,22 +1,22 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-snow";
+@import "../../styles/constants-snow";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/layout";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/layout";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";


### PR DESCRIPTION
Fixed scss files to work on Windows as noted in issue #2604 

Tested on Windows 10 (node v13, npm v6) and Ubuntu 18 (node v12, npm v6)