### PR TITLE
[Display Layout] Bug fix for object removal (#3117)

### DIFF
--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -443,7 +443,27 @@ export default {
         initializeItems() {
             this.telemetryViewMap = {};
             this.objectViewMap = {};
-            this.layoutItems.forEach(this.trackItem);
+            let compositionKeys = this.getCompositionIdentifierKeys();
+            let self = this;
+            this.layoutItems.forEach(function(item){
+                let itemKey = self.openmct.objects.makeKeyString(item.identifier);
+                if(compositionKeys.indexOf(itemKey) === -1) {
+                    //orphaned item found; remove it
+                    self.removeFromConfiguration(itemKey);
+                }else{
+                    self.trackItem(item);
+                }
+            });
+        },
+        getCompositionIdentifierKeys() {
+            let composition = _.get(this.internalDomainObject, 'composition');
+            let keys = [];
+            composition.forEach(function(item) {
+                if(item && item.key) {
+                    keys.push(item.key);
+                }
+            });
+            return keys;
         },
         addChild(child) {
             let keyString = this.openmct.objects.makeKeyString(child.identifier);

--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -445,7 +445,7 @@ export default {
             this.objectViewMap = {};
             let compositionKeys = this.getCompositionIdentifierKeys();
             let self = this;
-            this.layoutItems.forEach(function(item){
+            this.layoutItems.forEach(function (item) {
                 let itemKey = self.openmct.objects.makeKeyString(item.identifier);
                 if(compositionKeys.indexOf(itemKey) === -1) {
                     //orphaned item found; remove it
@@ -458,7 +458,7 @@ export default {
         getCompositionIdentifierKeys() {
             let composition = _.get(this.internalDomainObject, 'composition');
             let keys = [];
-            composition.forEach(function(item) {
+            composition.forEach(function (item) {
                 if(item && item.key) {
                     keys.push(item.key);
                 }

--- a/src/plugins/remove/RemoveAction.js
+++ b/src/plugins/remove/RemoveAction.js
@@ -85,6 +85,7 @@ export default class RemoveAction {
         );
 
         this.openmct.objects.mutate(parent, 'composition', composition);
+        this.openmct.objects.mutate(parent, 'configuration.items', composition);
 
         if (this.inNavigationPath(child) && this.openmct.editor.isEditing()) {
             this.openmct.editor.save();

--- a/src/plugins/remove/RemoveAction.js
+++ b/src/plugins/remove/RemoveAction.js
@@ -85,7 +85,6 @@ export default class RemoveAction {
         );
 
         this.openmct.objects.mutate(parent, 'composition', composition);
-        this.openmct.objects.mutate(parent, 'configuration.items', composition);
 
         if (this.inNavigationPath(child) && this.openmct.editor.isEditing()) {
             this.openmct.editor.save();


### PR DESCRIPTION
* remove display layout objects that weren't being removed

To test:
    1. Add a display layout to "My Items" folder
    2. In Display Layout main window, click "Save and Finish Editing"
    3. Add a "State Generator" object to the Display Layout in the object tree
    4. Select the Dispay Layout in the object tree so it's active in the main window
    5. Note that you can see the State Generator in the display layout in the upper left corner of the main window
    6. Select the State Generator in the object tree so it's active in the main window
    7. Right-click the State Generator and select Remove from the drop-down menu
    8. Ensure that the State Generator is removed from the object tree
    9. Select the Display Layout in the object tree so it's active in the main window
    10. Ensure that the State Generator is removed from the display layout in the main window

Author Checklist:
    1. Changes address original issue? Yes
    2. Unit tests included and/or updated with changes? No
    3. Command line build passes? Yes
    4. Changes have been smoke-tested? Yes
