### PR TITLE
Removing telemetry from conditionSet with any/all telemetry criterion breaks condition set output

### DIFF
--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -57,7 +57,6 @@ export default class ConditionManager extends EventEmitter {
             endpoint,
             this.telemetryReceived.bind(this, id)
         );
-        // TODO check if this is needed
         this.updateConditionTelemetry();
     }
 
@@ -71,6 +70,7 @@ export default class ConditionManager extends EventEmitter {
         this.subscriptions[id]();
         delete this.subscriptions[id];
         delete this.telemetryObjects[id];
+        this.updateConditionTelemetry();
     }
 
     initialize() {

--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -47,6 +47,21 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
 
     updateTelemetry(telemetryObjects) {
         this.telemetryObjects = { ...telemetryObjects };
+        this.removeTelemetryDataCache();
+    }
+
+    removeTelemetryDataCache() {
+        const telemetryCacheIds = Object.keys(this.telemetryDataCache);
+        Object.values(this.telemetryObjects).forEach(telemetryObject => {
+            const id = this.openmct.objects.makeKeyString(telemetryObject.identifier);
+            const foundIndex = telemetryCacheIds.indexOf(id);
+            if (foundIndex > -1) {
+                telemetryCacheIds.splice(foundIndex, 1);
+            }
+        });
+        telemetryCacheIds.forEach(id => {
+            delete (this.telemetryDataCache[id]);
+        });
     }
 
     formatData(data, telemetryObjects) {


### PR DESCRIPTION
Remove telemetry data cache if a telemetry endpoint is removed

**Author Checklist**

- Changes address original issue? Yes
- Unit tests included and/or updated with changes? No
- Command line build passes? Yes
- Changes have been smoke-tested? Yes