### PR TITLE
Fixes #2604: Use relative paths for scss imports

### DIFF
--- a/src/plugins/themes/espresso-theme.scss
+++ b/src/plugins/themes/espresso-theme.scss
@@ -1,21 +1,21 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-espresso";
+@import "../../styles/constants-espresso";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";

--- a/src/plugins/themes/maelstrom-theme.scss
+++ b/src/plugins/themes/maelstrom-theme.scss
@@ -1,21 +1,21 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-maelstrom";
+@import "../../styles/constants-maelstrom";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";

--- a/src/plugins/themes/snow-theme.scss
+++ b/src/plugins/themes/snow-theme.scss
@@ -1,21 +1,21 @@
-@import "~styles/vendor/normalize-min";
-@import "~styles/constants";
-@import "~styles/constants-mobile.scss";
+@import "../../styles/vendor/normalize-min";
+@import "../../styles/constants";
+@import "../../styles/constants-mobile.scss";
 
-@import "~styles/constants-snow";
+@import "../../styles/constants-snow";
 
-@import "~styles/mixins";
-@import "~styles/animations";
-@import "~styles/about";
-@import "~styles/glyphs";
-@import "~styles/global";
-@import "~styles/status";
-@import "~styles/controls";
-@import "~styles/forms";
-@import "~styles/table";
-@import "~styles/legacy";
-@import "~styles/legacy-plots";
-@import "~styles/plotly";
-@import "~styles/legacy-messages";
+@import "../../styles/mixins";
+@import "../../styles/animations";
+@import "../../styles/about";
+@import "../../styles/glyphs";
+@import "../../styles/global";
+@import "../../styles/status";
+@import "../../styles/controls";
+@import "../../styles/forms";
+@import "../../styles/table";
+@import "../../styles/legacy";
+@import "../../styles/legacy-plots";
+@import "../../styles/plotly";
+@import "../../styles/legacy-messages";
 
-@import "~styles/vue-styles.scss";
+@import "../../styles/vue-styles.scss";


### PR DESCRIPTION
Replaces https://github.com/nasa/openmct/pull/2721

Tested on Windows 10 (node v10.15.3, npm 6.4.1) and Windows Subsystem for Linux (node v10.20.1, npm 6.14.4)