### PR TITLE
[Telemetry Tables] Duplicate requests when users change time system

### DIFF
--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -181,7 +181,7 @@ define([
         }
 
         refreshData(bounds, isTick) {
-            if (!isTick) {
+            if (!isTick && this.outstandingRequests === 0) {
                 this.filteredRows.clear();
                 this.boundedRows.clear();
                 this.boundedRows.sortByTimeSystem(this.openmct.time.timeSystem());


### PR DESCRIPTION
When a time system is changed, it emits a timeSystem update as well as a bounds update, this caused telemetry table to request data twice when users changed time systems

This PR fixes that by checking outstanding requests before requesting again. 