### PR TITLE
Removed image properties button from display layouts toolbar

### DIFF
--- a/src/plugins/displayLayout/DisplayLayoutToolbar.js
+++ b/src/plugins/displayLayout/DisplayLayoutToolbar.js
@@ -55,22 +55,6 @@ define(['lodash'], function (_) {
                                 ]
                             }
                         ]
-                    },
-                    'image': {
-                        name: "Image Properties",
-                        sections: [
-                            {
-                                rows: [
-                                    {
-                                        key: "url",
-                                        control: "textfield",
-                                        name: "Image URL",
-                                        "cssClass": "l-input-lg",
-                                        required: true
-                                    }
-                                ]
-                            }
-                        ]
                     }
                 };
 
@@ -347,22 +331,6 @@ define(['lodash'], function (_) {
                     };
                 }
 
-                function getURLButton(selectedParent, selection) {
-                    return {
-                        control: "button",
-                        domainObject: selectedParent,
-                        applicableSelectedItems: selection.filter(selectionPath => {
-                            return selectionPath[0].context.layoutItem.type === 'image-view';
-                        }),
-                        property: function (selectionPath) {
-                            return getPath(selectionPath);
-                        },
-                        icon: "icon-image",
-                        title: "Edit image properties",
-                        dialog: DIALOG_FORM.image
-                    };
-                }
-
                 function getTextButton(selectedParent, selection) {
                     return {
                         control: "button",
@@ -550,9 +518,6 @@ define(['lodash'], function (_) {
                                 getHeightInput(selectedParent, selectedObjects),
                                 getWidthInput(selectedParent, selectedObjects)
                             ];
-                        }
-                        if (toolbar.url.length === 0) {
-                            toolbar.url = [getURLButton(selectedParent, selectedObjects)];
                         }
                         if (toolbar.remove.length === 0) {
                             toolbar.remove = [getRemoveButton(selectedParent, selectionPath, selectedObjects)];

--- a/src/plugins/displayLayout/DisplayLayoutToolbar.js
+++ b/src/plugins/displayLayout/DisplayLayoutToolbar.js
@@ -55,6 +55,22 @@ define(['lodash'], function (_) {
                                 ]
                             }
                         ]
+                    },
+                    'image': {
+                        name: "Image Properties",
+                        sections: [
+                            {
+                                rows: [
+                                    {
+                                        key: "url",
+                                        control: "textfield",
+                                        name: "Image URL",
+                                        "cssClass": "l-input-lg",
+                                        required: true
+                                    }
+                                ]
+                            }
+                        ]
                     }
                 };
 


### PR DESCRIPTION
Removed 'image' property from DIALOG_FORM and removed getURLButton method and call to same from DisplayLayoutToolbar.js

Issue tracked here: https://github.com/nasa/openmct/issues/2808
Testathon2 issues: #2796