### PR TITLE
Criterion field change causing incorrect input type

### DIFF
--- a/src/plugins/condition/components/Criterion.vue
+++ b/src/plugins/condition/components/Criterion.vue
@@ -200,7 +200,7 @@ export default {
             }
         },
         updateOperations(ev) {
-            if (ev && ev.target === this.$refs.telemetrySelect) {
+            if (ev) {
                 this.clearDependentFields(ev.target);
                 this.persist();
             }


### PR DESCRIPTION
Problem was that clearDependentFields wasn't being called for a change in the field selector.

Result was that previous input(s) remained but with undefined type. Also, the comparison selector had no selected option so appeared blank. When clearDependentFields is called it knows which selector was changed and makes appropriate changes to downstream fields. In this case it removes any input fields and returns comparison selector to its default state of "-Select Comparison-".

Issue tracked here: https://github.com/nasa/openmct/issues/2803
Testathon2 issues: https://github.com/nasa/openmct/issues/2796