### PR TITLE
[Flexible Layout] bug fix for object removal (#3119)

### DIFF
--- a/src/plugins/flexibleLayout/components/flexibleLayout.vue
+++ b/src/plugins/flexibleLayout/components/flexibleLayout.vue
@@ -167,6 +167,7 @@ export default {
         }
     },
     mounted() {
+        this.removeOrphanedFrames();
         this.composition = this.openmct.composition.get(this.domainObject);
         this.composition.on('remove', this.removeChildObject);
         this.composition.on('add', this.addFrame);
@@ -346,6 +347,27 @@ export default {
             });
 
             this.persist();
+        },
+        removeOrphanedFrames() {
+            let compositionKeys = this.getCompositionIdentifierKeys();
+            let self = this;
+            this.containers.forEach(function (container) {
+                container.frames.forEach(function (frame) {
+                    let frameKey = self.openmct.objects.makeKeyString(frame.domainObjectIdentifier);
+                    if(compositionKeys.indexOf(frameKey) === -1) {
+                        self.removeChildObject(frame.domainObjectIdentifier);
+                    }
+                });
+            });
+        },
+        getCompositionIdentifierKeys() {
+            let keys = [];
+            this.domainObject.composition.forEach(function (item) {
+                if(item && item.key) {
+                    keys.push(item.key);
+                }
+            });
+            return keys;
         }
     }
 }


### PR DESCRIPTION
* checked for orphaned objects and remove

Author Checklist:
1. Changes address original issue? Yes
2. Unit tests included and/or updated with changes? No
3. Command line build passes? Yes
4. Changes have been smoke-tested? Yes
5. Testing instructions included? Yes

To test:
1. Add an item to flexible layout, then "Save and Finish Editing"
2. Select the child item in the object tree so that it's active in the main window
3. Right-click and remove the child object from the object tree.
4. Ensure the object is removed from the flexible layout.
