### PR TITLE
More consistent Object Labels

### DIFF
--- a/src/plugins/tabs/components/tabs.vue
+++ b/src/plugins/tabs/components/tabs.vue
@@ -40,10 +40,10 @@
     >
         <div
             v-if="currentTab"
-            class="c-tabs-view__object-name l-browse-bar__object-name--w"
+            class="c-tabs-view__object-name c-object-label l-browse-bar__object-name--w"
             :class="currentTab.type.definition.cssClass"
         >
-            <div class="l-browse-bar__object-name">
+            <div class="l-browse-bar__object-name c-object-label__name">
                 {{ currentTab.domainObject.name }}
             </div>
         </div>

--- a/src/ui/components/ObjectFrame.vue
+++ b/src/ui/components/ObjectFrame.vue
@@ -28,12 +28,12 @@
     }"
 >
     <div class="c-so-view__header">
-        <div
-            class="c-so-view__header__icon"
-            :class="cssClass"
-        ></div>
-        <div class="c-so-view__header__name">
-            {{ domainObject && domainObject.name }}
+        <div class="c-object-label"
+             :class="cssClass"
+        >
+            <div class="c-object-label__name">
+                {{ domainObject && domainObject.name }}
+            </div>
         </div>
         <context-menu-drop-down
             :object-path="objectPath"

--- a/src/ui/components/object-label.scss
+++ b/src/ui/components/object-label.scss
@@ -1,28 +1,42 @@
 .c-object-label {
     // <a> tag and draggable element that holds type icon and name.
     // Used mostly in trees and lists
-    border-radius: $controlCr;
     display: flex;
     align-items: center;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     overflow: hidden;
-    padding: $interiorMarginSm 1px;
     white-space: nowrap;
 
     &__name {
         @include ellipsize();
         display: inline;
-        color: $colorItemTreeFg;
+    }
+
+    &__type-icon,
+    &:before {
+        // Type icon. Must be an HTML entity to allow inclusion of alias indicator.
+        display: block;
+        flex: 0 0 auto;
+        font-size: 1.1em;
+        opacity: 0.6;
+        margin-right: $interiorMargin;
+    }
+}
+
+.c-tree .c-object-label {
+    border-radius: $controlCr;
+    padding: $interiorMarginSm 1px;
+
+    &__name {
+        display: inline;
         width: 100%;
     }
 
     &__type-icon {
-        // Type icon. Must be an HTML entity to allow inclusion of alias indicator.
-        display: block;
-        flex: 0 0 auto;
-        font-size: 1.3em;
-        margin-right: $interiorMarginSm;
         color: $colorItemTreeIcon;
+        font-size: 1.25em;
+        margin-right: $interiorMarginSm;
+        opacity: 1;
         width: $treeTypeIconW;
     }
 }

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -7,11 +7,11 @@
             @click="goToParent"
         ></button>
         <div
-            class="l-browse-bar__object-name--w"
+            class="l-browse-bar__object-name--w c-object-label"
             :class="type.cssClass"
         >
             <span
-                class="l-browse-bar__object-name c-input-inline"
+                class="l-browse-bar__object-name c-object-label__name c-input-inline"
                 contenteditable
                 @blur="updateName"
                 @keydown.enter.prevent


### PR DESCRIPTION
![Screen Shot 2020-03-30 at 1 36 17 PM](https://user-images.githubusercontent.com/1056412/77959471-7b20f700-728b-11ea-9d31-cb920342b6f3.png)

Object labels appear in multiple locations in the application. This mod uses the `c-object-label` CSS tag more consistently and simplifies associated markup. Changes here were cherry picked into the new Notebook in `notebook-ver2` branch.

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
