### PR TITLE
Fix `.s-status-ok` styling

### DIFF
--- a/platform/persistence/couch/src/CouchIndicator.js
+++ b/platform/persistence/couch/src/CouchIndicator.js
@@ -33,7 +33,7 @@ define(
         var CONNECTED = {
                 text: "Connected",
                 glyphClass: "ok",
-                statusClass: "s-status-ok",
+                statusClass: "s-status-on",
                 description: "Connected to the domain object database."
             },
             DISCONNECTED = {

--- a/platform/persistence/elastic/src/ElasticIndicator.js
+++ b/platform/persistence/elastic/src/ElasticIndicator.js
@@ -32,7 +32,7 @@ define(
         var CONNECTED = {
                 text: "Connected",
                 glyphClass: "ok",
-                statusClass: "s-status-ok",
+                statusClass: "s-status-on",
                 description: "Connected to the domain object database."
             },
             DISCONNECTED = {

--- a/src/plugins/URLIndicatorPlugin/URLIndicator.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicator.js
@@ -30,7 +30,7 @@ define(
         // DISCONNECTED: HTTP failed; maybe misconfigured, disconnected.
         // PENDING: Still trying to connect, and haven't failed yet.
         var CONNECTED = {
-                statusClass: "s-status-ok"
+                statusClass: "s-status-on"
             },
             PENDING = {
                 statusClass: "s-status-warning-lo"

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorSpec.js
@@ -122,7 +122,7 @@ define(
                 it("indicates success if connection is nominal", function () {
                     jasmine.clock().tick(pluginOptions.interval + 1);
                     ajaxOptions.success();
-                    expect(indicatorElement.classList.contains('s-status-ok')).toBe(true);
+                    expect(indicatorElement.classList.contains('s-status-on')).toBe(true);
                 });
 
                 it("indicates an error when the server cannot be reached", function () {

--- a/src/styles/_status.scss
+++ b/src/styles/_status.scss
@@ -54,7 +54,6 @@
 
 @mixin elementStatusColors($c) {
     // Sets bg and icon colors for elements
-    background: rgba($c, 0.5) !important;
     &:before {
         color: $c !important;
     }


### PR DESCRIPTION
Fixes #2878
- Remove background from `elementStatusColors` mixin;
- Change Indicators to use more correct style of `.s-status-on`;

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
