### PR TITLE
[Tables] Use parsed data to sort

### DIFF
--- a/src/plugins/telemetryTable/TelemetryTableColumn.js
+++ b/src/plugins/telemetryTable/TelemetryTableColumn.js
@@ -56,6 +56,14 @@ define(function () {
                 return formattedValue;
             }
         }
+
+        getParsedValue(telemetryDatum) {
+            if (telemetryDatum === undefined) {
+                return '';
+            } else {
+                return this.formatter.parse(telemetryDatum);
+            }
+        }
     }
 
     return TelemetryTableColumn;

--- a/src/plugins/telemetryTable/TelemetryTableColumn.js
+++ b/src/plugins/telemetryTable/TelemetryTableColumn.js
@@ -58,11 +58,7 @@ define(function () {
         }
 
         getParsedValue(telemetryDatum) {
-            if (telemetryDatum === undefined) {
-                return '';
-            } else {
-                return this.formatter.parse(telemetryDatum);
-            }
+            return this.formatter.parse(telemetryDatum);
         }
     }
 

--- a/src/plugins/telemetryTable/TelemetryTableRow.js
+++ b/src/plugins/telemetryTable/TelemetryTableRow.js
@@ -42,6 +42,11 @@ define([], function () {
             return column && column.getFormattedValue(this.datum[key]);
         }
 
+        getParsedValue(key) {
+            let column = this.columns[key];
+            return column && column.getParsedValue(this.datum[key]);
+        }
+
         getCellComponentName(key) {
             let column = this.columns[key];
             return column &&

--- a/src/plugins/telemetryTable/collections/SortedTableRowCollection.js
+++ b/src/plugins/telemetryTable/collections/SortedTableRowCollection.js
@@ -201,7 +201,7 @@ define(
             sortBy(sortOptions) {
                 if (arguments.length > 0) {
                     this.sortOptions = sortOptions;
-                    this.rows = _.sortByOrder(this.rows, 'datum.' + sortOptions.key, sortOptions.direction);
+                    this.rows = _.sortByOrder(this.rows, (row) => row.getParsedValue(sortOptions.key) , sortOptions.direction);
                     this.emit('sort');
                 }
                 // Return duplicate to avoid direct modification of underlying object
@@ -222,7 +222,7 @@ define(
             }
 
             getValueForSortColumn(row) {
-                return row.datum[this.sortOptions.key];
+                return row.getParsedValue(this.sortOptions.key);
             }
 
             remove(removedRows) {


### PR DESCRIPTION
Tables in the past were using raw data to sort values. This caused issues when all data coming from a server was sent as strings.

Solution: User formatter parsed values to sort. 

