### PR TITLE
[Notebook] Example Imagery doesn't capture images #2942

### DIFF
--- a/src/exporters/ImageExporter.js
+++ b/src/exporters/ImageExporter.js
@@ -78,6 +78,9 @@ class ImageExporter {
         }
 
         return html2canvas(element, {
+            useCORS: true,
+            allowTaint: true,
+            logging: false,
             onclone: function (document) {
                 if (className) {
                     const clonedElement = document.getElementById(exportId);


### PR DESCRIPTION
resolves: https://github.com/nasa/openmct/issues/2942

Notes:
Images can be captured if, 
1. with `access-control-allow-origin` prop as * ,
1. with `access-control-allow-origin` prop has same domain (eg: if openmct is on hulk, then value should include `hulk.ndc.nasa.gov` etc)

images:
Space force: https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Seal_of_the_United_States_Space_Force.svg/1200px-Seal_of_the_United_States_Space_Force.svg.png

Nasa logo:
https://www.nasa.gov/sites/all/themes/custom/nasatwo/images/nasa-logo.svg

<img width="1401" alt="Screen Shot 2020-04-15 at 10 16 39 PM" src="https://user-images.githubusercontent.com/1292612/79419718-358f4a00-7f6c-11ea-8813-fa2bae870945.png">

<img width="1206" alt="Screen Shot 2020-04-15 at 10 56 35 PM" src="https://user-images.githubusercontent.com/1292612/79419821-696a6f80-7f6c-11ea-85bf-2c02a4b6e15d.png">
