### PR TITLE
Do not respond to bounds tick changes

### DIFF
--- a/src/plugins/URLTimeSettingsSynchronizer/URLTimeSettingsSynchronizer.js
+++ b/src/plugins/URLTimeSettingsSynchronizer/URLTimeSettingsSynchronizer.js
@@ -24,7 +24,7 @@ import {
     setAllSearchParams
 } from 'utils/openmctLocation';
 
-const TIME_EVENTS = ['bounds', 'timeSystem', 'clock', 'clockOffsets'];
+const TIME_EVENTS = ['timeSystem', 'clock', 'clockOffsets'];
 const SEARCH_MODE = 'tc.mode';
 const SEARCH_TIME_SYSTEM = 'tc.timeSystem';
 const SEARCH_START_BOUND = 'tc.startBound';
@@ -42,6 +42,7 @@ export default class URLTimeSettingsSynchronizer {
         this.destroy = this.destroy.bind(this);
         this.updateTimeSettings = this.updateTimeSettings.bind(this);
         this.setUrlFromTimeApi = this.setUrlFromTimeApi.bind(this);
+        this.updateBounds = this.updateBounds.bind(this);
 
         openmct.on('start', this.initialize);
         openmct.on('destroy', this.destroy);
@@ -54,7 +55,7 @@ export default class URLTimeSettingsSynchronizer {
         TIME_EVENTS.forEach(event => {
             this.openmct.time.on(event, this.setUrlFromTimeApi);
         });
-
+        this.openmct.time.on('bounds', this.updateBounds);
     }
 
     destroy() {
@@ -65,13 +66,13 @@ export default class URLTimeSettingsSynchronizer {
         TIME_EVENTS.forEach(event => {
             this.openmct.time.off(event, this.setUrlFromTimeApi);
         });
+        this.openmct.time.on('bounds', this.updateBounds);
     }
 
     updateTimeSettings() {
         // Prevent from triggering self
         if (!this.isUrlUpdateInProgress) {
             let timeParameters = this.parseParametersFromUrl();
-
 
             if (this.areTimeParametersValid(timeParameters)) {
                 this.setTimeApiFromUrl(timeParameters);
@@ -135,6 +136,12 @@ export default class URLTimeSettingsSynchronizer {
                 this.openmct.time.timeSystem().key !== timeParameters.timeSystem) {
                 this.openmct.time.timeSystem(timeParameters.timeSystem);
             }
+        }
+    }
+
+    updateBounds(bounds, isTick) {
+        if (!isTick) {
+            this.setUrlFromTimeApi();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/nasa/openmct/issues/3088 testing issues.

Adds a new check to prevent bounds changes that occur due to clock ticks from updating the URL. These regular tickets were pre-empting the URL change event from realtime to fixed time mode.

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? Y
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y