### PR TITLE
[Flexible Layouts] Prevent duplicate object from being added when frame delete is canceled

### DIFF
--- a/src/plugins/flexibleLayout/components/flexibleLayout.vue
+++ b/src/plugins/flexibleLayout/components/flexibleLayout.vue
@@ -231,11 +231,33 @@ export default {
         setFrameLocation(containerIndex, insertFrameIndex) {
             this.newFrameLocation = [containerIndex, insertFrameIndex];
         },
+        isFrameAlreadyTracked(frame) {
+            let found = false,
+                keyString = this.openmct.objects.makeKeyString(frame.domainObjectIdentifier);
+
+            this.containers.forEach(container => {
+                container.frames.forEach(item => {
+                    if (item.domainObjectIdentifier) {
+                        let itemKeyString = this.openmct.objects.makeKeyString(item.domainObjectIdentifier);
+                        if (itemKeyString === keyString) {
+                            found = true;
+                            return;
+                        }
+                    }
+                });
+            });
+
+            return found;
+        },
         addFrame(domainObject) {
+            let frame = new Frame(domainObject.identifier);
+            if (this.isFrameAlreadyTracked(frame)) {
+                return;
+            }
+
             let containerIndex = this.newFrameLocation.length ? this.newFrameLocation[0] : 0;
             let container = this.containers[containerIndex];
             let frameIndex = this.newFrameLocation.length ? this.newFrameLocation[1] : container.frames.length;
-            let frame = new Frame(domainObject.identifier);
 
             container.frames.splice(frameIndex + 1, 0, frame);
             sizeItems(container.frames, frame);


### PR DESCRIPTION
Author Checklist:
1. Changes address original issue? Yes
2. Unit tests included and/or updated with changes? No
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes
5. Testing instructions included? Yes

To test:
    1. Add a Flexible Layout to object tree
    2. Add object to Flexible Layout and save
    3. Go into Flexible Layout edit mode
    4. Delete object frame, click OK to confirm, then cancel deletion by clicking the "X"
    5. The deleted object should reappear in the frame without a duplicate
