### PR TITLE
[Conditions] ConditionManager should observe its own mutations

### DIFF
--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -32,6 +32,10 @@ export default class ConditionManager extends EventEmitter {
         this.timeAPI = this.openmct.time;
         this.latestTimestamp = {};
         this.initialize();
+
+        this.stopObservingForChanges = this.openmct.objects.observe(this.conditionSetDomainObject, '*', (newDomainObject) => {
+            this.update(newDomainObject);
+        });
     }
 
     initialize() {
@@ -48,6 +52,9 @@ export default class ConditionManager extends EventEmitter {
     update(newDomainObject) {
         this.destroy();
         this.conditionSetDomainObject = newDomainObject;
+        this.stopObservingForChanges = this.openmct.objects.observe(this.conditionSetDomainObject, '*', (newDO) => {
+            this.update(newDO);
+        });
         this.initialize();
     }
 
@@ -218,6 +225,9 @@ export default class ConditionManager extends EventEmitter {
     }
 
     destroy() {
+        if(this.stopObservingForChanges) {
+            this.stopObservingForChanges();
+        }
         this.conditionClassCollection.forEach((condition) => {
             condition.off('conditionResultUpdated', this.handleConditionResult);
             condition.destroy();

--- a/src/plugins/condition/ConditionSetTelemetryProvider.js
+++ b/src/plugins/condition/ConditionSetTelemetryProvider.js
@@ -43,16 +43,9 @@ export default class ConditionSetTelemetryProvider {
         let conditionManager = new ConditionManager(domainObject, this.openmct);
         conditionManager.on('conditionSetResultUpdated', callback);
 
-        let stopObservingForChanges = this.openmct.objects.observe(domainObject, '*', (newDomainObject) => {
-            conditionManager.update(newDomainObject);
-        });
-
         return function unsubscribe() {
             conditionManager.off('conditionSetResultUpdated');
             conditionManager.destroy();
-            if (stopObservingForChanges) {
-                stopObservingForChanges();
-            }
         }
     }
 }

--- a/src/plugins/condition/components/Criterion.vue
+++ b/src/plugins/condition/components/Criterion.vue
@@ -52,7 +52,7 @@
                 <input v-model="criterion.input[inputIndex]"
                        class="c-cdef__control__input"
                        type="text"
-                       @blur="persist"
+                       @change="persist"
                 >
                 <span v-if="inputIndex < inputCount-1">and</span>
             </span>


### PR DESCRIPTION
## Overview
Addresses comments in #2747
- move ConditionManager observe logic out of telemetry provider and into ConditionManager

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |