### PR TITLE
Addresses notebook snapshot that doesn't preserve display bounds (#2915)

### DIFF
--- a/src/plugins/notebook/components/notebook-embed.vue
+++ b/src/plugins/notebook/components/notebook-embed.vue
@@ -30,6 +30,7 @@ import PreviewAction from '../../../ui/preview/PreviewAction';
 import Painterro from 'painterro';
 import RemoveDialog from '../utils/removeDialog';
 import SnapshotTemplate from './snapshot-template.html';
+import ViewportService from '../../plot/src/services/ViewportService';
 import Vue from 'vue';
 
 export default {
@@ -238,6 +239,14 @@ export default {
             const self = this;
             const previewAction = new PreviewAction(self.openmct);
             previewAction.invoke(JSON.parse(self.embed.objectPath));
+
+            //set the plot viewport
+            if ('viewportBounds' in self.embed) {
+                let svc = new ViewportService(self.openmct);
+                Object.keys(self.embed.viewportBounds).forEach(function (childIndex) {
+                    svc.setBounds(childIndex, self.embed.viewportBounds[childIndex]);
+                });
+            }
         },
         removeEmbed(success) {
             if (!success) {

--- a/src/plugins/notebook/components/notebook-entry.vue
+++ b/src/plugins/notebook/components/notebook-entry.vue
@@ -194,6 +194,7 @@ export default {
             const bounds = this.openmct.time.bounds();
             const snapshotMeta = {
                 bounds,
+                viewportBounds: null,
                 link: null,
                 objectPath,
                 openmct: this.openmct

--- a/src/plugins/notebook/components/notebook-menu-switcher.vue
+++ b/src/plugins/notebook/components/notebook-menu-switcher.vue
@@ -31,6 +31,7 @@
 import Snapshot from '../snapshot';
 import { getDefaultNotebook } from '../utils/notebook-storage';
 import { NOTEBOOK_DEFAULT, NOTEBOOK_SNAPSHOT } from '../notebook-constants';
+import ViewportService from '../../plot/src/services/ViewportService';
 
 export default {
     inject: ['openmct'],
@@ -108,15 +109,20 @@ export default {
             this.$nextTick(() => {
                 const element = document.querySelector('.c-overlay__contents')
                     || document.getElementsByClassName('l-shell__main-container')[0];
-
                 const bounds = this.openmct.time.bounds();
                 const link = !this.ignoreLink
                     ? window.location.href
                     : null;
 
                 const objectPath = this.objectPath || this.openmct.router.path;
+
+                //get viewport bounds from mct-plot
+                let svc = new ViewportService(this.openmct);
+                const viewportBounds = svc.getBounds();
+
                 const snapshotMeta = {
                     bounds,
+                    viewportBounds,
                     link,
                     objectPath,
                     openmct: this.openmct

--- a/src/plugins/notebook/components/notebook.vue
+++ b/src/plugins/notebook/components/notebook.vue
@@ -273,6 +273,7 @@ export default {
             const bounds = this.openmct.time.bounds();
             const snapshotMeta = {
                 bounds,
+                viewportBounds: null,
                 link: null,
                 objectPath,
                 openmct: this.openmct

--- a/src/plugins/notebook/utils/notebook-entries.js
+++ b/src/plugins/notebook/utils/notebook-entries.js
@@ -69,6 +69,7 @@ export const getNotebookDefaultEntries = (notebookStorage, domainObject) => {
 export const createNewEmbed = (snapshotMeta, snapshot = '') => {
     const {
         bounds,
+        viewportBounds,
         link,
         objectPath,
         openmct
@@ -88,6 +89,7 @@ export const createNewEmbed = (snapshotMeta, snapshot = '') => {
 
     return {
         bounds,
+        viewportBounds,
         createdOn: date,
         cssClass,
         domainObject,

--- a/src/plugins/plot/plugin.js
+++ b/src/plugins/plot/plugin.js
@@ -36,6 +36,7 @@ define([
     "./src/inspector/PlotSeriesFormController",
     "./src/inspector/HideElementPoolDirective",
     "./src/services/ExportImageService",
+    "./src/services/ViewportService",
     './src/PlotViewPolicy',
     "./res/templates/plot-options.html",
     "./res/templates/plot-options-browse.html",
@@ -56,6 +57,7 @@ define([
     PlotSeriesFormController,
     HideElementPool,
     ExportImageService,
+    ViewportService,
     PlotViewPolicy,
     plotOptionsTemplate,
     plotOptionsBrowseTemplate,
@@ -152,10 +154,12 @@ define([
                             "depends": [
                                 "$scope",
                                 "$element",
+                                "$location",
                                 "formatService",
                                 "openmct",
                                 "objectService",
-                                "exportImageService"
+                                "exportImageService",
+                                "viewportService"
                             ]
                         },
                         {
@@ -212,6 +216,13 @@ define([
                             "implementation": ExportImageService,
                             "depends": [
                                 "dialogService"
+                            ]
+                        },
+                        {
+                            "key": "viewportService",
+                            "implementation": ViewportService,
+                            "depends": [
+                                "openmct"
                             ]
                         }
                     ],

--- a/src/plugins/plot/src/lib/constants.js
+++ b/src/plugins/plot/src/lib/constants.js
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2020, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+export const QUERY_PARAM_NAMES = {
+    VIEWPORT_X: 'viewportX',
+    VIEWPORT_Y: 'viewportY'
+};

--- a/src/plugins/plot/src/services/ViewportService.js
+++ b/src/plugins/plot/src/services/ViewportService.js
@@ -1,0 +1,83 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2018, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+define([
+    "../lib/constants",
+    "zepto"
+], function (
+    constants,
+    $
+) {
+    function ViewportService(openmct) {
+        this.openmct = openmct;
+    }
+
+    ViewportService.prototype.getBounds = function () {
+        let mainContainer = document.getElementsByClassName('l-shell__main-container')[0];
+        if (!mainContainer) {
+            return;
+        }
+
+        let returnData = {};
+        let plots = $(mainContainer).find("mct-plot");
+        for(let i=0, len=plots.length; i<len; i++) {
+            let scope = this.openmct.$angular.element(plots.get(i)).scope();
+            if (!scope || !scope.config) {
+                continue;
+            }
+
+            let id = scope.config.id ? scope.config.id : null;
+            if(!id) {
+                continue;
+            }
+
+            let model = scope.config.model ? scope.config.model : null;
+            if (!model) {
+                continue;
+            }
+
+            let xAxis = model.xAxis ? model.xAxis : null;
+            let yAxis = model.yAxis ? model.yAxis : null;
+            if (!xAxis || !yAxis || !xAxis.displayRange || !yAxis.displayRange) {
+                continue;
+            }
+
+            returnData[i] = {
+                x: xAxis.displayRange,
+                y: yAxis.displayRange
+            };
+        }
+
+        return returnData;
+    }
+
+    ViewportService.prototype.setBounds = function (childIndex, viewportBounds) {
+        let index = parseInt(childIndex);
+        if (index >= 0 && 'x' in viewportBounds && 'y' in viewportBounds) {
+            this.openmct.router.updateParams({
+                [constants.QUERY_PARAM_NAMES.VIEWPORT_X+"["+childIndex+"]"]: viewportBounds.x.min+','+viewportBounds.x.max,
+                [constants.QUERY_PARAM_NAMES.VIEWPORT_Y+"["+childIndex+"]"]: viewportBounds.y.min+','+viewportBounds.y.max
+            });
+        }
+    }
+
+    return ViewportService;
+});


### PR DESCRIPTION
* show proper x/y axis ranges at the time snapshot was taken

* apply update to both snaphot loading and previewing

* added support for stacked plots

Test single plot.....
1. Add Sine Wave Generator and Notebook objects to workspace
2. Open Notebook and start a new entry
3. Open Sine Wave Generator
4. Zoom into sine wave plot via +/- or mouse left-click lasso
5. Take a notebook snapshot of the Sine Wave Generator and (1) save to notebook entry previously created, and (2) save to notebook snapshots
6. Open notebook
7. Click snapshot **thumbnail** image to make sure x and y axes match what you took a snapshot of, including time and zoom levels
8. **Preview** your snapshot (via drop menu >> Preview) to make sure x and y axes match what you took a snapshot of, including time and zoom levels
9. **Open** your snapshot (click snapshot hyperlink) to make sure x and y axes match what you took a snapshot of, including time and zoom levels
10. Now open notebook snapshots via indicator menu at top
11. Click snapshot **thumbnail** image to make sure x and y axes match what you took a snapshot of, including time and zoom levels
12. **Preview** your snapshot (via drop menu >> Preview) to make sure x and y axes match what you took a snapshot of, including time and zoom levels
13. **Open** your snapshot (click snapshot hyperlink) to make sure x and y axes match what you took a snapshot of, including time and zoom levels

Test multi-plots.......
1. Add Sine Wave Generator, Notebook, and Stacked Plot objects to workspace
2. Open Notebook and start a new entry
3. Add two or more Sine Wave Generators to stacked plot
4. Set a random zoom level in each sine wave plot via +/- or mouse left-click lasso
5. Take a notebook snapshot of the Stacked Plot and (1) save to notebook entry previously created, and (2) save to notebook snapshots
6. Open notebook
7. Click snapshot **thumbnail** image to make sure each plot's x and y axes match what you took a snapshot of, including time and zoom levels
8. **Preview** your snapshot (via drop menu >> Preview) to make sure each plot's x and y axes match what you took a snapshot of, including time and zoom levels
9. **Open** your snapshot (click snapshot hyperlink) to make sure each plot's x and y axes match what you took a snapshot of, including time and zoom levels
10. Now open notebook snapshots via indicator menu at top
11. Click snapshot **thumbnail** image to make sure each plot's x and y axes match what you took a snapshot of, including time and zoom levels
12. **Preview** your snapshot (via drop menu >> Preview) to make sure each plot's x and y axes match what you took a snapshot of, including time and zoom levels
13. **Open** your snapshot (click snapshot hyperlink) to make sure each plot's x and y axes match what you took a snapshot of, including time and zoom levels

Author Checklist:
1. Changes address original issue? Yes
2. Unit tests included and/or updated with changes? No
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes