### PR TITLE
[Conditions] Enable dropping Condition Sets into overlay plots

### DIFF
--- a/src/plugins/condition/ConditionSetMetadataProvider.js
+++ b/src/plugins/condition/ConditionSetMetadataProvider.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2020, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 export default class ConditionSetMetadataProvider {
     constructor(openmct) {
         this.openmct = openmct;
@@ -21,12 +43,21 @@ export default class ConditionSetMetadataProvider {
     }
 
     getMetadata(domainObject) {
+        const enumerations = domainObject.configuration.conditionCollection
+            .map((condition, index) => {
+                return {
+                    string: condition.configuration.output,
+                    value: index
+                };
+            });
+
         return {
             values: this.getDomains().concat([
                 {
                     name: 'Output',
                     key: 'output',
-                    format: 'string',
+                    format: 'enum',
+                    enumerations: enumerations,
                     hints: {
                         range: 1
                     }

--- a/src/plugins/condition/ConditionSetViewPolicy.js
+++ b/src/plugins/condition/ConditionSetViewPolicy.js
@@ -1,0 +1,33 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2020, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+function ConditionSetViewPolicy() {
+}
+
+ConditionSetViewPolicy.prototype.allow = function (view, domainObject) {
+    if (domainObject.getModel().type === 'conditionSet') {
+        return view.key === 'conditionSet.view';
+    }
+    return true;
+}
+
+export default ConditionSetViewPolicy;

--- a/src/plugins/condition/ConditionSetViewProvider.js
+++ b/src/plugins/condition/ConditionSetViewProvider.js
@@ -30,7 +30,7 @@ export default class ConditionSetViewProvider {
         this.openmct = openmct;
         this.name = 'Conditions View';
         this.key = 'conditionSet.view';
-        this.cssClass = 'icon-conditional'; // TODO: replace with class for new icon
+        this.cssClass = 'icon-conditional';
     }
 
     canView(domainObject) {

--- a/src/plugins/condition/plugin.js
+++ b/src/plugins/condition/plugin.js
@@ -23,6 +23,7 @@ import ConditionSetViewProvider from './ConditionSetViewProvider.js';
 import ConditionSetCompositionPolicy from "./ConditionSetCompositionPolicy";
 import ConditionSetMetadataProvider from './ConditionSetMetadataProvider';
 import ConditionSetTelemetryProvider from './ConditionSetTelemetryProvider';
+import ConditionSetViewPolicy from './ConditionSetViewPolicy';
 import uuid from "uuid";
 
 export default function ConditionPlugin() {
@@ -53,7 +54,10 @@ export default function ConditionPlugin() {
                 domainObject.telemetry = {};
             }
         });
-
+        openmct.legacyExtension('policies', {
+            category: 'view',
+            implementation: ConditionSetViewPolicy
+        });
         openmct.composition.addPolicy(new ConditionSetCompositionPolicy(openmct).allow);
         openmct.telemetry.addProvider(new ConditionSetMetadataProvider(openmct));
         openmct.telemetry.addProvider(new ConditionSetTelemetryProvider(openmct));

--- a/src/plugins/condition/plugin.js
+++ b/src/plugins/condition/plugin.js
@@ -35,7 +35,7 @@ export default function ConditionPlugin() {
             key: 'conditionSet',
             description: 'A set of one or more conditions based on user-specified criteria.',
             creatable: true,
-            cssClass: 'icon-conditional',  // TODO: replace with class for new icon
+            cssClass: 'icon-conditional',
             initialize: function (domainObject) {
                 domainObject.configuration = {
                     conditionCollection: [{

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -82,7 +82,10 @@ describe('the plugin', function () {
         it('provides a view', () => {
             const testViewObject = {
                 id:"test-object",
-                type: "conditionSet"
+                type: "conditionSet",
+                configuration: {
+                    conditionCollection: []
+                }
             };
 
             const applicableViews = openmct.objectViews.get(testViewObject);


### PR DESCRIPTION
## Overview
Addresses #2743
- allow condition set nodes to be dropped into overlay plots, and display plotted outputs
- suppress plot view when viewing condition set nodes

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | Y |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |