### PR TITLE
Clone condition, criteria issues

### DIFF
--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -108,7 +108,7 @@ export default class ConditionManager extends EventEmitter {
                 ...conditionConfiguration,
                 id: uuid(),
                 configuration: {
-                    ...JSON.parse(JSON.stringify(conditionConfiguration)).configuration,
+                    ...conditionConfiguration.configuration,
                     name: `Copy of ${conditionConfiguration.configuration.name}`
                 }
             };
@@ -138,7 +138,7 @@ export default class ConditionManager extends EventEmitter {
     }
 
     cloneCondition(conditionConfiguration, index) {
-        this.createAndSaveCondition(index, conditionConfiguration);
+        this.createAndSaveCondition(index, JSON.parse(JSON.stringify(conditionConfiguration)));
     }
 
     createAndSaveCondition(index, conditionConfiguration) {

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -103,16 +103,12 @@ export default class ConditionManager extends EventEmitter {
 
     createCondition(conditionConfiguration) {
         let conditionObj;
-        let newConfiguration;
-        if (conditionConfiguration) {
-            newConfiguration = JSON.parse(JSON.stringify(conditionConfiguration));
-        }
         if (conditionConfiguration) {
             conditionObj = {
-                ...newConfiguration,
+                ...conditionConfiguration,
                 id: uuid(),
                 configuration: {
-                    ...newConfiguration.configuration,
+                    ...JSON.parse(JSON.stringify(conditionConfiguration)).configuration,
                     name: `Copy of ${conditionConfiguration.configuration.name}`
                 }
             };

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -23,7 +23,6 @@
 import Condition from "./Condition";
 import uuid from "uuid";
 import EventEmitter from 'EventEmitter';
-import _ from "lodash";
 
 export default class ConditionManager extends EventEmitter {
     constructor(conditionSetDomainObject, openmct) {
@@ -104,12 +103,16 @@ export default class ConditionManager extends EventEmitter {
 
     createCondition(conditionConfiguration) {
         let conditionObj;
+        let newConfiguration;
+        if (conditionConfiguration) {
+            newConfiguration = JSON.parse(JSON.stringify(conditionConfiguration));
+        }
         if (conditionConfiguration) {
             conditionObj = {
-                ...conditionConfiguration,
+                ...newConfiguration,
                 id: uuid(),
                 configuration: {
-                    ...conditionConfiguration.configuration,
+                    ...newConfiguration.configuration,
                     name: `Copy of ${conditionConfiguration.configuration.name}`
                 }
             };
@@ -143,7 +146,7 @@ export default class ConditionManager extends EventEmitter {
     }
 
     createAndSaveCondition(index, conditionConfiguration) {
-        const newCondition = _.cloneDeep(this.createCondition(conditionConfiguration));
+        const newCondition = this.createCondition(conditionConfiguration);
         if (index !== undefined) {
             this.conditionSetDomainObject.configuration.conditionCollection.splice(index + 1, 0, newCondition);
         } else {

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -23,6 +23,7 @@
 import Condition from "./Condition";
 import uuid from "uuid";
 import EventEmitter from 'EventEmitter';
+import _ from "lodash";
 
 export default class ConditionManager extends EventEmitter {
     constructor(conditionSetDomainObject, openmct) {
@@ -142,7 +143,7 @@ export default class ConditionManager extends EventEmitter {
     }
 
     createAndSaveCondition(index, conditionConfiguration) {
-        let newCondition = this.createCondition(conditionConfiguration);
+        const newCondition = _.cloneDeep(this.createCondition(conditionConfiguration));
         if (index !== undefined) {
             this.conditionSetDomainObject.configuration.conditionCollection.splice(index + 1, 0, newCondition);
         } else {

--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -181,7 +181,6 @@
 <script>
 import Criterion from './Criterion.vue';
 import ConditionDescription from "./ConditionDescription.vue";
-import _ from "lodash";
 
 export default {
     inject: ['openmct'],
@@ -295,7 +294,7 @@ export default {
             this.persist();
         },
         cloneCriterion(index) {
-            const clonedCriterion = _.cloneDeep(this.condition.configuration.criteria[index]);
+            const clonedCriterion = JSON.parse(JSON.stringify(this.condition.configuration.criteria[index]));
             this.condition.configuration.criteria.splice(index + 1, 0, clonedCriterion);
             this.persist();
         },

--- a/src/plugins/condition/components/Condition.vue
+++ b/src/plugins/condition/components/Condition.vue
@@ -181,6 +181,7 @@
 <script>
 import Criterion from './Criterion.vue';
 import ConditionDescription from "./ConditionDescription.vue";
+import _ from "lodash";
 
 export default {
     inject: ['openmct'],
@@ -291,12 +292,12 @@ export default {
         },
         removeCriterion(index) {
             this.condition.configuration.criteria.splice(index, 1);
-            this.persist()
+            this.persist();
         },
         cloneCriterion(index) {
-            const clonedCriterion = {...this.condition.configuration.criteria[index]};
+            const clonedCriterion = _.cloneDeep(this.condition.configuration.criteria[index]);
             this.condition.configuration.criteria.splice(index + 1, 0, clonedCriterion);
-            this.persist()
+            this.persist();
         },
         persist() {
             this.$emit('updateCondition', {

--- a/src/plugins/condition/components/Criterion.vue
+++ b/src/plugins/condition/components/Criterion.vue
@@ -118,14 +118,6 @@ export default {
             inputTypes: INPUT_TYPES
         }
     },
-    watch: {
-        telemetry: {
-            handler(newTelemetry, oldTelemetry) {
-                this.checkTelemetry();
-            },
-            deep: true
-        }
-    },
     computed: {
         setRowLabel: function () {
             let operator = this.trigger === 'all' ? 'and ': 'or ';
@@ -147,6 +139,14 @@ export default {
                 }
             }
             return type;
+        }
+    },
+    watch: {
+        telemetry: {
+            handler(newTelemetry, oldTelemetry) {
+                this.checkTelemetry();
+            },
+            deep: true
         }
     },
     mounted() {


### PR DESCRIPTION
Two issues:
1) Cloned criteria were not deep clones. Updating the values of cloned input fields resulted in reflected updates in source input fields and vise-versa.
2) Cloned conditions were also not deep clones. The same behavior was observed as in issue 1.

Use of lodash cloneDeep method solves both issues. A lighter weight approach is to use JSON serialization: `let clonedObj = JSON.parse(JSON.stringify(sourceObj);` 

This approach has some limitations (from https://stackoverflow.com/questions/38416020/deep-copy-in-es6-using-the-spread-syntax): 
"...solution using JSON serialization has some problems. By doing this you will lose any Javascript property that has no equivalent type in JSON, like Function or Infinity. Any property that’s assigned to undefined will be ignored by JSON.stringify, causing them to be missed on the cloned object. Also, some objects are converted to strings, like Date, Set, Map, and many others."

Issue tracked here: https://github.com/nasa/openmct/issues/2801
Testathon2 issues: https://github.com/nasa/openmct/issues/2796