### PR TITLE
Fixes computation of result when telemetry is not used by an object

### DIFF
--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -70,15 +70,18 @@ export default class ConditionClass extends EventEmitter {
             return;
         }
 
-        this.criteria.forEach(criterion => {
-            if (this.isAnyOrAllTelemetry(criterion)) {
-                criterion.getResult(datum, this.conditionManager.telemetryObjects);
-            } else {
-                criterion.getResult(datum);
-            }
-        });
+        if (this.isTelemetryUsed(datum.id)) {
 
-        this.result = evaluateResults(this.criteria.map(criterion => criterion.result), this.trigger);
+            this.criteria.forEach(criterion => {
+                if (this.isAnyOrAllTelemetry(criterion)) {
+                    criterion.getResult(datum, this.conditionManager.telemetryObjects);
+                } else {
+                    criterion.getResult(datum);
+                }
+            });
+
+            this.result = evaluateResults(this.criteria.map(criterion => criterion.result), this.trigger);
+        }
     }
 
     isAnyOrAllTelemetry(criterion) {

--- a/src/plugins/condition/ConditionSpec.js
+++ b/src/plugins/condition/ConditionSpec.js
@@ -47,17 +47,24 @@ describe("The condition", function () {
             name: "Test Object",
             telemetry: {
                 values: [{
-                    key: "some-key",
-                    name: "Some attribute",
+                    key: "value",
+                    name: "Value",
+                    hints: {
+                        range: 2
+                    }
+                },
+                {
+                    key: "utc",
+                    name: "Time",
+                    format: "utc",
                     hints: {
                         domain: 1
                     }
                 }, {
-                    key: "some-other-key",
-                    name: "Another attribute",
-                    hints: {
-                        range: 1
-                    }
+                    key: "testSource",
+                    source: "value",
+                    name: "Test",
+                    format: "string"
                 }]
             }
         };
@@ -135,5 +142,39 @@ describe("The condition", function () {
         const result = conditionObj.destroyCriteria();
         expect(result).toBeTrue();
         expect(conditionObj.criteria.length).toEqual(0);
+    });
+
+    it("gets the result of a condition when new telemetry data is received", function () {
+        conditionObj.getResult({
+            value: '0',
+            utc: 'Hi',
+            id: testTelemetryObject.identifier.key
+        });
+        expect(conditionObj.result).toBeTrue();
+    });
+
+    it("gets the result of a condition when new telemetry data is received", function () {
+        conditionObj.getResult({
+            value: '1',
+            utc: 'Hi',
+            id: testTelemetryObject.identifier.key
+        });
+        expect(conditionObj.result).toBeFalse();
+    });
+
+    it("keeps the old result new telemetry data is not used by it", function () {
+        conditionObj.getResult({
+            value: '0',
+            utc: 'Hi',
+            id: testTelemetryObject.identifier.key
+        });
+        expect(conditionObj.result).toBeTrue();
+
+        conditionObj.getResult({
+            value: '1',
+            utc: 'Hi',
+            id: '1234'
+        });
+        expect(conditionObj.result).toBeTrue();
     });
 });


### PR DESCRIPTION
Resolves issue #3037 
Don't compute the result of a condition if telemetry datum is not being used by that condition.
Testing instructions: See #3037

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y