### PR TITLE
When view params change, get a new copy of the domainObject

### DIFF
--- a/src/ui/router/Browse.js
+++ b/src/ui/router/Browse.js
@@ -19,13 +19,10 @@ define([
 
         openmct.router.on('change:params', function (newParams, oldParams, changed) {
             if (changed.view && browseObject) {
-                //get latest version of the browseObject
-                openmct.objects.get(browseObject.identifier).then((newBrowseObject) => {
-                    let provider = openmct
-                        .objectViews
-                        .getByProviderKey(changed.view);
-                    viewObject(newBrowseObject, provider);
-                });
+                let provider = openmct
+                    .objectViews
+                    .getByProviderKey(changed.view);
+                viewObject(browseObject, provider);
             }
         });
 
@@ -66,6 +63,7 @@ define([
 
                 unobserve = this.openmct.objects.observe(openmct.router.path[0], '*', (newObject) => {
                     openmct.router.path[0] = newObject;
+                    browseObject = newObject;
                 });
 
                 openmct.layout.$refs.browseBar.domainObject = navigatedObject;

--- a/src/ui/router/Browse.js
+++ b/src/ui/router/Browse.js
@@ -19,10 +19,13 @@ define([
 
         openmct.router.on('change:params', function (newParams, oldParams, changed) {
             if (changed.view && browseObject) {
-                let provider = openmct
-                    .objectViews
-                    .getByProviderKey(changed.view);
-                viewObject(browseObject, provider);
+                //get latest version of the browseObject
+                openmct.objects.get(browseObject.identifier).then((newBrowseObject) => {
+                    let provider = openmct
+                        .objectViews
+                        .getByProviderKey(changed.view);
+                    viewObject(newBrowseObject, provider);
+                });
             }
         });
 


### PR DESCRIPTION
We have a bug where, if a user edits a domainObject with more than one view, and then saves and switches the view, the new view will receive an outdated domainObject.

This fixes it by fetching the latest domainObject before switching views. 