### PR TITLE
Adds customizable randomness factor to sine wave generator

### DIFF
--- a/example/generator/GeneratorProvider.js
+++ b/example/generator/GeneratorProvider.js
@@ -31,6 +31,7 @@ define([
         period: 10,
         offset: 0,
         dataRateInHz: 1,
+        randomness: 0,
         phase: 0
     };
 
@@ -52,7 +53,8 @@ define([
             'period',
             'offset',
             'dataRateInHz',
-            'phase'
+            'phase',
+            'randomness'
         ];
 
         request = request || {};

--- a/example/generator/generatorWorker.js
+++ b/example/generator/generatorWorker.js
@@ -65,8 +65,8 @@
                         name: data.name,
                         utc: nextStep,
                         yesterday: nextStep - 60*60*24*1000,
-                        sin: sin(nextStep, data.period, data.amplitude, data.offset, data.phase),
-                        cos: cos(nextStep, data.period, data.amplitude, data.offset, data.phase)
+                        sin: sin(nextStep, data.period, data.amplitude, data.offset, data.phase, data.randomness),
+                        cos: cos(nextStep, data.period, data.amplitude, data.offset, data.phase, data.randomness)
                     }
                 });
                 nextStep += step;
@@ -99,19 +99,20 @@
         var offset = request.offset;
         var dataRateInHz = request.dataRateInHz;
         var phase = request.phase;
+        var randomness = request.randomness;
 
         var step = 1000 / dataRateInHz;
         var nextStep = start - (start % step) + step;
 
         var data = [];
 
-        for (; nextStep < end && data.length < 5000; nextStep += step) {
+        for (; nextStep < end && data.length < 50000; nextStep += step) {
             data.push({
                 name: request.name,
                 utc: nextStep,
                 yesterday: nextStep - 60*60*24*1000,
-                sin: sin(nextStep, period, amplitude, offset, phase),
-                cos: cos(nextStep, period, amplitude, offset, phase)
+                sin: sin(nextStep, period, amplitude, offset, phase, randomness),
+                cos: cos(nextStep, period, amplitude, offset, phase, randomness)
             });
         }
         self.postMessage({
@@ -120,14 +121,14 @@
         });
     }
 
-    function cos(timestamp, period, amplitude, offset, phase) {
+    function cos(timestamp, period, amplitude, offset, phase, randomness) {
         return amplitude *
-            Math.cos(phase + (timestamp / period / 1000 * Math.PI * 2)) + offset;
+            Math.cos(phase + (timestamp / period / 1000 * Math.PI * 2)) + (amplitude * Math.random() * randomness) + offset;
     }
 
-    function sin(timestamp, period, amplitude, offset, phase) {
+    function sin(timestamp, period, amplitude, offset, phase, randomness) {
         return amplitude *
-            Math.sin(phase + (timestamp / period / 1000 * Math.PI * 2)) + offset;
+            Math.sin(phase + (timestamp / period / 1000 * Math.PI * 2)) + (amplitude * Math.random() * randomness) + offset;
     }
 
     function sendError(error, message) {

--- a/example/generator/generatorWorker.js
+++ b/example/generator/generatorWorker.js
@@ -106,7 +106,7 @@
 
         var data = [];
 
-        for (; nextStep < end && data.length < 50000; nextStep += step) {
+        for (; nextStep < end && data.length < 5000; nextStep += step) {
             data.push({
                 name: request.name,
                 utc: nextStep,

--- a/example/generator/plugin.js
+++ b/example/generator/plugin.js
@@ -122,6 +122,17 @@ define([
                         "telemetry",
                         "phase"
                     ]
+                },
+                {
+                    name: "Randomness",
+                    control: "numberfield",
+                    cssClass: "l-input-sm l-numeric",
+                    key: "randomness",
+                    required: true,
+                    property: [
+                        "telemetry",
+                        "randomness"
+                    ]
                 }
             ],
             initialize: function (object) {
@@ -130,7 +141,8 @@ define([
                     amplitude: 1,
                     offset: 0,
                     dataRateInHz: 1,
-                    phase: 0
+                    phase: 0,
+                    randomness: 0
                 };
             }
         });


### PR DESCRIPTION
Adds a new 'randomness' parameter to Sine Wave Generator objects. This is a user-definable factor that will be applied to values generated by thee Sine Wave Generator. A value of `0` (the default) will apply no randomness. A value of `1` will add a random number to each generated value with a maximum equal to the amplitude of the sine wave.

## Author Checklist

* Changes address original issue? Y
* Unit tests included and/or updated with changes?
* Command line build passes?
* Changes have been smoke-tested?