### PR TITLE
Revert minMax to minmax

### DIFF
--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -143,7 +143,7 @@ define([
             let strategy;
 
             if (this.model.interpolate !== 'none') {
-                strategy = 'minMax';
+                strategy = 'minmax';
             }
 
             options = _.extend({}, { size: 1000, strategy, filters: this.filters }, options || {});


### PR DESCRIPTION
A fix for a bug introduced during a fix for issue #2381.

The typo in minmax was causing providers not to recognize when to use the minmax strategy. Reported by S6/SWOT on 3/6/2020

## Author Checklist
Changes address original issue? Y
Unit tests included and/or updated with changes? N/A
Command line build passes? Y
Changes have been smoke-tested? Y