### PR TITLE
Preserve user input when changing criterion comparison

### DIFF
--- a/src/plugins/condition/components/Criterion.vue
+++ b/src/plugins/condition/components/Criterion.vue
@@ -20,8 +20,7 @@
         <span v-if="criterion.telemetry"
               class="c-cdef__control"
         >
-            <select ref="metadataSelect"
-                    v-model="criterion.metadata"
+            <select v-model="criterion.metadata"
                     @change="updateOperations"
             >
                 <option value="">- Select Field -</option>
@@ -200,7 +199,7 @@ export default {
             }
         },
         updateOperations(ev) {
-            if (ev && ev.target === this.$refs.telemetrySelect) {
+            if (ev) {
                 this.clearDependentFields(ev.target);
                 this.persist();
             }
@@ -208,8 +207,9 @@ export default {
         },
         updateOperationInputVisibility(ev) {
             if (ev) {
-                this.criterion.input = this.enumerations.length ? [this.enumerations[0].value.toString()] : [];
-                this.inputCount = 0;
+                if (this.enumerations.length) {
+                    this.criterion.input = [this.enumerations[0].value.toString()];
+                }
                 this.persist();
             }
             for (let i = 0; i < this.filteredOps.length; i++) {
@@ -222,10 +222,8 @@ export default {
         clearDependentFields(el) {
             if (el === this.$refs.telemetrySelect) {
                 this.criterion.metadata = '';
-                this.criterion.operation = '';
-            } else if (el === this.$refs.metadataSelect) {
-                this.criterion.operation = '';
             }
+            this.criterion.operation = '';
             this.criterion.input = [];
             this.inputCount = 0;
         },

--- a/src/plugins/condition/utils/operations.js
+++ b/src/plugins/condition/utils/operations.js
@@ -82,7 +82,7 @@ export const OPERATIONS = [
         appliesTo: ['number'],
         inputCount: 2,
         getDescription: function (values) {
-            return ' is between ' + values.join(', ') + ' and ' + values[1];
+            return ' is between ' + values[0] + ' and ' + values[1];
         }
     },
     {
@@ -94,7 +94,7 @@ export const OPERATIONS = [
         appliesTo: ['number'],
         inputCount: 2,
         getDescription: function (values) {
-            return ' is not between ' + values.join(', ') + ' and ' + values[1];
+            return ' is not between ' + values[0] + ' and ' + values[1];
         }
     },
     {


### PR DESCRIPTION
Issues addressed:
1) When user has entered values in one or more input fields for a given criteria, and then the comparison selector is changed, inputs along with their data are removed and new empty input(s) are rendered as appropriate for the comparison type. This causes user provided data to be lost.
2) Description for between and not between is incorrect. The first input value is shown as both input values separated by a comma, such as: 
`between 1,2 and 2` instead of
`between 1 and 2`

Issue 1 is fixed by changes updateOperations() and clearDependentFields() in Criterion.vue
Issue 2 is fixed by changes to between and notBetween objects in operations.js 

Issue tracked here: https://github.com/nasa/openmct/issues/2805
Testathon2 issues: https://github.com/nasa/openmct/issues/2796