### PR TITLE
Enum comparisons now use string values.

### DIFF
--- a/src/plugins/condition/utils/operations.js
+++ b/src/plugins/condition/utils/operations.js
@@ -245,9 +245,7 @@ export const OPERATIONS = [
             const lhsValue = input[0] !== undefined ? input[0].toString() : '';
             if (input[1]) {
                 const values = input[1].split(',');
-                let stringValues = [];
-                values.forEach(inputValue => stringValues.push(inputValue !== undefined ? inputValue.toString() : ''));
-                return stringValues.find((value) => lhsValue === _.trim(value.toString()));
+                return values.find((value) => lhsValue === _.trim(value.toString()));
             }
             return false;
         },
@@ -264,9 +262,7 @@ export const OPERATIONS = [
             const lhsValue = input[0] !== undefined ? input[0].toString() : '';
             if (input[1]) {
                 const values = input[1].split(',');
-                let stringValues = [];
-                values.forEach(inputValue => stringValues.push(inputValue !== undefined ? inputValue.toString() : ''));
-                const found = stringValues.find((value) => lhsValue === _.trim(value.toString()));
+                const found = values.find((value) => lhsValue === _.trim(value.toString()));
                 return !found;
             }
             return false;

--- a/src/plugins/condition/utils/operations.js
+++ b/src/plugins/condition/utils/operations.js
@@ -214,7 +214,9 @@ export const OPERATIONS = [
     {
         name: 'enumValueIs',
         operation: function (input) {
-            return input[0] === input[1];
+            let stringInputs = [];
+            input.forEach(inputValue => stringInputs.push(inputValue !== undefined ? inputValue.toString() : ''));
+            return stringInputs[0] === stringInputs[1];
         },
         text: 'is',
         appliesTo: ['enum'],
@@ -226,7 +228,9 @@ export const OPERATIONS = [
     {
         name: 'enumValueIsNot',
         operation: function (input) {
-            return input[0] !== input[1];
+            let stringInputs = [];
+            input.forEach(inputValue => stringInputs.push(inputValue !== undefined ? inputValue.toString() : ''));
+            return stringInputs[0] !== stringInputs[1];
         },
         text: 'is not',
         appliesTo: ['enum'],
@@ -238,9 +242,12 @@ export const OPERATIONS = [
     {
         name: 'valueIs',
         operation: function (input) {
+            const lhsValue = input[0] !== undefined ? input[0].toString() : '';
             if (input[1]) {
                 const values = input[1].split(',');
-                return values.find((value) => input[0].toString() === _.trim(value.toString()));
+                let stringValues = [];
+                values.forEach(inputValue => stringValues.push(inputValue !== undefined ? inputValue.toString() : ''));
+                return stringValues.find((value) => lhsValue === _.trim(value.toString()));
             }
             return false;
         },
@@ -254,9 +261,12 @@ export const OPERATIONS = [
     {
         name: 'valueIsNot',
         operation: function (input) {
+            const lhsValue = input[0] !== undefined ? input[0].toString() : '';
             if (input[1]) {
                 const values = input[1].split(',');
-                const found = values.find((value) => input[0].toString() === _.trim(value.toString()));
+                let stringValues = [];
+                values.forEach(inputValue => stringValues.push(inputValue !== undefined ? inputValue.toString() : ''));
+                const found = stringValues.find((value) => lhsValue === _.trim(value.toString()));
                 return !found;
             }
             return false;

--- a/src/plugins/condition/utils/operationsSpec.js
+++ b/src/plugins/condition/utils/operationsSpec.js
@@ -25,8 +25,10 @@ let isOneOfOperation = OPERATIONS.find((operation) => operation.name === 'valueI
 let isNotOneOfOperation = OPERATIONS.find((operation) => operation.name === 'valueIsNot');
 let isBetween = OPERATIONS.find((operation) => operation.name === 'between');
 let isNotBetween = OPERATIONS.find((operation) => operation.name === 'notBetween');
+let enumIsOperation = OPERATIONS.find((operation) => operation.name === 'enumValueIs');
+let enumIsNotOperation = OPERATIONS.find((operation) => operation.name === 'enumValueIsNot');
 
-describe('Is one of and is not one of operations', function () {
+describe('operations', function () {
 
     it('should evaluate isOneOf to true for number inputs', () => {
         const inputs = [45, "5,6,45,8"];
@@ -86,5 +88,55 @@ describe('Is one of and is not one of operations', function () {
     it('should evaluate isNotBetween to false', () => {
         const inputs = ["45", "30", "50"];
         expect(!!isNotBetween.operation(inputs)).toBeFalse();
+    });
+
+    it('should evaluate enumValueIs to true for number inputs', () => {
+        const inputs = [1, "1"];
+        expect(!!enumIsOperation.operation(inputs)).toBeTrue();
+    });
+
+    it('should evaluate enumValueIs to true for string inputs', () => {
+        const inputs = ["45", "45"];
+        expect(!!enumIsOperation.operation(inputs)).toBeTrue();
+    });
+
+    it('should evaluate enumValueIsNot to true for number inputs', () => {
+        const inputs = [45, "46"];
+        expect(!!enumIsNotOperation.operation(inputs)).toBeTrue();
+    });
+
+    it('should evaluate enumValueIsNot to true for string inputs', () => {
+        const inputs = ["45", "46"];
+        expect(!!enumIsNotOperation.operation(inputs)).toBeTrue();
+    });
+
+    it('should evaluate enumValueIs to false for number inputs', () => {
+        const inputs = [1, "2"];
+        expect(!!enumIsOperation.operation(inputs)).toBeFalse();
+    });
+
+    it('should evaluate enumValueIs to false for string inputs', () => {
+        const inputs = ["45", "46"];
+        expect(!!enumIsOperation.operation(inputs)).toBeFalse();
+    });
+
+    it('should evaluate enumValueIsNot to false for number inputs', () => {
+        const inputs = [45, "45"];
+        expect(!!enumIsNotOperation.operation(inputs)).toBeFalse();
+    });
+
+    it('should evaluate enumValueIsNot to false for string inputs', () => {
+        const inputs = ["45", "45"];
+        expect(!!enumIsNotOperation.operation(inputs)).toBeFalse();
+    });
+
+    it('should evaluate enumValueIs to false for undefined input', () => {
+        const inputs = [undefined, "45"];
+        expect(!!enumIsOperation.operation(inputs)).toBeFalse();
+    });
+
+    it('should evaluate enumValueIsNot to true for undefined input', () => {
+        const inputs = [undefined, "45"];
+        expect(!!enumIsNotOperation.operation(inputs)).toBeTrue();
     });
 });


### PR DESCRIPTION
Resolves #2881
Resolves #2882 

Also checks for undefined for is one of and is not one of operations.

**Author Checklist**

- Changes address original issue? Yes
- Unit tests included and/or updated with changes? Yes
- Command line build passes? Yes
- Changes have been smoke-tested? Yes