### PR TITLE
[Conditionals] Improve logic for Operation Format chooser

### DIFF
--- a/src/plugins/condition/components/Criterion.vue
+++ b/src/plugins/condition/components/Criterion.vue
@@ -201,6 +201,8 @@ export default {
                 if (foundMetadata.enumerations !== undefined) {
                     this.operationFormat = 'enum';
                     this.enumerations = foundMetadata.enumerations;
+                } else if (foundMetadata.format === 'string' || foundMetadata.format === 'number') {
+                    this.operationFormat = foundMetadata.format;
                 } else if (foundMetadata.hints.hasOwnProperty('range')) {
                     this.operationFormat = 'number';
                 } else if (foundMetadata.hints.hasOwnProperty('domain')) {
@@ -208,7 +210,7 @@ export default {
                 } else if (foundMetadata.key === 'name') {
                     this.operationFormat = 'string';
                 } else {
-                    this.operationFormat = 'string';
+                    this.operationFormat = 'number';
                 }
             }
             this.updateInputVisibilityAndValues();


### PR DESCRIPTION
## Overview
Addresses #2847
- if metadata format exists, use to determine operation format
- use number as fallback instead of string

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |