### PR TITLE
[Time Conductor] add history and select range features  to vista-r4.4.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,6 @@
         openmct.install(openmct.plugins.Generator());
         openmct.install(openmct.plugins.ExampleImagery());
         openmct.install(openmct.plugins.UTCTimeSystem());
-        openmct.install(openmct.plugins.LocalTimeSystem());
         openmct.install(openmct.plugins.AutoflowView({
             type: "telemetry.panel"
         }));

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
     <body>
     </body>
     <script>
-        const FIVE_MINUTES = 5 * 60 * 1000;
-        const THIRTY_MINUTES = 30 * 60 * 1000;
+        const THIRTY_SECONDS = 30 * 1000;
+        const THIRTY_MINUTES = THIRTY_SECONDS * 60;
 
         [
             'example/eventGenerator'
@@ -49,6 +49,7 @@
         openmct.install(openmct.plugins.Generator());
         openmct.install(openmct.plugins.ExampleImagery());
         openmct.install(openmct.plugins.UTCTimeSystem());
+        openmct.install(openmct.plugins.LocalTimeSystem());
         openmct.install(openmct.plugins.AutoflowView({
             type: "telemetry.panel"
         }));
@@ -71,9 +72,26 @@
                     clock: 'local',
                     clockOffsets: {
                         start: - THIRTY_MINUTES,
-                        end: FIVE_MINUTES
+                        end: THIRTY_SECONDS
                     }
-                }
+                },
+                {
+                    name: "Fixed",
+                    timeSystem: 'local',
+                    bounds: {
+                        start: Date.now() - THIRTY_MINUTES,
+                        end: Date.now()
+                    }
+                },
+                {
+                    name: "Realtime",
+                    timeSystem: 'local',
+                    clock: 'local',
+                    clockOffsets: {
+                        start: - THIRTY_MINUTES,
+                        end: THIRTY_SECONDS
+                    }
+                },
             ]
         }));
         openmct.install(openmct.plugins.SummaryWidget());

--- a/index.html
+++ b/index.html
@@ -64,7 +64,32 @@
                     bounds: {
                         start: Date.now() - THIRTY_MINUTES,
                         end: Date.now()
-                    }
+                    },
+                    presets: [
+                        {
+                            label: 'Last Day',
+                            bounds: {
+                                start: Date.now() - 1000 * 60 * 60 * 24,
+                                end: Date.now()
+                            }
+                        },
+                        {
+                            label: 'Last 2 hours',
+                            bounds: {
+                                start: Date.now() - 1000 * 60 * 60 * 2,
+                                end: Date.now()
+                            }
+                        },
+                        {
+                            label: 'Last hour',
+                            bounds: {
+                                start: Date.now() - 1000 * 60 * 60,
+                                end: Date.now()
+                            }
+                        }
+                    ],
+                    // maximum entries to retain in conductor history
+                    records: 10
                 },
                 {
                     name: "Realtime",
@@ -74,24 +99,7 @@
                         start: - THIRTY_MINUTES,
                         end: THIRTY_SECONDS
                     }
-                },
-                {
-                    name: "Fixed",
-                    timeSystem: 'local',
-                    bounds: {
-                        start: Date.now() - THIRTY_MINUTES,
-                        end: Date.now()
-                    }
-                },
-                {
-                    name: "Realtime",
-                    timeSystem: 'local',
-                    clock: 'local',
-                    clockOffsets: {
-                        start: - THIRTY_MINUTES,
-                        end: THIRTY_SECONDS
-                    }
-                },
+                }
             ]
         }));
         openmct.install(openmct.plugins.SummaryWidget());

--- a/index.html
+++ b/index.html
@@ -64,26 +64,30 @@
                         start: Date.now() - THIRTY_MINUTES,
                         end: Date.now()
                     },
+                    // commonly used bounds can be stored in history
+                    // bounds (start and end) can accept either a milliseconds number
+                    // or a callback function returning a milliseconds number
+                    // a function is useful for invoking Date.now() at exact moment of preset selection
                     presets: [
                         {
                             label: 'Last Day',
                             bounds: {
-                                start: Date.now() - 1000 * 60 * 60 * 24,
-                                end: Date.now()
+                                start: () => Date.now() - 1000 * 60 * 60 * 24,
+                                end: () => Date.now()
                             }
                         },
                         {
                             label: 'Last 2 hours',
                             bounds: {
-                                start: Date.now() - 1000 * 60 * 60 * 2,
-                                end: Date.now()
+                                start: () => Date.now() - 1000 * 60 * 60 * 2,
+                                end: () => Date.now()
                             }
                         },
                         {
                             label: 'Last hour',
                             bounds: {
-                                start: Date.now() - 1000 * 60 * 60,
-                                end: Date.now()
+                                start: () => Date.now() - 1000 * 60 * 60,
+                                end: () => Date.now()
                             }
                         }
                     ],

--- a/index.html
+++ b/index.html
@@ -88,7 +88,9 @@
                         }
                     ],
                     // maximum entries to retain in conductor history
-                    records: 10
+                    records: 10,
+                    // maximum duration between start and end bounds
+                    limit: 1000 * 60 * 60 * 24
                 },
                 {
                     name: "Realtime",

--- a/index.html
+++ b/index.html
@@ -87,9 +87,10 @@
                             }
                         }
                     ],
-                    // maximum entries to retain in conductor history
+                    // maximum recent bounds to retain in conductor history
                     records: 10,
                     // maximum duration between start and end bounds
