### PR TITLE
Closes issue of notebook snapshot that doesn't preserve display bounds (#2915)

### DIFF
--- a/src/plugins/notebook/components/notebook-embed.vue
+++ b/src/plugins/notebook/components/notebook-embed.vue
@@ -30,6 +30,7 @@ import PreviewAction from '../../../ui/preview/PreviewAction';
 import Painterro from 'painterro';
 import RemoveDialog from '../utils/removeDialog';
 import SnapshotTemplate from './snapshot-template.html';
+import ViewportService from '../../plot/src/services/ViewportService';
 import Vue from 'vue';
 
 export default {
@@ -238,6 +239,12 @@ export default {
             const self = this;
             const previewAction = new PreviewAction(self.openmct);
             previewAction.invoke(JSON.parse(self.embed.objectPath));
+
+            //set the plot viewport
+            if ('viewportBounds' in self.embed && self.embed.type in self.embed.viewportBounds) {
+                let svc = new ViewportService(self.openmct);
+                svc.setBounds(self.embed.viewportBounds[self.embed.type]);
+            }
         },
         removeEmbed(success) {
             if (!success) {

--- a/src/plugins/notebook/components/notebook-entry.vue
+++ b/src/plugins/notebook/components/notebook-entry.vue
@@ -194,6 +194,7 @@ export default {
             const bounds = this.openmct.time.bounds();
             const snapshotMeta = {
                 bounds,
+                viewportBounds: null,
                 link: null,
                 objectPath,
                 openmct: this.openmct

--- a/src/plugins/notebook/components/notebook-menu-switcher.vue
+++ b/src/plugins/notebook/components/notebook-menu-switcher.vue
@@ -31,6 +31,7 @@
 import Snapshot from '../snapshot';
 import { getDefaultNotebook } from '../utils/notebook-storage';
 import { NOTEBOOK_DEFAULT, NOTEBOOK_SNAPSHOT } from '../notebook-constants';
+import ViewportService from '../../plot/src/services/ViewportService';
 
 export default {
     inject: ['openmct'],
@@ -108,15 +109,20 @@ export default {
             this.$nextTick(() => {
                 const element = document.querySelector('.c-overlay__contents')
                     || document.getElementsByClassName('l-shell__main-container')[0];
-
                 const bounds = this.openmct.time.bounds();
                 const link = !this.ignoreLink
                     ? window.location.href
                     : null;
 
                 const objectPath = this.objectPath || this.openmct.router.path;
+
+                //get viewport bounds from mct-plot
+                let svc = new ViewportService(this.openmct);
+                const viewportBounds = svc.getBounds();
+
                 const snapshotMeta = {
                     bounds,
+                    viewportBounds,
                     link,
                     objectPath,
                     openmct: this.openmct

--- a/src/plugins/notebook/components/notebook.vue
+++ b/src/plugins/notebook/components/notebook.vue
@@ -273,6 +273,7 @@ export default {
             const bounds = this.openmct.time.bounds();
             const snapshotMeta = {
                 bounds,
+                viewportBounds: null,
                 link: null,
                 objectPath,
                 openmct: this.openmct

--- a/src/plugins/notebook/utils/notebook-entries.js
+++ b/src/plugins/notebook/utils/notebook-entries.js
@@ -69,6 +69,7 @@ export const getNotebookDefaultEntries = (notebookStorage, domainObject) => {
 export const createNewEmbed = (snapshotMeta, snapshot = '') => {
     const {
         bounds,
+        viewportBounds,
         link,
         objectPath,
         openmct
@@ -88,6 +89,7 @@ export const createNewEmbed = (snapshotMeta, snapshot = '') => {
 
     return {
         bounds,
+        viewportBounds,
         createdOn: date,
         cssClass,
         domainObject,

--- a/src/plugins/plot/plugin.js
+++ b/src/plugins/plot/plugin.js
@@ -36,6 +36,7 @@ define([
     "./src/inspector/PlotSeriesFormController",
     "./src/inspector/HideElementPoolDirective",
     "./src/services/ExportImageService",
+    "./src/services/ViewportService",
     './src/PlotViewPolicy',
     "./res/templates/plot-options.html",
     "./res/templates/plot-options-browse.html",
@@ -56,6 +57,7 @@ define([
     PlotSeriesFormController,
     HideElementPool,
     ExportImageService,
+    ViewportService,
     PlotViewPolicy,
     plotOptionsTemplate,
     plotOptionsBrowseTemplate,
@@ -152,10 +154,12 @@ define([
                             "depends": [
                                 "$scope",
                                 "$element",
+                                "$location",
                                 "formatService",
                                 "openmct",
                                 "objectService",
-                                "exportImageService"
+                                "exportImageService",
+                                "viewportService"
                             ]
                         },
                         {
@@ -212,6 +216,13 @@ define([
                             "implementation": ExportImageService,
                             "depends": [
                                 "dialogService"
+                            ]
+                        },
+                        {
+                            "key": "viewportService",
+                            "implementation": ViewportService,
+                            "depends": [
+                                "openmct"
                             ]
                         }
                     ],

--- a/src/plugins/plot/src/lib/constants.js
+++ b/src/plugins/plot/src/lib/constants.js
@@ -1,0 +1,28 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2020, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+export const QUERY_PARAM_NAMES = {
+    START_VIEWPORT_X: 'startViewX',
+    END_VIEWPORT_X: 'endViewX',
+    START_VIEWPORT_Y: 'startViewY',
+    END_VIEWPORT_Y: 'endViewY'
+};

--- a/src/plugins/plot/src/services/ViewportService.js
+++ b/src/plugins/plot/src/services/ViewportService.js
@@ -1,0 +1,85 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+define([
+    "../lib/constants",
+    "zepto"
+], function (
+    constants,
+    $
+) {
+    function ViewportService(openmct) {
+        this.openmct = openmct;
+    }
+
+    ViewportService.prototype.getBounds = function () {
+        let mainContainer = document.getElementsByClassName('l-shell__main-container')[0];
+        if (!mainContainer) {
+            return;
+        }
+
+        let returnData = {};
+        let plots = $(mainContainer).find("mct-plot");
+        for(let i=0, len=plots.length; i<len; i++) {
+            let scope = this.openmct.$angular.element(plots.get(i)).scope();
+            if (!scope || !scope.config) {
+                continue;
+            }
+
+            let id = scope.config.id ? scope.config.id : null;
+            if(!id) {
+                continue;
+            }
+
+            let model = scope.config.model ? scope.config.model : null;
+            if (!model) {
+                continue;
+            }
+
+            let xAxis = model.xAxis ? model.xAxis : null;
+            let yAxis = model.yAxis ? model.yAxis : null;
+            if (!xAxis || !yAxis || !xAxis.displayRange || !yAxis.displayRange) {
+                continue;
+            }
+
+            returnData[id] = {
+                x: xAxis.displayRange,
+                y: yAxis.displayRange
+            };
+        }
+
+        return returnData;
+    }
+
+    ViewportService.prototype.setBounds = function (viewportBounds) {
+        if ('x' in viewportBounds && 'y' in viewportBounds) {
+            this.openmct.router.updateParams({
+                [constants.QUERY_PARAM_NAMES.START_VIEWPORT_X]: viewportBounds.x.min,
+                [constants.QUERY_PARAM_NAMES.END_VIEWPORT_X]: viewportBounds.x.max,
+                [constants.QUERY_PARAM_NAMES.START_VIEWPORT_Y]: viewportBounds.y.min,
+                [constants.QUERY_PARAM_NAMES.END_VIEWPORT_Y]: viewportBounds.y.max
+            });
+        }
+    }
+
+    return ViewportService;
+});

--- a/src/plugins/plot/src/telemetry/PlotController.js
+++ b/src/plugins/plot/src/telemetry/PlotController.js
@@ -26,12 +26,14 @@ define([
     'lodash',
     '../configuration/PlotConfigurationModel',
     '../configuration/configStore',
-    '../lib/eventHelpers'
+    '../lib/eventHelpers',
+    '../lib/constants'
 ], function (
     _,
     PlotConfigurationModel,
     configStore,
-    eventHelpers
+    eventHelpers,
+    constants
 ) {
 
     /**
@@ -47,18 +49,21 @@ define([
     function PlotController(
         $scope,
         $element,
+        $location,
         formatService,
         openmct,
         objectService,
-        exportImageService
+        exportImageService,
+        viewportService
     ) {
-
         this.$scope = $scope;
         this.$element = $element;
+        this.$location = $location;
         this.formatService = formatService;
         this.openmct = openmct;
         this.objectService = objectService;
         this.exportImageService = exportImageService;
+        this.viewportService = viewportService;
         this.cursorGuide = false;
 
         $scope.pending = 0;
@@ -68,6 +73,7 @@ define([
         this.listenTo($scope, 'user:viewport:change:end', this.onUserViewportChangeEnd, this);
         this.listenTo($scope, '$destroy', this.destroy, this);
         this.listenTo($scope, 'clearData', this.clearData);
+        this.listenTo($scope, '$locationChangeSuccess', this.setAxisDisplayRange, this);
 
         this.config = this.getConfig(this.$scope.domainObject);
         this.listenTo(this.config.series, 'add', this.addSeries, this);
@@ -78,6 +84,8 @@ define([
 
         this.newStyleDomainObject = $scope.domainObject.useCapability('adapter');
         this.keyString = this.openmct.objects.makeKeyString(this.newStyleDomainObject.identifier);
+
+        this.setAxisDisplayRange();
 
         this.filterObserver = this.openmct.objects.observe(
             this.newStyleDomainObject,
@@ -257,7 +265,23 @@ define([
      */
     PlotController.prototype.onUserViewportChangeEnd = function () {
         var xDisplayRange = this.config.xAxis.get('displayRange');
+        var yDisplayRange = this.config.yAxis.get('displayRange');
         var xRange = this.config.xAxis.get('range');
+
+        //add viewport x and y axes to URL
+        if (xDisplayRange && !isNaN(parseInt(xDisplayRange.min, 0xA)) && !isNaN(parseInt(xDisplayRange.max, 0xA)) &&
+            yDisplayRange && !isNaN(parseFloat(yDisplayRange.min, 0xA)) && !isNaN(parseFloat(yDisplayRange.max, 0xA))) {
+            this.viewportService.setBounds({
+                x: {
+                    min: parseInt(xDisplayRange.min, 0xA),
+                    max: parseInt(xDisplayRange.max, 0xA)
+                },
+                y: {
+                    min: parseFloat(yDisplayRange.min, 0xA),
+                    max: parseFloat(yDisplayRange.max, 0xA)
+                }
+            });
+        }
 
         if (!this.skipReloadOnInteraction) {
             this.loadMoreData(xDisplayRange);
@@ -300,6 +324,31 @@ define([
     PlotController.prototype.toggleCursorGuide = function ($event) {
         this.cursorGuide = !this.cursorGuide;
         this.$scope.$broadcast('cursorguide', $event);
+    };
+
+    PlotController.prototype.setAxisDisplayRange = function () {
+        //read viewport axis values from URL
+        var searchParams = _.pick(this.$location.search(), Object.values(constants.QUERY_PARAM_NAMES));
+
+        //set X-axis viewport
+        if (!isNaN(parseInt(searchParams[constants.QUERY_PARAM_NAMES.START_VIEWPORT_X], 0xA)) &&
+            !isNaN(parseInt(searchParams[constants.QUERY_PARAM_NAMES.END_VIEWPORT_X], 0xA))) {
+            this.config.xAxis.set('autoscale', false);
+            this.config.xAxis.set('displayRange', {
+                min:parseInt(searchParams[constants.QUERY_PARAM_NAMES.START_VIEWPORT_X], 0xA),
+                max:parseInt(searchParams[constants.QUERY_PARAM_NAMES.END_VIEWPORT_X], 0xA)
+            });
+        }
+
+        //set y-axis viewport
+        if (!isNaN(parseFloat(searchParams[constants.QUERY_PARAM_NAMES.START_VIEWPORT_Y], 0xA)) &&
+            !isNaN(parseFloat(searchParams[constants.QUERY_PARAM_NAMES.END_VIEWPORT_Y], 0xA))) {
+            this.config.yAxis.set('autoscale', false);
+            this.config.yAxis.set('displayRange', {
+                min:parseFloat(searchParams[constants.QUERY_PARAM_NAMES.START_VIEWPORT_Y], 0xA),
+                max:parseFloat(searchParams[constants.QUERY_PARAM_NAMES.END_VIEWPORT_Y], 0xA)
+            });
+        }
     };
 
     return PlotController;


### PR DESCRIPTION
* show proper x/y axis ranges at the time snapshot was taken

* apply update to both snaphot loading and previewing

To test:
1. Add Sine Wave Generator and Notebook objects to workspace
2. Open Notebook and start a new entry
3. Open Sine Wave Generator
4. Zoom into sine wave plot via mouse left-click lasso
5. Take a notebook snapshot of the Sine Wave Generator and save to *notebook entry previously created*
6. Open notebook
7. Click snapshot thumbnail to make sure x and y axes match that of your snapshot 
8. Preview your snapshot to make sure x and y axes match that of your snapshot
9. Open your snapshot to make sure x and y axes match that of your snapshot
10. Now take a notebook snapshot and save to "notebook snapshots" instead
11. Open notebook snapshots via indicator menu at top
12. Click snapshot thumbnail to make sure x and y axes match that of your snapshot 
13. Preview your snapshot to make sure x and y axes match that of your snapshot
14. Open your snapshot to make sure x and y axes match that of your snapshot
15. Hooray!

Author Checklist:
    Changes address original issue? Yes
    Unit tests included and/or updated with changes? No
    Command line build passes? Yes
    Changes have been smoke-tested? Yes