### PR TITLE
Remove telemetry subscription from conditionSet edit view

### DIFF
--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -34,7 +34,7 @@ export default class ConditionManager extends EventEmitter {
         this.initialize();
 
         this.stopObservingForChanges = this.openmct.objects.observe(this.conditionSetDomainObject, '*', (newDomainObject) => {
-            this.update(newDomainObject);
+            this.conditionSetDomainObject = newDomainObject;
         });
     }
 
@@ -46,15 +46,6 @@ export default class ConditionManager extends EventEmitter {
                 this.initCondition(conditionConfiguration, index);
             });
         }
-    }
-
-    update(newDomainObject) {
-        this.destroy();
-        this.conditionSetDomainObject = newDomainObject;
-        this.stopObservingForChanges = this.openmct.objects.observe(this.conditionSetDomainObject, '*', (newDO) => {
-            this.update(newDO);
-        });
-        this.initialize();
     }
 
     updateCondition(conditionConfiguration, index) {

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -121,6 +121,9 @@ export default {
         this.conditionCollection = this.domainObject.configuration.conditionCollection;
         this.observeForChanges();
         this.conditionManager = new ConditionManager(this.domainObject, this.openmct);
+        this.conditionManager.on('conditionSetResultUpdated', (data) => {
+            this.$emit('conditionSetResultUpdated', data);
+        })
     },
     methods: {
         observeForChanges() {

--- a/src/plugins/condition/components/ConditionSet.vue
+++ b/src/plugins/condition/components/ConditionSet.vue
@@ -34,7 +34,8 @@
         </div>
     </section>
     <TestData :is-editing="isEditing" />
-    <ConditionCollection :is-editing="isEditing" />
+    <ConditionCollection :is-editing="isEditing"
+                         @conditionSetResultUpdated="updateCurrentOutput" />
 </div>
 </template>
 
@@ -58,7 +59,6 @@ export default {
     },
     mounted() {
         this.conditionSetIdentifier = this.openmct.objects.makeKeyString(this.domainObject.identifier);
-        this.provideTelemetry();
     },
     beforeDestroy() {
         if (this.stopProvidingTelemetry) {
@@ -68,13 +68,6 @@ export default {
     methods: {
         updateCurrentOutput(currentConditionResult) {
             this.currentConditionOutput = currentConditionResult.output;
-        },
-        provideTelemetry() {
-            if (this.stopProvidingTelemetry) {
-                this.stopProvidingTelemetry();
-            }
-            this.stopProvidingTelemetry = this.openmct.telemetry
-                .subscribe(this.domainObject, output => { this.updateCurrentOutput(output); });
         }
     }
 };


### PR DESCRIPTION
ConditionSet view listens to an event from conditionCollection to display current output.

**Author Checklist**

- Changes address original issue? Yes
- Unit tests included and/or updated with changes? Yes
- Command line build passes? Yes
- Changes have been smoke-tested? Yes