+                    // for utc-based time systems this is in milliseconds
                     limit: 1000 * 60 * 60 * 24
                 },
                 {

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -157,7 +157,6 @@ define(['EventEmitter'], function (EventEmitter) {
         } else if (bounds.start > bounds.end) {
             return "Specified start date exceeds end bound";
         }
-
         return true;
     };
 

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -156,12 +156,6 @@ define(['EventEmitter'], function (EventEmitter) {
             return "Start and end must be specified as integer values";
         } else if (bounds.start > bounds.end) {
             return "Specified start date exceeds end bound";
-        } else if (
-            this.system
-            && this.system.isUTCBased
-            && bounds.end - bounds.start > this.system.maxDuration
-        ) {
-            return "Start and end difference exceeds allowable limit";
         }
 
         return true;

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -156,7 +156,14 @@ define(['EventEmitter'], function (EventEmitter) {
             return "Start and end must be specified as integer values";
         } else if (bounds.start > bounds.end) {
             return "Specified start date exceeds end bound";
+        } else if (
+            this.system
+            && this.system.isUTCBased
+            && bounds.end - bounds.start > this.system.maxDuration
+        ) {
+            return "Start and end difference exceeds allowable limit";
         }
+
         return true;
     };
 

--- a/src/plugins/localTimeSystem/LocalTimeSystem.js
+++ b/src/plugins/localTimeSystem/LocalTimeSystem.js
@@ -41,7 +41,7 @@ define([], function () {
         this.timeFormat = 'local-format';
         this.durationFormat = 'duration';
 
-        this.isUTCBased = false;
+        this.isUTCBased = true;
     }
 
     return LocalTimeSystem;

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -230,6 +230,7 @@ export default {
     mounted() {
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));
         this.openmct.time.on('bounds', this.setViewFromBounds);
+        this.openmct.time.on('bounds', this.setNewBounds);
         this.openmct.time.on('timeSystem', this.setTimeSystem);
         this.openmct.time.on('clock', this.setViewFromClock);
         this.openmct.time.on('clockOffsets', this.setViewFromOffsets)
@@ -315,10 +316,11 @@ export default {
             }
         },
         getBoundsLimit() {
-            const limit = this.configuration.menuOptions
+            const configuration = this.configuration.menuOptions
                 .filter(option => option.timeSystem ===  this.timeSystem.key)
-                .find(option => option.limit)
-                .limit;
+                .find(option => option.limit);
+
+            const limit = configuration ? configuration.limit : undefined;
 
             return limit;
         },

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -241,8 +241,9 @@ export default {
         },
         endPan(bounds) {
             this.isPanning = false;
-            this.openmct.time.bounds(bounds);
-            // this.setViewFromBounds(bounds);
+            if (bounds) {
+                this.openmct.time.bounds(bounds);
+            }
         },
         zoom(bounds) {
             this.isZooming = true;

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -42,7 +42,9 @@
                 class="c-ctrl-wrapper c-conductor-input c-conductor__start-fixed"
             >
                 <!-- Fixed start -->
-                <div class="c-conductor__start-fixed__label">Start</div>
+                <div class="c-conductor__start-fixed__label">
+                    Start
+                </div>
                 <input
                     ref="startDate"
                     v-model="formattedBounds.start"

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -206,26 +206,30 @@ export default {
             isZooming: false
         }
     },
-    created() {
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Alt') {
-                this.altPressed = true;
-            }
-        });
-        document.addEventListener('keyup', (e) => {
-            if (e.key === 'Alt') {
-                this.altPressed = false;
-            }
-        });
-    },
     mounted() {
+        document.addEventListener('keydown', this.handleKeyDown);
+        document.addEventListener('keyup', this.handleKeyUp);
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));
         this.openmct.time.on('bounds', this.setViewFromBounds);
         this.openmct.time.on('timeSystem', this.setTimeSystem);
         this.openmct.time.on('clock', this.setViewFromClock);
         this.openmct.time.on('clockOffsets', this.setViewFromOffsets)
     },
