### PR TITLE
Give users the option to hide table headers

### DIFF
--- a/src/plugins/telemetryTable/components/table-configuration.vue
+++ b/src/plugins/telemetryTable/components/table-configuration.vue
@@ -47,6 +47,27 @@
                 </div>
             </li>
         </ul>
+        <div class="c-inspect-properties__header">
+            Table Header Visibility
+        </div>
+        <ul class="c-inspect-properties__section">
+            <li class="c-inspect-properties__row">
+                <div
+                    class="c-inspect-properties__label"
+                    title="Show or hide headers"
+                >
+                    <label for="header-visibility">Hide Header</label>
+                </div>
+                <div class="c-inspect-properties__value">
+                    <input
+                        id="header-visibility"
+                        type="checkbox"
+                        :checked="configuration.hideHeaders === true"
+                        @change="toggleHeaderVisibility"
+                    >
+                </div>
+            </li>
+        </ul>
     </template>
 </div>
 </template>
@@ -120,6 +141,12 @@ export default {
                 let column = new TelemetryTableColumn(this.openmct, metadatum);
                 this.tableConfiguration.addSingleColumnForObject(telemetryObject, column);
             });
+        },
+        toggleHeaderVisibility() {
+            let hideHeaders = this.configuration.hideHeaders;
+
+            this.configuration.hideHeaders = !hideHeaders;
+            this.tableConfiguration.updateConfiguration(this.configuration);
         }
     }
 }

--- a/src/plugins/telemetryTable/components/table-configuration.vue
+++ b/src/plugins/telemetryTable/components/table-configuration.vue
@@ -2,7 +2,7 @@
 <div class="c-inspect-properties">
     <template v-if="isEditing">
         <div class="c-inspect-properties__header">
-            Table Column Size
+            Table Layout
         </div>
         <ul class="c-inspect-properties__section">
             <li class="c-inspect-properties__row">
@@ -18,6 +18,22 @@
                         type="checkbox"
                         :checked="configuration.autosize !== false"
                         @change="toggleAutosize()"
+                    >
+                </div>
+            </li>
+            <li class="c-inspect-properties__row">
+                <div
+                        class="c-inspect-properties__label"
+                        title="Show or hide headers"
+                >
+                    <label for="header-visibility">Hide Header</label>
+                </div>
+                <div class="c-inspect-properties__value">
+                    <input
+                            id="header-visibility"
+                            type="checkbox"
+                            :checked="configuration.hideHeaders === true"
+                            @change="toggleHeaderVisibility"
                     >
                 </div>
             </li>
@@ -43,27 +59,6 @@
                         type="checkbox"
                         :checked="configuration.hiddenColumns[key] !== true"
                         @change="toggleColumn(key)"
-                    >
-                </div>
-            </li>
-        </ul>
-        <div class="c-inspect-properties__header">
-            Table Header Visibility
-        </div>
-        <ul class="c-inspect-properties__section">
-            <li class="c-inspect-properties__row">
-                <div
-                    class="c-inspect-properties__label"
-                    title="Show or hide headers"
-                >
-                    <label for="header-visibility">Hide Header</label>
-                </div>
-                <div class="c-inspect-properties__value">
-                    <input
-                        id="header-visibility"
-                        type="checkbox"
-                        :checked="configuration.hideHeaders === true"
-                        @change="toggleHeaderVisibility"
                     >
                 </div>
             </li>

--- a/src/plugins/telemetryTable/components/table-configuration.vue
+++ b/src/plugins/telemetryTable/components/table-configuration.vue
@@ -23,17 +23,17 @@
             </li>
             <li class="c-inspect-properties__row">
                 <div
-                        class="c-inspect-properties__label"
-                        title="Show or hide headers"
+                    class="c-inspect-properties__label"
+                    title="Show or hide headers"
                 >
                     <label for="header-visibility">Hide Header</label>
                 </div>
                 <div class="c-inspect-properties__value">
                     <input
-                            id="header-visibility"
-                            type="checkbox"
-                            :checked="configuration.hideHeaders === true"
-                            @change="toggleHeaderVisibility"
+                        id="header-visibility"
+                        type="checkbox"
+                        :checked="configuration.hideHeaders === true"
+                        @change="toggleHeaderVisibility"
                     >
                 </div>
             </li>

--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -139,6 +139,7 @@
         ></div>
         <!-- Headers table -->
         <div
+            v-show="!hideHeaders"
             ref="headersTable"
             class="c-telemetry-table__headers-w js-table__headers-w"
             :style="{ 'max-width': widthWithScroll}"
@@ -336,7 +337,8 @@ export default {
             markCounter: 0,
             paused: false,
             markedRows: [],
-            isShowingMarkedRowsOnly: false
+            isShowingMarkedRowsOnly: false,
+            hideHeaders: configuration.hideHeaders
         }
     },
     computed: {
@@ -615,6 +617,7 @@ export default {
         },
         updateConfiguration(configuration) {
             this.isAutosizeEnabled = configuration.autosize;
+            this.hideHeaders = configuration.hideHeaders;
 
             this.updateHeaders();
             this.$nextTick().then(this.calculateColumnWidths);


### PR DESCRIPTION
This is for VCP-0034.

Testing Notes:

1. Create a Telemetry Table
2. Add some telemetry (eg sine wave) 
3. Notice the new option in the inspector for hide headers
4. Toggle the option and verify the table headers are toggled with the checkbox. 

Fixes #3086 