### PR TITLE
[Notebook] Clicking on an embed in a notebook entry does not result i…n bounds change #3034

### DIFF
--- a/src/plugins/notebook/components/notebook-embed.vue
+++ b/src/plugins/notebook/components/notebook-embed.vue
@@ -172,6 +172,7 @@ export default {
                 && this.embed.bounds.end !== bounds.end;
             const isFixedTimespanMode = !this.openmct.time.clock();
 
+            this.openmct.time.stopClock();
             window.location.href = link;
 
             let message = '';


### PR DESCRIPTION
### Fixes: #3034

### Steps to reproduce

1. Switch to realtime mode
2. Create a new notebook
3. Drag a SWG into the first entry
4. Click on the SWG embed link
5. Notification says changed to fixed-time mode but still in real time mode **(fixed)**