### PR TITLE
Global Filters not re-requesting on value change

### DIFF
--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -377,8 +377,11 @@ define([
          * @public
          */
         updateFiltersAndRefresh: function (updatedFilters) {
-            if (this.filters && !_.isEqual(this.filters, updatedFilters)) {
-                this.filters = updatedFilters;
+            let deepCopiedFilters = JSON.parse(JSON.stringify(updatedFilters));
+
+            if (this.filters && !_.isEqual(this.filters, deepCopiedFilters)) {
+                console.log('actually updating');
+                this.filters = deepCopiedFilters;
                 this.reset();
                 if (this.unsubscribe) {
                     this.unsubscribe();
@@ -386,7 +389,7 @@ define([
                 }
                 this.fetch();
             } else {
-                this.filters = updatedFilters;
+                this.filters = deepCopiedFilters;
             }
         }
     });

--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -380,7 +380,6 @@ define([
             let deepCopiedFilters = JSON.parse(JSON.stringify(updatedFilters));
 
             if (this.filters && !_.isEqual(this.filters, deepCopiedFilters)) {
-                console.log('actually updating');
                 this.filters = deepCopiedFilters;
                 this.reset();
                 if (this.unsubscribe) {


### PR DESCRIPTION
make a copy of filters before checking isEqual
- to prevent using same pointer

## Author Checklist
Changes address original issue? Y
Unit tests included and/or updated with changes? N/A
Command line build passes? Y
Changes have been smoke-tested? Y