### PR TITLE
request LAD for default condition

### DIFF
--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -238,7 +238,7 @@ export default class ConditionManager extends EventEmitter {
     }
 
     requestLADConditionSetOutput() {
-        if (!this.conditionClassCollection.length || this.conditionClassCollection.length === 1) {
+        if (!this.conditionClassCollection.length) {
             return Promise.resolve([]);
         }
 


### PR DESCRIPTION
## Overview
Addresses #2831
- note side effect is that requests for LAD in telemetry table view will return a row with no timestamp and default output

Fix involves
- requesting LAD even if we know it isn't there and letting evaluation default to... (wait for it...) default.
## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |