### PR TITLE
Added headless mode start option

### DIFF
--- a/src/MCT.js
+++ b/src/MCT.js
@@ -249,7 +249,7 @@ define([
         this.legacyRegistry = new BundleRegistry();
         installDefaultBundles(this.legacyRegistry);
 
-        // Plugin's that are installed by default
+        // Plugins that are installed by default
 
         this.install(this.plugins.Plot());
         this.install(this.plugins.TelemetryTable());
@@ -350,15 +350,11 @@ define([
      * @param {HTMLElement} [domElement] the DOM element in which to run
      *        MCT; if undefined, MCT will be run in the body of the document
      */
-    MCT.prototype.start = function (domElement) {
+    MCT.prototype.start = function (domElement = document.body, isHeadlessMode = false) {
         if (!this.plugins.DisplayLayout._installed) {
             this.install(this.plugins.DisplayLayout({
                 showAsView: ['summary-widget']
             }));
-        }
-
-        if (!domElement) {
-            domElement = document.body;
         }
 
         this.element = domElement;
@@ -400,23 +396,30 @@ define([
                 // something has depended upon objectService.  Cool, right?
                 this.$injector.get('objectService');
 
-                var appLayout = new Vue({
-                    components: {
-                        'Layout': Layout.default
-                    },
-                    provide: {
-                        openmct: this
-                    },
-                    template: '<Layout ref="layout"></Layout>'
-                });
-                domElement.appendChild(appLayout.$mount().$el);
+                if (!isHeadlessMode) {
+                    var appLayout = new Vue({
+                        components: {
+                            'Layout': Layout.default
+                        },
+                        provide: {
+                            openmct: this
+                        },
+                        template: '<Layout ref="layout"></Layout>'
+                    });
+                    domElement.appendChild(appLayout.$mount().$el);
 
-                this.layout = appLayout.$refs.layout;
-                Browse(this);
+                    this.layout = appLayout.$refs.layout;
+                    Browse(this);
+                }
                 this.router.start();
                 this.emit('start');
             }.bind(this));
     };
+
+    MCT.prototype.startHeadless = function () {
+        let unreachableNode = document.createElement('div');
+        return this.start(unreachableNode, true);
+    }
 
     /**
      * Install a plugin in MCT.

--- a/src/MCTSpec.js
+++ b/src/MCTSpec.js
@@ -21,11 +21,11 @@
  *****************************************************************************/
 
 define([
-    './MCT',
     './plugins/plugins',
-    'legacyRegistry'
-], function (MCT, plugins, legacyRegistry) {
-    xdescribe("MCT", function () {
+    'legacyRegistry',
+    'testTools'
+], function (plugins, legacyRegistry, testTools) {
+    describe("MCT", function () {
         var openmct;
         var mockPlugin;
         var mockPlugin2;
@@ -38,7 +38,7 @@ define([
             mockListener = jasmine.createSpy('listener');
             oldBundles = legacyRegistry.list();
 
-            openmct = new MCT();
+            openmct = testTools.createOpenMct();
 
             openmct.install(mockPlugin);
             openmct.install(mockPlugin2);
@@ -63,8 +63,11 @@ define([
         });
 
         describe("start", function () {
-            beforeEach(function () {
-                openmct.start();
+            let appHolder;
+            beforeEach(function (done) {
+                appHolder = document.createElement("div");
+                openmct.on('start', done);
+                openmct.start(appHolder);
             });
 
             it("calls plugins for configuration", function () {
@@ -75,25 +78,51 @@ define([
             it("emits a start event", function () {
                 expect(mockListener).toHaveBeenCalled();
             });
+
+            it("Renders the application into the provided container element", function () {
+                let openMctShellElements = appHolder.querySelectorAll('div.l-shell');
+                expect(openMctShellElements.length).toBe(1);
+            });
+        });
+
+        describe("startHeadless", function () {
+            beforeEach(function (done) {
+                openmct.on('start', done);
+                openmct.startHeadless();
+            });
+
+            it("calls plugins for configuration", function () {
+                expect(mockPlugin).toHaveBeenCalledWith(openmct);
+                expect(mockPlugin2).toHaveBeenCalledWith(openmct);
+            });
+
+            it("emits a start event", function () {
+                expect(mockListener).toHaveBeenCalled();
+            });
+
+            it("Does not render Open MCT", function () {
+                let openMctShellElements = document.body.querySelectorAll('div.l-shell');
+                expect(openMctShellElements.length).toBe(0);
+            });
         });
 
         describe("setAssetPath", function () {
             var testAssetPath;
 
             beforeEach(function () {
-                testAssetPath = "some/path";
                 openmct.legacyExtension = jasmine.createSpy('legacyExtension');
-                openmct.setAssetPath(testAssetPath);
             });
 
-            it("internally configures the path for assets", function () {
-                expect(openmct.legacyExtension).toHaveBeenCalledWith(
-                    'constants',
-                    {
-                        key: "ASSETS_PATH",
-                        value: testAssetPath
-                    }
-                );
+            it("configures the path for assets", function () {
+                testAssetPath = "some/path/";
+                openmct.setAssetPath(testAssetPath);
+                expect(openmct.getAssetPath()).toBe(testAssetPath);
+            });
+
+            it("adds a trailing /", function () {
+                testAssetPath = "some/path";
+                openmct.setAssetPath(testAssetPath);
+                expect(openmct.getAssetPath()).toBe(testAssetPath + "/");
             });
         });
     });

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -23,22 +23,18 @@
 import { createOpenMct } from "testTools";
 import ConditionPlugin from "./plugin";
 
-let openmct = createOpenMct();
-openmct.install(new ConditionPlugin());
-
-let conditionSetDefinition;
-let mockConditionSetDomainObject;
-let element;
-let child;
-
 describe('the plugin', function () {
+    let conditionSetDefinition;
+    let mockConditionSetDomainObject;
+    let element;
+    let child;
+    let openmct;
 
     beforeAll((done) => {
+        openmct = createOpenMct();
+        openmct.install(new ConditionPlugin());
 
         conditionSetDefinition = openmct.types.get('conditionSet').definition;
-        const appHolder = document.createElement('div');
-        appHolder.style.width = '640px';
-        appHolder.style.height = '480px';
 
         element = document.createElement('div');
         child = document.createElement('div');
@@ -55,7 +51,7 @@ describe('the plugin', function () {
         conditionSetDefinition.initialize(mockConditionSetDomainObject);
 
         openmct.on('start', done);
-        openmct.start(appHolder);
+        openmct.startHeadless();
     });
 
     let mockConditionSetObject = {

--- a/src/plugins/telemetryTable/pluginSpec.js
+++ b/src/plugins/telemetryTable/pluginSpec.js
@@ -26,31 +26,36 @@ import {
     createMouseEvent
 } from 'testTools';
 
-let openmct;
-let tablePlugin;
-let element;
-let child;
-
 describe("the plugin", () => {
-    beforeEach((done) => {
-        const appHolder = document.createElement('div');
-        appHolder.style.width = '640px';
-        appHolder.style.height = '480px';
+    let openmct;
+    let tablePlugin;
+    let element;
+    let child;
 
+    beforeEach((done) => {
         openmct = createOpenMct();
+
+        // Table Plugin is actually installed by default, but because installing it 
+        // again is harmless it is left here as an examplar for non-default plugins.
+        tablePlugin = new TablePlugin();
+        openmct.install(tablePlugin);
 
         element = document.createElement('div');
         child = document.createElement('div');
         element.appendChild(child);
 
-        tablePlugin = new TablePlugin();
-        openmct.install(tablePlugin);
-
         spyOn(openmct.telemetry, 'request').and.returnValue(Promise.resolve([]));
 
         openmct.on('start', done);
-        openmct.start(appHolder);
+        openmct.startHeadless();
     });
+
+    describe("defines a table object", function () {
+        it("that is creatable", () => {
+            let tableType = openmct.types.get('table');
+            expect(tableType.definition.creatable).toBe(true);
+        });
+    })
 
     it("provides a table view for objects with telemetry", () => {
         const testTelemetryObject = {

--- a/src/plugins/telemetryTable/pluginSpec.js
+++ b/src/plugins/telemetryTable/pluginSpec.js
@@ -35,7 +35,7 @@ describe("the plugin", () => {
     beforeEach((done) => {
         openmct = createOpenMct();
 
-        // Table Plugin is actually installed by default, but because installing it 
+        // Table Plugin is actually installed by default, but because installing it
         // again is harmless it is left here as an examplar for non-default plugins.
         tablePlugin = new TablePlugin();
         openmct.install(tablePlugin);


### PR DESCRIPTION
Fixes https://github.com/nasa/openmct/issues/3064

Adds a new startup option to Open MCT to start it without the UI. This slightly improves performance for testing purposes.

The new headless mode can be invoked using:
```
openmct.startHeadless()
```
Instead of
```
openmct.start(element)
```

Where appropriate, specs that need to test UI features should just load the relevant sections of UI in isolation (eg. an object view). Where the full Open MCT UI is required for testing, `.start()` can still be called.

This PR also updates two test specs to use the new headless mode, and removes some boilerplate code that was previously necessary to create a container element for the application.

Note that Angular still requires __some__ element for bootstrapping purposes. For this, [a throwaway div is used](https://github.com/nasa/openmct/pull/3065/files#diff-99bf719c45547a2a6e959e529854b8a0R419). Note that nothing will render into it, since the UI itself is being bootstrapped outside of Angular now. When Angular is removed this throwaway element won't be necessary any more.