+    beforeDestroy() {
+        document.removeEventListener('keydown', this.handleKeyDown);
+        document.removeEventListener('keyup', this.handleKeyUp);
+    },
     methods: {
+        handleKeyDown(event) {
+            if (event.key === 'Alt') {
+                this.altPressed = true;
+            }
+        },
+        handleKeyUp(event) {
+            if (event.key === 'Alt') {
+                this.altPressed = false;
+            }
+        },
         pan(bounds) {
             this.isPanning = true;
             this.setViewFromBounds(bounds);

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -22,7 +22,15 @@
 <template>
 <div
     class="c-conductor"
+<<<<<<< HEAD
     :class="[isFixed ? 'is-fixed-mode' : 'is-realtime-mode']"
+=======
+    :class="[
+        { 'is-zooming': isZooming },
+        { 'is-panning': isPanning },
+        isFixed ? 'is-fixed-mode' : 'is-realtime-mode'
+    ]"
+>>>>>>> acc0abc90... move zoom/pan styling up to conductor
 >
     <form
         ref="conductorForm"
@@ -124,8 +132,10 @@
                 class="c-conductor__ticks"
                 :bounds="rawBounds"
                 :is-fixed="isFixed"
-                @panAxis="setViewFromBounds"
-                @zoomAxis="setZoomBounds"
+                @stopPanning="stopPanning"
+                @stopZooming="stopZooming"
+                @panAxis="pan"
+                @zoomAxis="zoom"
             />
 
         </div>
@@ -197,7 +207,9 @@ export default {
             },
             isFixed: this.openmct.time.clock() === undefined,
             isUTCBased: timeSystem.isUTCBased,
-            showDatePicker: false
+            showDatePicker: false,
+            isPanning: false,
+            isZooming: false
         }
     },
     mounted() {
@@ -208,6 +220,21 @@ export default {
         this.openmct.time.on('clockOffsets', this.setViewFromOffsets)
     },
     methods: {
+        pan(bounds) {
+            this.isPanning = true;
+            this.setViewFromBounds(bounds);
+        },
+        stopPanning() {
+            this.isPanning = false;
+        },
+        zoom(bounds) {
+            this.isZooming = true;
+            this.formattedBounds.start = this.timeFormatter.format(bounds.start);
+            this.formattedBounds.end = this.timeFormatter.format(bounds.end);
+        },
+        stopZooming() {
+            this.isZooming = false;
+        },
         setTimeSystem(timeSystem) {
             this.timeSystem = timeSystem
             this.timeFormatter = this.getFormatter(timeSystem.timeFormat);
@@ -258,10 +285,6 @@ export default {
         setViewFromOffsets(offsets) {
             this.offsets.start = this.durationFormatter.format(Math.abs(offsets.start));
             this.offsets.end = this.durationFormatter.format(Math.abs(offsets.end));
-        },
-        setZoomBounds(bounds) {
-            this.formattedBounds.start = this.timeFormatter.format(bounds.start);
-            this.formattedBounds.end = this.timeFormatter.format(bounds.end);
         },
         updateTimeFromConductor() {
             if (this.isFixed) {

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -20,32 +20,37 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 <template>
-<div class="c-conductor"
-     :class="[isFixed ? 'is-fixed-mode' : 'is-realtime-mode']"
+<div
+    class="c-conductor"
+    :class="[isFixed ? 'is-fixed-mode' : 'is-realtime-mode']"
 >
-    <form ref="conductorForm"
-          class="u-contents"
-          @submit.prevent="updateTimeFromConductor"
+    <form
+        ref="conductorForm"
+        class="u-contents"
+        @submit.prevent="updateTimeFromConductor"
     >
         <div class="c-conductor__time-bounds">
-            <button ref="submitButton"
-                    class="c-input--submit"
-                    type="submit"
+            <button
+                ref="submitButton"
+                class="c-input--submit"
+                type="submit"
             ></button>
             <ConductorModeIcon class="c-conductor__mode-icon" />
 
-            <div v-if="isFixed"
-                 class="c-ctrl-wrapper c-conductor-input c-conductor__start-fixed"
+            <div
+                v-if="isFixed"
+                class="c-ctrl-wrapper c-conductor-input c-conductor__start-fixed"
             >
                 <!-- Fixed start -->
                 <div class="c-conductor__start-fixed__label">Start</div>
-                <input ref="startDate"
-                       v-model="formattedBounds.start"
-                       class="c-input--datetime"
-                       type="text"
-                       autocorrect="off"
-                       spellcheck="false"
-                       @change="validateAllBounds(); submitForm()"
+                <input
+                    ref="startDate"
+                    v-model="formattedBounds.start"
+                    class="c-input--datetime"
+                    type="text"
+                    autocorrect="off"
+                    spellcheck="false"
+                    @change="validateAllBounds(); submitForm()"
                 >
                 <date-picker
                     v-if="isFixed && isUTCBased"
@@ -55,18 +60,20 @@
                 />
             </div>
 
-            <div v-if="!isFixed"
-                 class="c-ctrl-wrapper c-conductor-input c-conductor__start-delta"
+            <div
+                v-if="!isFixed"
+                class="c-ctrl-wrapper c-conductor-input c-conductor__start-delta"
             >
                 <!-- RT start -->
                 <div class="c-direction-indicator icon-minus"></div>
-                <input ref="startOffset"
-                       v-model="offsets.start"
-                       class="c-input--hrs-min-sec"
-                       type="text"
-                       autocorrect="off"
-                       spellcheck="false"
-                       @change="validateAllOffsets(); submitForm()"
+                <input
+                    ref="startOffset"
+                    v-model="offsets.start"
+                    class="c-input--hrs-min-sec"
+                    type="text"
+                    autocorrect="off"
+                    spellcheck="false"
+                    @change="validateAllOffsets(); submitForm()"
                 >
             </div>
 
@@ -75,14 +82,15 @@
                 <div class="c-conductor__end-fixed__label">
                     {{ isFixed ? 'End' : 'Updated' }}
                 </div>
-                <input ref="endDate"
-                       v-model="formattedBounds.end"
-                       class="c-input--datetime"
-                       type="text"
-                       autocorrect="off"
-                       spellcheck="false"
-                       :disabled="!isFixed"
-                       @change="validateAllBounds(); submitForm()"
+                <input
+                    ref="endDate"
+                    v-model="formattedBounds.end"
+                    class="c-input--datetime"
+                    type="text"
+                    autocorrect="off"
+                    spellcheck="false"
+                    :disabled="!isFixed"
+                    @change="validateAllBounds(); submitForm()"
                 >
                 <date-picker
                     v-if="isFixed && isUTCBased"
@@ -93,18 +101,20 @@
                 />
             </div>
 
-            <div v-if="!isFixed"
-                 class="c-ctrl-wrapper c-conductor-input c-conductor__end-delta"
+            <div
+                v-if="!isFixed"
+                class="c-ctrl-wrapper c-conductor-input c-conductor__end-delta"
             >
                 <!-- RT end -->
                 <div class="c-direction-indicator icon-plus"></div>
-                <input ref="endOffset"
-                       v-model="offsets.end"
-                       class="c-input--hrs-min-sec"
-                       type="text"
-                       autocorrect="off"
-                       spellcheck="false"
-                       @change="validateAllOffsets(); submitForm()"
+                <input
+                    ref="endOffset"
+                    v-model="offsets.end"
+                    class="c-input--hrs-min-sec"
+                    type="text"
+                    autocorrect="off"
+                    spellcheck="false"
+                    @change="validateAllOffsets(); submitForm()"
                 >
             </div>
 
@@ -128,8 +138,9 @@
                 @select-timespan="setViewFromBounds"
             />
         </div>
-        <input type="submit"
-               class="invisible"
+        <input
+            type="submit"
+            class="invisible"
         >
     </form>
 </div>

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -314,6 +314,14 @@ export default {
                 this.setOffsetsFromView();
             }
         },
+        getBoundsLimit() {
+            const limit = this.configuration.menuOptions
+                .filter(option => option.timeSystem ===  this.timeSystem.key)
+                .find(option => option.limit)
+                .limit;
+
+            return limit;
+        },
         clearAllValidation() {
             if (this.isFixed) {
                 [this.$refs.startDate, this.$refs.endDate].forEach(this.clearValidationForInput);
@@ -343,7 +351,18 @@ export default {
                         start: this.timeFormatter.parse(this.formattedBounds.start),
                         end: this.timeFormatter.parse(this.formattedBounds.end)
                     };
-                    validationResult = this.openmct.time.validateBounds(boundsValues);
+                    const limit = this.getBoundsLimit();
+
+                    if (
+                        this.timeSystem.isUTCBased
+                        && limit
+                        && boundsValues.end - boundsValues.start > limit
+                    ) {
+                        validationResult = "Start and end difference exceeds allowable limit";
+                    } else {
+                        validationResult = this.openmct.time.validateBounds(boundsValues);
+                    }
+
                 }
 
                 if (validationResult !== true) {

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -130,10 +130,10 @@
 
             <conductor-axis
                 class="c-conductor__ticks"
-                :bounds="rawBounds"
+                :view-bounds="viewBounds"
                 :is-fixed="isFixed"
-                @stopPanning="stopPanning"
-                @stopZooming="stopZooming"
+                @endPan="endPan"
+                @endZoom="endZoom"
                 @panAxis="pan"
                 @zoomAxis="zoom"
             />
@@ -201,7 +201,7 @@ export default {
                 start: bounds.start,
                 end: bounds.end
             },
-            rawBounds: {
+            viewBounds: {
                 start: bounds.start,
                 end: bounds.end
             },
@@ -214,7 +214,7 @@ export default {
     },
     mounted() {
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));
-        this.openmct.time.on('bounds', this.setNewBounds);
+        this.openmct.time.on('bounds', this.setViewFromBounds);
         this.openmct.time.on('timeSystem', this.setTimeSystem);
         this.openmct.time.on('clock', this.setViewFromClock);
         this.openmct.time.on('clockOffsets', this.setViewFromOffsets)
@@ -224,16 +224,21 @@ export default {
             this.isPanning = true;
             this.setViewFromBounds(bounds);
         },
-        stopPanning() {
+        endPan(bounds) {
             this.isPanning = false;
+            this.openmct.time.bounds(bounds);
+            // this.setViewFromBounds(bounds);
         },
         zoom(bounds) {
             this.isZooming = true;
             this.formattedBounds.start = this.timeFormatter.format(bounds.start);
             this.formattedBounds.end = this.timeFormatter.format(bounds.end);
         },
-        stopZooming() {
+        endZoom(bounds) {
+            const _bounds = bounds ? bounds : this.openmct.time.bounds();
             this.isZooming = false;
+
+            this.openmct.time.bounds(_bounds);
         },
         setTimeSystem(timeSystem) {
             this.timeSystem = timeSystem
@@ -279,8 +284,8 @@ export default {
         setViewFromBounds(bounds) {
             this.formattedBounds.start = this.timeFormatter.format(bounds.start);
             this.formattedBounds.end = this.timeFormatter.format(bounds.end);
-            this.rawBounds.start = bounds.start;
-            this.rawBounds.end = bounds.end;
+            this.viewBounds.start = bounds.start;
+            this.viewBounds.end = bounds.end;
         },
         setViewFromOffsets(offsets) {
             this.offsets.start = this.durationFormatter.format(Math.abs(offsets.start));

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -22,16 +22,12 @@
 <template>
 <div
     class="c-conductor"
-<<<<<<< HEAD
-    :class="[isFixed ? 'is-fixed-mode' : 'is-realtime-mode']"
-=======
     :class="[
         { 'is-zooming': isZooming },
         { 'is-panning': isPanning },
         { 'alt-pressed': altPressed },
         isFixed ? 'is-fixed-mode' : 'is-realtime-mode'
     ]"
->>>>>>> acc0abc90... move zoom/pan styling up to conductor
 >
     <form
         ref="conductorForm"

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -147,7 +147,7 @@
             <ConductorHistory
                 v-if="isFixed"
                 class="c-conductor__history-select"
-                :bounds="bounds"
+                :bounds="openmct.time.bounds()"
                 :time-system="timeSystem"
             />
         </div>
@@ -198,10 +198,6 @@ export default {
                 start: timeFormatter.format(bounds.start),
                 end: timeFormatter.format(bounds.end)
             },
-            bounds: {
-                start: bounds.start,
-                end: bounds.end
-            },
             viewBounds: {
                 start: bounds.start,
                 end: bounds.end
@@ -229,7 +225,6 @@ export default {
     mounted() {
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));
         this.openmct.time.on('bounds', this.setViewFromBounds);
-        this.openmct.time.on('bounds', this.setNewBounds);
         this.openmct.time.on('timeSystem', this.setTimeSystem);
         this.openmct.time.on('clock', this.setViewFromClock);
         this.openmct.time.on('clockOffsets', this.setViewFromOffsets)
@@ -428,10 +423,6 @@ export default {
             this.formattedBounds.end = this.timeFormatter.format(date);
             this.validateAllBounds();
             this.submitForm();
-        },
-        setNewBounds(bounds) {
-            this.bounds.start = bounds.start;
-            this.bounds.end = bounds.end;
         }
     }
 }

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -125,7 +125,7 @@
                 :bounds="rawBounds"
                 :is-fixed="isFixed"
                 @panAxis="setViewFromBounds"
-                @zoomAxis="setViewFromBounds"
+                @zoomAxis="setZoomBounds"
             />
 
         </div>
@@ -258,6 +258,10 @@ export default {
         setViewFromOffsets(offsets) {
             this.offsets.start = this.durationFormatter.format(Math.abs(offsets.start));
             this.offsets.end = this.durationFormatter.format(Math.abs(offsets.end));
+        },
+        setZoomBounds(bounds) {
+            this.formattedBounds.start = this.timeFormatter.format(bounds.start);
+            this.formattedBounds.end = this.timeFormatter.format(bounds.end);
         },
         updateTimeFromConductor() {
             if (this.isFixed) {

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -149,7 +149,6 @@
                 class="c-conductor__history-select"
                 :bounds="bounds"
                 :time-system="timeSystem"
-                @select-timespan="setViewFromBounds"
             />
         </div>
         <input

--- a/src/plugins/timeConductor/Conductor.vue
+++ b/src/plugins/timeConductor/Conductor.vue
@@ -28,6 +28,7 @@
     :class="[
         { 'is-zooming': isZooming },
         { 'is-panning': isPanning },
+        { 'alt-pressed': altPressed },
         isFixed ? 'is-fixed-mode' : 'is-realtime-mode'
     ]"
 >>>>>>> acc0abc90... move zoom/pan styling up to conductor
@@ -132,6 +133,7 @@
                 class="c-conductor__ticks"
                 :view-bounds="viewBounds"
                 :is-fixed="isFixed"
+                :alt-pressed="altPressed"
                 @endPan="endPan"
                 @endZoom="endZoom"
                 @panAxis="pan"
@@ -208,9 +210,22 @@ export default {
             isFixed: this.openmct.time.clock() === undefined,
             isUTCBased: timeSystem.isUTCBased,
             showDatePicker: false,
+            altPressed: false,
             isPanning: false,
             isZooming: false
         }
+    },
+    created() {
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Alt') {
+                this.altPressed = true;
+            }
+        });
+        document.addEventListener('keyup', (e) => {
+            if (e.key === 'Alt') {
+                this.altPressed = false;
+            }
+        });
     },
     mounted() {
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));

--- a/src/plugins/timeConductor/ConductorAxis.vue
+++ b/src/plugins/timeConductor/ConductorAxis.vue
@@ -215,7 +215,9 @@ export default {
             this.$emit('panAxis', panBounds);
         },
         endPan() {
-            const panBounds = this.getPanBounds();
+            const panBounds = this.dragStartX && this.dragX && this.dragStartX !== this.dragX
+                ? this.getPanBounds()
+                : undefined;
             this.$emit('endPan', panBounds);
             this.isPanMode = false;
         },

--- a/src/plugins/timeConductor/ConductorAxis.vue
+++ b/src/plugins/timeConductor/ConductorAxis.vue
@@ -252,27 +252,34 @@ export default {
             });
         },
         zoom() {
-            const zoomBounds = this.getZoomBounds();
+            const zoomRange = this.getZoomRange();
 
             this.zoomStyle = {
-                left: `${zoomBounds.start}px`,
-                width: `${zoomBounds.end - zoomBounds.start}px`
+                left: `${zoomRange.start - this.left}px`,
+                width: `${zoomRange.end - zoomRange.start}px`
             };
 
             this.$emit('zoomAxis', {
-                start: this.scaleToBounds(zoomBounds.start),
-                end: this.scaleToBounds(zoomBounds.end)
+                start: this.scaleToBounds(zoomRange.start),
+                end: this.scaleToBounds(zoomRange.end)
             });
         },
         endZoom() {
-            const zoomBounds = this.dragStartX && this.dragX && this.dragStartX !== this.dragX
-                ? this.getZoomBounds()
+            const zoomRange = this.dragStartX && this.dragX && this.dragStartX !== this.dragX
+                ? this.getZoomRange()
                 : undefined;
+
+            const zoomBounds = zoomRange
+                ? {
+                    start: this.scaleToBounds(zoomRange.start),
+                    end: this.scaleToBounds(zoomRange.end)
+                }
+                : this.openmct.time.bounds();
 
             this.zoomStyle = {};
             this.$emit('endZoom', zoomBounds);
         },
-        getZoomBounds() {
+        getZoomRange() {
             const leftBound = this.left;
             const rightBound = this.left + this.width;
 
@@ -285,13 +292,11 @@ export default {
                 : Math.max(this.dragX, this.dragStartX);
 
             return {
-                start: zoomStart - leftBound,
-                end: zoomEnd - leftBound
+                start: zoomStart,
+                end: zoomEnd
             };
         },
         scaleToBounds(value) {
-
-
             const bounds = this.openmct.time.bounds();
             const timeDelta = bounds.end - bounds.start;
             const valueDelta = value - this.left;

--- a/src/plugins/timeConductor/ConductorAxis.vue
+++ b/src/plugins/timeConductor/ConductorAxis.vue
@@ -55,6 +55,10 @@ export default {
         isFixed: {
             type: Boolean,
             required: true
+        },
+        altPressed: {
+            type: Boolean,
+            required: true
         }
     },
     data() {
@@ -77,18 +81,6 @@ export default {
             },
             deep: true
         }
-    },
-    created() {
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Alt') {
-                this.altPressed = true;
-            }
-        });
-        document.addEventListener('keyup', (e) => {
-            if (e.key === 'Alt') {
-                this.altPressed = false;
-            }
-        });
     },
     mounted() {
         let axisHolder = this.$refs.axisHolder;

--- a/src/plugins/timeConductor/ConductorAxis.vue
+++ b/src/plugins/timeConductor/ConductorAxis.vue
@@ -63,15 +63,15 @@ export default {
     },
     data() {
         return {
-            isPanMode: false,
+            inPanMode: false,
             dragStartX: undefined,
             dragX: undefined,
             zoomStyle: {}
         }
     },
     computed: {
-        isZoomMode() {
-            return !this.isPanMode;
+        inZoomMode() {
+            return !this.inPanMode;
         }
     },
     watch: {
@@ -171,7 +171,7 @@ export default {
                 this.dragStartX = $event.clientX;
 
                 if (this.altPressed) {
-                    this.isPanMode = true;
+                    this.inPanMode = true;
                 }
 
                 document.addEventListener('mousemove', this.drag);
@@ -179,7 +179,7 @@ export default {
                     once: true
                 });
 
-                if (this.isZoomMode) {
+                if (this.inZoomMode) {
                     this.startZoom();
                 }
             }
@@ -194,21 +194,17 @@ export default {
 
             requestAnimationFrame(() => {
                 this.dragX = $event.clientX;
-                this.isPanMode ? this.pan() : this.zoom();
+                this.inPanMode ? this.pan() : this.zoom();
             });
 
             this.dragging = false;
         },
         dragEnd() {
-            this.isPanMode ? this.endPan() : this.endZoom();
+            this.inPanMode ? this.endPan() : this.endZoom();
 
             document.removeEventListener('mousemove', this.drag);
             this.dragStartX = undefined;
             this.dragX = undefined;
-            // this.openmct.time.bounds({
-            //     start: this.bounds.start,
-            //     end: this.bounds.end
-            // });
         },
         pan() {
             const panBounds = this.getPanBounds();
@@ -219,7 +215,7 @@ export default {
                 ? this.getPanBounds()
                 : undefined;
             this.$emit('endPan', panBounds);
-            this.isPanMode = false;
+            this.inPanMode = false;
         },
         getPanBounds() {
             const bounds = this.openmct.time.bounds();

--- a/src/plugins/timeConductor/ConductorAxis.vue
+++ b/src/plugins/timeConductor/ConductorAxis.vue
@@ -20,11 +20,11 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 <template>
-<div ref="axisHolder"
-     class="c-conductor-axis"
-     @mousedown="dragStart($event)"
->
-</div>
+<div
+    ref="axisHolder"
+    class="c-conductor-axis"
+    @mousedown="dragStart($event)"
+></div>
 </template>
 
 <script>

--- a/src/plugins/timeConductor/ConductorAxis.vue
+++ b/src/plugins/timeConductor/ConductorAxis.vue
@@ -185,19 +185,15 @@ export default {
             }
         },
         drag($event) {
-            if (this.dragging) {
-                console.log('Rejected drag due to RAF cap');
-                return;
+            if (!this.dragging) {
+                this.dragging = true;
+
+                requestAnimationFrame(() => {
+                    this.dragX = $event.clientX;
+                    this.inPanMode ? this.pan() : this.zoom();
+                    this.dragging = false;
+                });
             }
-
-            this.dragging = true;
-
-            requestAnimationFrame(() => {
-                this.dragX = $event.clientX;
-                this.inPanMode ? this.pan() : this.zoom();
-            });
-
-            this.dragging = false;
         },
         dragEnd() {
             this.inPanMode ? this.endPan() : this.endZoom();

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -27,18 +27,30 @@
         <span class="c-button__label">History</span>
     </button>
     <div v-if="open"
-         class="c-menu"
+         class="c-menu c-conductor__history-menu"
     >
         <ul
             v-if="isUTCBased"
         >
-            <li @click="selectHours(24)">Last 24 hours</li>
-            <li @click="selectHours(2)">Last 2 hours</li>
-            <li @click="selectHours(1)">Last hour</li>
+            <li class="icon-clock"
+                @click="selectHours(24)">Last 24 hours
+            </li>
+            <li class="icon-clock"
+                @click="selectHours(2)">Last 2 hours
+            </li>
+            <li class="icon-clock"
+                @click="selectHours(1)">Last hour
+            </li>
         </ul>
+
+        <div class="c-menu__section-separator c-menu__section-hint">
+            Past timeframes, ordered by latest first
+        </div>
+
         <ul>
             <li
                 v-for="(timespan, index) in historyForCurrentTimeSystem"
+                class="icon-history"
                 :key="index"
                 @click="selectTimespan(timespan)"
             >
@@ -79,7 +91,8 @@ export default {
             return this.timeSystem.isUTCBased;
         },
         historyForCurrentTimeSystem() {
-            return this.history[this.timeSystem.key]
+            // Return a reversed array so that timeframes are ordered latest first
+            return this.history[this.timeSystem.key].reverse();
         }
     },
     watch: {

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -29,9 +29,7 @@
     <div v-if="open"
          class="c-menu c-conductor__history-menu"
     >
-        <ul
-            v-if="hasHistoryPresets"
-        >
+        <ul v-if="hasHistoryPresets">
             <li
                 v-for="preset in presets"
                 :key="preset.label"
@@ -42,7 +40,12 @@
             </li>
         </ul>
 
-        <div class="c-menu__section-separator c-menu__section-hint">
+        <div
+            v-if="hasHistoryPresets"
+            class="c-menu__section-separator"
+        ></div>
+
+        <div class="c-menu__section-hint">
             Past timeframes, ordered by latest first
         </div>
 
@@ -65,29 +68,6 @@ import toggleMixin from '../../ui/mixins/toggle-mixin';
 
 const LOCAL_STORAGE_HISTORY_KEY = 'tcHistory';
 const DEFAULT_RECORDS = 10;
-const DEFAULT_UTC_PRESETS = [
-    {
-        label: 'Last Day',
-        bounds: {
-            start: Date.now() - 1000 * 60 * 60 * 24,
-            end: Date.now()
-        }
-    },
-    {
-        label: 'Last 2 hours',
-        bounds: {
-            start: Date.now() - 1000 * 60 * 60 * 2,
-            end: Date.now()
-        }
-    },
-    {
-        label: 'Last hour',
-        bounds: {
-            start: Date.now() - 1000 * 60 * 60,
-            end: Date.now()
-        }
-    }
-];
 
 export default {
     inject: ['openmct', 'configuration'],
@@ -196,9 +176,9 @@ export default {
         },
         loadPresets(configurations) {
             const configuration = configurations.find(option => option.presets);
-            const preset = configuration ? configuration.presets : DEFAULT_UTC_PRESETS;
+            const presets = configuration ? configuration.presets : [];
 
-            return preset;
+            return presets;
         },
         loadRecords(configurations) {
             const configuration = configurations.find(option => option.records);

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -162,8 +162,6 @@ export default {
                 end: this.bounds.end
             };
 
-            // when choosing an existing entry, remove it and add it back as latest entry
-            // const isNotEqual = (entry) => entry.start !== this.start || entry.end !== this.end;
             const isNotEqual = function (entry) {
                 const start = entry.start !== this.start;
                 const end = entry.end !== this.end;

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -33,13 +33,19 @@
             v-if="isUTCBased"
         >
             <li class="icon-clock"
-                @click="selectHours(24)">Last 24 hours
+                @click="selectHours(24)"
+            >
+                Last 24 hours
             </li>
             <li class="icon-clock"
-                @click="selectHours(2)">Last 2 hours
+                @click="selectHours(2)"
+            >
+                Last 2 hours
             </li>
             <li class="icon-clock"
-                @click="selectHours(1)">Last hour
+                @click="selectHours(1)"
+            >
+                Last hour
             </li>
         </ul>
 
@@ -65,7 +71,7 @@
 import toggleMixin from '../../ui/mixins/toggle-mixin';
 import _ from 'lodash'
 
-const LOCAL_STORAGE_HISTORY_MAX_RECORDS = 20;
+const LOCAL_STORAGE_HISTORY_MAX_RECORDS = 10;
 const LOCAL_STORAGE_HISTORY_KEY = 'tcHistory';
 
 export default {
@@ -91,8 +97,10 @@ export default {
             return this.timeSystem.isUTCBased;
         },
         historyForCurrentTimeSystem() {
+            const history = this.history[this.timeSystem.key];
             // Return a reversed array so that timeframes are ordered latest first
-            return this.history[this.timeSystem.key].reverse();
+            // return history.reverse();
+            return history;
         }
     },
     watch: {
@@ -143,7 +151,7 @@ export default {
                 return !_.isEqual(timespan, entry);
             });
 
-            if (currentHistory.length >= LOCAL_STORAGE_HISTORY_MAX_RECORDS) {
+            while (currentHistory.length >= LOCAL_STORAGE_HISTORY_MAX_RECORDS) {
                 currentHistory.shift();
             }
 

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -62,7 +62,6 @@
 
 <script>
 import toggleMixin from '../../ui/mixins/toggle-mixin';
-import _ from 'lodash'
 
 const LOCAL_STORAGE_HISTORY_KEY = 'tcHistory';
 const DEFAULT_RECORDS = 10;

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -1,0 +1,159 @@
+/*****************************************************************************
+ * Open MCT Web, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT Web is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT Web includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+<template>
+<div class="c-ctrl-wrapper c-ctrl-wrapper--menus-up">
+    <button class="c-button--menu c-history-button icon-history"
+            @click.prevent="toggle"
+    >
+        <span class="c-button__label">History</span>
+    </button>
+    <div v-if="open"
+         class="c-menu"
+    >
+        <ul
+            v-if="isUTCBased"
+        >
+            <li @click="selectHours(24)">Last 24 hours</li>
+            <li @click="selectHours(2)">Last 2 hours</li>
+            <li @click="selectHours(1)">Last hour</li>
+        </ul>
+        <ul>
+            <li
+                v-for="(timespan, index) in historyForCurrentTimeSystem"
+                :key="index"
+                @click="selectTimespan(timespan)"
+            >
+                {{ formatTime(timespan.start) }} - {{ formatTime(timespan.end) }}
+            </li>
+        </ul>
+    </div>
+</div>
+</template>
+
+<script>
+import toggleMixin from '../../ui/mixins/toggle-mixin';
+import _ from 'lodash'
+
+const LOCAL_STORAGE_HISTORY_MAX_RECORDS = 20;
+const LOCAL_STORAGE_HISTORY_KEY = 'tcHistory';
+
+export default {
+    inject: ['openmct'],
+    mixins: [toggleMixin],
+    props: {
+        bounds: {
+            type: Object,
+            required: true
+        },
+        timeSystem: {
+            type: Object,
+            required: true
+        }
+    },
+    data() {
+        return {
+            history: {} // contains arrays of timespans {start, end}, array key is time system key
+        }
+    },
+    computed: {
+        isUTCBased() {
+            return this.timeSystem.isUTCBased;
+        },
+        historyForCurrentTimeSystem() {
+            return this.history[this.timeSystem.key]
+        }
+    },
+    watch: {
+        bounds: {
+            handler() {
+                this.addTimespan();
+            },
+            deep: true
+        },
+        timeSystem: {
+            handler() {
+                this.addTimespan();
+            },
+            deep: true
+        },
+        history: {
+            handler() {
+                this.persistHistoryToLocalStorage();
+            },
+            deep: true
+        }
+    },
+    mounted() {
+        this.getHistoryFromLocalStorage();
+    },
+    methods: {
+        getHistoryFromLocalStorage() {
+            if (localStorage.getItem(LOCAL_STORAGE_HISTORY_KEY)) {
+                this.history = JSON.parse(localStorage.getItem(LOCAL_STORAGE_HISTORY_KEY))
+            } else {
+                this.history = {};
+                this.persistHistoryToLocalStorage();
+            }
+        },
+        persistHistoryToLocalStorage() {
+            localStorage.setItem(LOCAL_STORAGE_HISTORY_KEY, JSON.stringify(this.history));
+        },
+        addTimespan() {
+            const key = this.timeSystem.key;
+            let [...currentHistory] = this.history[key] || [];
+            const timespan = {
+                start: this.bounds.start,
+                end: this.bounds.end
+            };
+
+            // when choosing an existing entry, remove it and add it back as latest entry
+            currentHistory = currentHistory.filter((entry) => {
+                return !_.isEqual(timespan, entry);
+            });
+
+            if (currentHistory.length >= LOCAL_STORAGE_HISTORY_MAX_RECORDS) {
+                currentHistory.shift();
+            }
+
+            currentHistory.push(timespan);
+            this.history[key] = currentHistory;
+        },
+        selectTimespan(timespan) {
+            this.$emit('select-timespan', timespan);
+        },
+        selectHours(hours) {
+            const now = Date.now();
+            this.selectTimespan({
+                start: now - hours * 60 * 60 * 1000,
+                end: now
+            });
+        },
+        formatTime(time) {
+            const formatter = this.openmct.telemetry.getValueFormatter({
+                format: this.timeSystem.timeFormat
+            }).formatter;
+
+            return formatter.format(time);
+        }
+    }
+}
+</script>

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -49,8 +49,8 @@
         <ul>
             <li
                 v-for="(timespan, index) in historyForCurrentTimeSystem"
-                class="icon-history"
                 :key="index"
+                class="icon-history"
                 @click="selectTimespan(timespan)"
             >
                 {{ formatTime(timespan.start) }} - {{ formatTime(timespan.end) }}
@@ -68,7 +68,7 @@ const LOCAL_STORAGE_HISTORY_KEY = 'tcHistory';
 const DEFAULT_RECORDS = 10;
 const DEFAULT_UTC_PRESETS = [
     {
-        label: 'XLast Day',
+        label: 'Last Day',
         bounds: {
             start: Date.now() - 1000 * 60 * 60 * 24,
             end: Date.now()
@@ -111,14 +111,11 @@ export default {
     },
     computed: {
         hasHistoryPresets() {
-            const isUTCBased = this.timeSystem.isUTCBased;
-
-            return isUTCBased && this.presets.length;
+            return this.timeSystem.isUTCBased && this.presets.length;
         },
         historyForCurrentTimeSystem() {
             const history = this.history[this.timeSystem.key];
-            // Return a reversed array so that timeframes are ordered latest first
-            // return history.reverse();
+
             return history;
         }
     },
@@ -167,9 +164,14 @@ export default {
             };
 
             // when choosing an existing entry, remove it and add it back as latest entry
-            currentHistory = currentHistory.filter((entry) => {
-                return !_.isEqual(timespan, entry);
-            });
+            // const isNotEqual = (entry) => entry.start !== this.start || entry.end !== this.end;
+            const isNotEqual = function (entry) {
+                const start = entry.start !== this.start;
+                const end = entry.end !== this.end;
+
+                return start || end;
+            };
+            currentHistory = currentHistory.filter(isNotEqual, timespan);
 
             while (currentHistory.length >= this.records) {
                 currentHistory.pop();
@@ -179,7 +181,7 @@ export default {
             this.history[key] = currentHistory;
         },
         selectTimespan(timespan) {
-            this.$emit('select-timespan', timespan);
+            this.openmct.time.bounds(timespan);
         },
         selectHours(hours) {
             const now = Date.now();

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -34,7 +34,7 @@
                 v-for="preset in presets"
                 :key="preset.label"
                 class="icon-clock"
-                @click="selectTimespan(preset.bounds)"
+                @click="selectPresetBounds(preset.bounds)"
             >
                 {{ preset.label }}
             </li>
@@ -160,11 +160,13 @@ export default {
         selectTimespan(timespan) {
             this.openmct.time.bounds(timespan);
         },
-        selectHours(hours) {
-            const now = Date.now();
+        selectPresetBounds(bounds) {
+            const start = typeof bounds.start === 'function' ? bounds.start() : bounds.start;
+            const end = typeof bounds.end === 'function' ? bounds.end() : bounds.end;
+
             this.selectTimespan({
-                start: now - hours * 60 * 60 * 1000,
-                end: now
+                start: start,
+                end: end
             });
         },
         loadConfiguration() {

--- a/src/plugins/timeConductor/ConductorMode.vue
+++ b/src/plugins/timeConductor/ConductorMode.vue
@@ -110,7 +110,7 @@ export default {
             if (clock === undefined) {
                 return {
                     key: 'fixed',
-                    name: 'Fixed Timespan Mode',
+                    name: 'Fixed Timespan',
                     description: 'Query and explore data that falls between two fixed datetimes.',
                     cssClass: 'icon-tabular'
                 }

--- a/src/plugins/timeConductor/conductor-axis.scss
+++ b/src/plugins/timeConductor/conductor-axis.scss
@@ -50,7 +50,6 @@
     }
 
     body.desktop .is-fixed-mode & {
-        // @include cursorGrab();
         background-size: 3px 30%;
         background-color: $colorBodyBgSubtle;
         box-shadow: inset rgba(black, 0.4) 0 1px 1px;

--- a/src/plugins/timeConductor/conductor-axis.scss
+++ b/src/plugins/timeConductor/conductor-axis.scss
@@ -54,22 +54,6 @@
             stroke: $colorBodyBgSubtle;
             transition: $transOut;
         }
-
-        &:hover,
-        &:active {
-            $c: $colorKeySubtle;
-            background-color: $c;
-            transition: $transIn;
-            svg text {
-                stroke: $c;
-                transition: $transIn;
-            }
-        }
-
-        .alt-pressed {
-            @include cursorGrab();
-            background-color: blue;
-        }
     }
 
     .is-realtime-mode & {

--- a/src/plugins/timeConductor/conductor-axis.scss
+++ b/src/plugins/timeConductor/conductor-axis.scss
@@ -13,7 +13,7 @@
         text-rendering: geometricPrecision;
         width: 100%;
         height: 100%;
-        > g {
+        > g.axis {
             // Overall Tick holder
             transform: translateY($tickYPos);
             path {

--- a/src/plugins/timeConductor/conductor-axis.scss
+++ b/src/plugins/timeConductor/conductor-axis.scss
@@ -9,12 +9,6 @@
     border-radius: $controlCr;
     height: $h;
 
-    .c-conductor__zooming {
-        position: absolute;
-        background-color: blue;
-        height: $h;
-    }
-
     svg {
         text-rendering: geometricPrecision;
         width: 100%;

--- a/src/plugins/timeConductor/conductor-axis.scss
+++ b/src/plugins/timeConductor/conductor-axis.scss
@@ -9,6 +9,12 @@
     border-radius: $controlCr;
     height: $h;
 
+    .c-conductor__zooming {
+        position: absolute;
+        background-color: blue;
+        height: $h;
+    }
+
     svg {
         text-rendering: geometricPrecision;
         width: 100%;
@@ -44,7 +50,7 @@
     }
 
     body.desktop .is-fixed-mode & {
-        @include cursorGrab();
+        // @include cursorGrab();
         background-size: 3px 30%;
         background-color: $colorBodyBgSubtle;
         box-shadow: inset rgba(black, 0.4) 0 1px 1px;
@@ -65,6 +71,11 @@
                 stroke: $c;
                 transition: $transIn;
             }
+        }
+
+        .alt-pressed {
+            @include cursorGrab();
+            background-color: blue;
         }
     }
 

--- a/src/plugins/timeConductor/conductor.scss
+++ b/src/plugins/timeConductor/conductor.scss
@@ -57,8 +57,6 @@
         }
     }
 
-<<<<<<< HEAD
-=======
     &.is-fixed-mode {
         .c-conductor-axis {
             &__zoom-indicator {
@@ -118,7 +116,6 @@
         }
     }
 
->>>>>>> 9271259a4... move altPressed up to parent
     &.is-realtime-mode {
         .c-conductor__time-bounds {
             grid-template-columns: 20px auto 1fr auto auto;

--- a/src/plugins/timeConductor/conductor.scss
+++ b/src/plugins/timeConductor/conductor.scss
@@ -57,6 +57,67 @@
         }
     }
 
+<<<<<<< HEAD
+=======
+    &.is-fixed-mode {
+        .c-conductor-axis {
+            &__zoom-indicator {
+                border: 1px solid transparent;
+                display: none; // Hidden by default
+            }
+        }
+
+        &:not(.is-panning),
+        &:not(.is-zooming) {
+            .c-conductor-axis {
+                &:hover,
+                &:active {
+                    cursor: col-resize;
+                    filter: $timeConductorAxisHoverFilter;
+                }
+            }
+        }
+
+        &.is-panning,
+        &.is-zooming {
+            .c-conductor-input input {
+                // Styles for inputs while zooming or panning
+                background: rgba($timeConductorActiveBg, 0.4);
+            }
+        }
+
+        &.alt-pressed {
+            .c-conductor-axis {
+                @include cursorGrab();
+            }
+        }
+
+        &.is-panning {
+            .c-conductor-axis {
+                @include cursorGrab();
+                background-color: $timeConductorActivePanBg;
+                transition: $transIn;
+
+                svg text {
+                    stroke: $timeConductorActivePanBg;
+                    transition: $transIn;
+                }
+            }
+        }
+
+        &.is-zooming {
+            .c-conductor-axis__zoom-indicator {
+                display: block;
+                position: absolute;
+                background: rgba($timeConductorActiveBg, 0.4);
+                border-left-color: $timeConductorActiveBg;
+                border-right-color: $timeConductorActiveBg;
+                top: 0; bottom: 0;
+            }
+        }
+    }
+
+>>>>>>> 9271259a4... move altPressed up to parent
     &.is-realtime-mode {
         .c-conductor__time-bounds {
             grid-template-columns: 20px auto 1fr auto auto;

--- a/src/plugins/timeConductor/conductor.scss
+++ b/src/plugins/timeConductor/conductor.scss
@@ -87,7 +87,8 @@
         }
 
         &.alt-pressed {
-            .c-conductor-axis {
+            .c-conductor-axis:hover {
+                // When alt is being pressed and user is hovering over the axis, set the cursor
                 @include cursorGrab();
             }
         }

--- a/src/styles/_constants-espresso.scss
+++ b/src/styles/_constants-espresso.scss
@@ -142,6 +142,9 @@ $colorTimeHov: pullForward($colorTime, 10%);
 $colorTimeSubtle: pushBack($colorTime, 20%);
 $colorTOI: $colorBodyFg; // was $timeControllerToiLineColor
 $colorTOIHov: $colorTime; // was $timeControllerToiLineColorHov
+$timeConductorAxisHoverFilter: brightness(1.2);
+$timeConductorActiveBg: $colorKey;
+$timeConductorActivePanBg: #226074;
 
 /************************************************** BROWSING */
 $browseFrameColor: pullForward($colorBodyBg, 10%);

--- a/src/styles/_constants-maelstrom.scss
+++ b/src/styles/_constants-maelstrom.scss
@@ -146,6 +146,9 @@ $colorTimeHov: pullForward($colorTime, 10%);
 $colorTimeSubtle: pushBack($colorTime, 20%);
 $colorTOI: $colorBodyFg; // was $timeControllerToiLineColor
 $colorTOIHov: $colorTime; // was $timeControllerToiLineColorHov
+$timeConductorAxisHoverFilter: brightness(1.2);
+$timeConductorActiveBg: $colorKey;
+$timeConductorActivePanBg: #226074;
 
 /************************************************** BROWSING */
 $browseFrameColor: pullForward($colorBodyBg, 10%);

--- a/src/styles/_constants-snow.scss
+++ b/src/styles/_constants-snow.scss
@@ -132,7 +132,7 @@ $colorPausedFg: #fff;
 // Base variations
 $colorBodyBgSubtle: pullForward($colorBodyBg, 5%);
 $colorBodyBgSubtleHov: pushBack($colorKey, 50%);
-$colorKeySubtle: pushBack($colorKey, 10%);
+$colorKeySubtle: pushBack($colorKey, 20%);
 
 // Time Colors
 $colorTime: #618cff;
@@ -142,6 +142,9 @@ $colorTimeHov: pushBack($colorTime, 5%);
 $colorTimeSubtle: pushBack($colorTime, 20%);
 $colorTOI: $colorBodyFg; // was $timeControllerToiLineColor
 $colorTOIHov: $colorTime; // was $timeControllerToiLineColorHov
+$timeConductorAxisHoverFilter: brightness(0.8);
+$timeConductorActiveBg: $colorKey;
+$timeConductorActivePanBg: #A0CDE1;
 
 /************************************************** BROWSING */
 $browseFrameColor: pullForward($colorBodyBg, 10%);

--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -512,10 +512,13 @@ select {
     @include menuInner();
 
     &__section-hint {
+        $m: $interiorMargin;
+        margin: $m 0;
+        padding: $m nth($menuItemPad, 2) 0 nth($menuItemPad, 2);
+
         opacity: 0.6;
         font-size: 0.9em;
         font-style: italic;
-        //text-align: center;
     }
 
     &__section-separator {

--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -462,9 +462,17 @@ select {
     text-shadow: $shdwMenuText;
     padding: $interiorMarginSm;
     box-shadow: $shdwMenu;
-    display: block;
+    display: flex;
+    flex-direction: column;
     position: absolute;
     z-index: 100;
+
+    > * {
+        flex: 0 0 auto;
+        //+ * {
+        //    margin-top: $interiorMarginSm;
+        //}
+    }
 }
 
 @mixin menuInner() {
@@ -502,6 +510,20 @@ select {
 .c-menu {
     @include menuOuter();
     @include menuInner();
+
+    &__section-hint {
+        opacity: 0.6;
+        font-size: 0.9em;
+        font-style: italic;
+        //text-align: center;
+    }
+
+    &__section-separator {
+        $m: $interiorMargin;
+        border-top: 1px solid $colorInteriorBorder;
+        margin: $m 0;
+        padding: $m nth($menuItemPad, 2) 0 nth($menuItemPad, 2);
+    }
 }
 
 .c-super-menu {


### PR DESCRIPTION
## Overview
Addresses  #2430, Supercedes #2552

- change pan axis to require alt key press and hold
- add zoom axis
  - drag to select a range within current bounds to "zoom" in to
  - zoomed range becomes new bounds
- visually highlight  on pan and on zoom
- time conductor history
  - records recently used times based on current time system
  - saves time history on bounds change
  - saves time history on time system change
  - configurable presets (ex. last hour, last day)
  - configurable number of previous history records
  - persists history for all used time systems in local storage

## Author Checklist
| | |
| --- | :---: |
| Changes address original issue? | Y |
| Unit tests included and/or updated with changes? | N/A |
| Command line build passes? | Y |
| Changes have been smoke-tested? | Y |