### PR TITLE
Remove telemetry and remove conditions from condition set

### DIFF
--- a/src/plugins/condition/ConditionSetTelemetryProvider.js
+++ b/src/plugins/condition/ConditionSetTelemetryProvider.js
@@ -77,8 +77,10 @@ export default class ConditionSetTelemetryProvider {
      * can be called manually for views that only request but do not subscribe to data
      */
     destroyConditionManager(id) {
-        this.conditionManagerPool[id].off('conditionSetResultUpdated');
-        this.conditionManagerPool[id].destroy();
-        delete this.conditionManagerPool[id];
+        if (this.conditionManagerPool[id]) {
+            this.conditionManagerPool[id].off('conditionSetResultUpdated');
+            this.conditionManagerPool[id].destroy();
+            delete this.conditionManagerPool[id];
+        }
     }
 }

--- a/src/plugins/condition/StyleRuleManager.js
+++ b/src/plugins/condition/StyleRuleManager.js
@@ -49,7 +49,11 @@ export default class StyleRuleManager extends EventEmitter {
         }
         this.openmct.objects.get(this.conditionSetIdentifier).then((conditionSetDomainObject) => {
             this.openmct.telemetry.request(conditionSetDomainObject)
-                .then(output => this.handleConditionSetResultUpdated(output));
+                .then(output => {
+                    if (output && output.length) {
+                        this.handleConditionSetResultUpdated(output[0]);
+                    }
+                });
             this.stopProvidingTelemetry = this.openmct.telemetry.subscribe(conditionSetDomainObject, output => this.handleConditionSetResultUpdated(output));
         });
     }
@@ -60,7 +64,7 @@ export default class StyleRuleManager extends EventEmitter {
             this.destroy();
         } else {
             let isNewConditionSet = !this.conditionSetIdentifier ||
-                                    this.openmct.objects.areIdsEqual(this.conditionSetIdentifier, styleConfiguration.conditionSetIdentifier);
+                                    !this.openmct.objects.areIdsEqual(this.conditionSetIdentifier, styleConfiguration.conditionSetIdentifier);
             this.initialize(styleConfiguration);
             //Only resubscribe if the conditionSet has changed.
             if (isNewConditionSet) {

--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -119,7 +119,7 @@
                 </select>
             </span>
 
-            <template v-if="telemetry.length">
+            <template v-if="telemetry.length || condition.configuration.criteria.length">
                 <div v-for="(criterion, index) in condition.configuration.criteria"
                      :key="index"
                      class="c-cdef__criteria"

--- a/src/plugins/condition/components/Criterion.vue
+++ b/src/plugins/condition/components/Criterion.vue
@@ -114,6 +114,14 @@ export default {
             inputTypes: INPUT_TYPES
         }
     },
+    watch: {
+        telemetry: {
+            handler(newTelemetry, oldTelemetry) {
+                this.checkTelemetry();
+            },
+            deep: true
+        }
+    },
     computed: {
         setRowLabel: function () {
             let operator = this.trigger === 'all' ? 'and ': 'or ';
@@ -141,6 +149,17 @@ export default {
         this.updateMetadataOptions();
     },
     methods: {
+        checkTelemetry() {
+            if(this.criterion.telemetry &&
+                !this.telemetry.find((telemetryObj) => this.openmct.objects.areIdsEqual(this.criterion.telemetry, telemetryObj.identifier))) {
+                //telemetry being used was removed. So reset this criterion.
+                this.criterion.telemetry = '';
+                this.criterion.metadata = '';
+                this.criterion.input = [];
+                this.criterion.operation = '';
+                this.persist();
+            }
+        },
         getOperationFormat() {
             this.enumerations = [];
             this.telemetryMetadata.valueMetadatas.forEach((value, index) => {

--- a/src/plugins/condition/components/inspector/ConditionalStylesView.vue
+++ b/src/plugins/condition/components/inspector/ConditionalStylesView.vue
@@ -262,18 +262,22 @@ export default {
             if (!this.conditions) {
                 this.conditions = {};
             }
+            let conditionalStyles = [];
             this.conditionSetDomainObject.configuration.conditionCollection.forEach((conditionConfiguration, index) => {
                 this.conditions[conditionConfiguration.id] = conditionConfiguration;
                 let foundStyle = this.findStyleByConditionId(conditionConfiguration.id);
                 if (foundStyle) {
                     foundStyle.style = Object.assign((this.canHide ? { isStyleInvisible: '' } : {}), this.initialStyles, foundStyle.style);
+                    conditionalStyles.push(foundStyle);
                 } else {
-                    this.conditionalStyles.splice(index, 0, {
+                    conditionalStyles.splice(index, 0, {
                         conditionId: conditionConfiguration.id,
                         style: Object.assign((this.canHide ? { isStyleInvisible: '' } : {}), this.initialStyles)
                     });
                 }
             });
+            //we're doing this so that we remove styles for any conditions that have been removed from the condition set
+            this.conditionalStyles = conditionalStyles;
             this.conditionsLoaded = true;
             this.persist(this.getDomainObjectConditionalStyle());
         },

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -120,7 +120,10 @@ export default class TelemetryCriterion extends EventEmitter {
         );
 
         if (!this.isValid()) {
-            return this.formatData({});
+            return {
+                id: this.id,
+                data: this.formatData({})
+            };
         }
 
         return this.telemetryAPI.request(


### PR DESCRIPTION
Handles remove telemetry from condition set - this resets criterion properties
Handles remove condition from a condition set that's being used in a conditional style.
Fixes a small bug with stye rule manager request lad results
Resolves part of #2772 

**Author Checklist**
- Changes address original issue? Yes
- Unit tests included and/or updated with changes? No
- Command line build passes? Yes
- Changes have been smoke-tested? Yes