### PR TITLE
[Conditionals] fix #2961 in vista-r4.4

### DIFF
--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -132,10 +132,9 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
                 let latestDatum;
                 telemetryRequestsResults.forEach((results, index) => {
                     latestDatum = results.length ? results[results.length - 1] : {};
-                    if (index < telemetryRequestsResults.length-1) {
-                        if (latestDatum) {
-                            this.telemetryDataCache[latestDatum.id] = this.computeResult(latestDatum);
-                        }
+                    if (latestDatum) {
+                        latestDatum.id = keys[index];
+                        this.telemetryDataCache[latestDatum.id] = this.computeResult(latestDatum);
                     }
                 });
                 return {


### PR DESCRIPTION
## Overview
Addresses #2961
- use correct id for data cache
- separate request and subscription any/all telemetry data cache
- use latest timestamp for any/all telemetry requests

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |