### PR TITLE
Fix Safari display issues for #3192

### DIFF
--- a/src/plugins/notebook/components/notebook-snapshot-container.vue
+++ b/src/plugins/notebook/components/notebook-snapshot-container.vue
@@ -2,13 +2,16 @@
 <div class="c-snapshots-h">
     <div class="l-browse-bar">
         <div class="l-browse-bar__start">
-            <div class="l-browse-bar__object-name--w icon-notebook">
-                <div class="l-browse-bar__object-name">
-                    Notebook Snapshots
-                    <span v-if="snapshots.length"
-                          class="l-browse-bar__object-details"
-                    >&nbsp;{{ snapshots.length }} of {{ getNotebookSnapshotMaxCount() }}
-                    </span>
+            <div class="l-browse-bar__object-name--w">
+                <div class="l-browse-bar__object-name c-object-label">
+                    <div class="c-object-label__type-icon icon-notebook"></div>
+                    <div class="c-object-label__name">
+                        Notebook Snapshots
+                        <span v-if="snapshots.length"
+                              class="l-browse-bar__object-details"
+                        >&nbsp;{{ snapshots.length }} of {{ getNotebookSnapshotMaxCount() }}
+                        </span>
+                    </div>
                 </div>
                 <PopupMenu v-if="snapshots.length > 0"
                            :popup-menu-items="popupMenuItems"

--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -411,7 +411,17 @@ select {
 
 .c-tab {
     // Used in Tab View, generic tabs
-    background: $colorBtnBg;
+    $notchSize: 7px;
+    $clipPath:
+        polygon(
+            0% 0%,
+            calc(100% - #{$notchSize}) 0%,
+            100% #{$notchSize},
+            100% calc(100% - #{$notchSize}),
+            100% 100%,
+            0% 100%
+        );
+    background: rgba($colorBtnBg, 0.7);
     color: $colorBtnFg;
     cursor: pointer;
     display: flex;
@@ -420,16 +430,8 @@ select {
     margin: 1px 1px 0 0;
     padding: $interiorMargin $interiorMarginLg;
     white-space: nowrap;
-    --notchSize: 7px;
-    clip-path:
-        polygon(
-            0% 0%,
-            calc(100% - var(--notchSize)) 0%,
-            100% var(--notchSize),
-            100% calc(100% - var(--notchSize)),
-            100% 100%,
-            0% 100%
-        );
+    clip-path: $clipPath;
+    -webkit-clip-path: $clipPath; // Safari
 
     > * + * {
         margin-left: $interiorMargin;

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -118,9 +118,7 @@ mct-plot {
 
 .gl-plot {
     display: flex;
-    position: relative;
-    width: 100%;
-    height: 100%;
+    flex: 1 1 auto;
 
     /*********************** AXIS AND DISPLAY AREA */
     .plot-wrapper-axis-and-display-area {

--- a/src/ui/components/object-frame.scss
+++ b/src/ui/components/object-frame.scss
@@ -74,11 +74,9 @@
         height: 0; // Chrome 73 overflow bug fix
         overflow: auto;
 
-        .u-angular-object-view-wrapper {
-            .u-fills-container {
-                // Expand component types that fill a container
-                @include abs();
-            }
+        .u-fills-container {
+            // Expand component types that fill a container
+            @include abs();
         }
     }
 
@@ -91,8 +89,5 @@
 }
 
 .u-angular-object-view-wrapper {
-    flex: 1 1 auto;
-    height: 100%;
-    width: 100%;
-    overflow: hidden;
+    display: contents;
 }

--- a/src/ui/components/object-label.scss
+++ b/src/ui/components/object-label.scss
@@ -3,7 +3,7 @@
     // Used mostly in trees and lists
     display: flex;
     align-items: center;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     overflow: hidden;
     white-space: nowrap;
 
@@ -19,7 +19,6 @@
         display: block;
         flex: 0 0 auto;
         font-size: 1.1em;
-        //margin-right: $interiorMargin;
     }
 
     &.is-missing {

--- a/src/ui/inspector/inspector.scss
+++ b/src/ui/inspector/inspector.scss
@@ -4,7 +4,7 @@
     flex-direction: column;
 
     > * {
-        // Thi is on purpose: want extra margin on top object-name element
+        // This is on purpose: want extra margin on top object-name element
         margin-top: $interiorMargin;
     }
 
@@ -41,6 +41,8 @@
 
     &__content {
         flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
     }
 
     &__elements {

--- a/src/ui/layout/status-bar/indicators.scss
+++ b/src/ui/layout/status-bar/indicators.scss
@@ -76,8 +76,12 @@
 [class*='minify-indicators'] {
     // All styles for minified Indicators should go in here
     .c-indicator:not(.no-minify) {
+        overflow: hidden; // Solves width problem in Safari as well as collapsing bubbles problem
+
         @include hover() {
             background: $colorIndicatorBgHov;
+            overflow: visible;
+
             .c-indicator__label {
                 box-shadow: $colorIndicatorMenuBgShdw;
                 transform: scale(1.0);

--- a/src/ui/layout/status-bar/indicators.scss
+++ b/src/ui/layout/status-bar/indicators.scss
@@ -78,21 +78,21 @@
     .c-indicator:not(.no-minify) {
         border: 1px solid transparent; // Hack to make minified sizing work in Safari. Have no idea why this works.
         overflow: visible;
-        transition: all;
+        transition: transform;
 
         @include hover() {
             background: $colorIndicatorBgHov;
-            transition: all 250ms ease-in 200ms;
+            transition: transform 250ms ease-in 200ms; // Go-away transition
 
             .c-indicator__label {
                 box-shadow: $colorIndicatorMenuBgShdw;
                 transform: scale(1.0);
                 overflow: visible;
-                //transition: all 100ms ease-out 100ms;
+                transition: transform 100ms ease-out 100ms; // Appear transition
             }
         }
         .c-indicator__label {
-            transition: all 250ms ease-in 200ms;
+            transition: transform 250ms ease-in 200ms; // Go-away transition
             background: $colorIndicatorMenuBg;
             color: $colorIndicatorMenuFg;
             border-radius: $controlCr;

--- a/src/ui/layout/status-bar/indicators.scss
+++ b/src/ui/layout/status-bar/indicators.scss
@@ -76,16 +76,19 @@
 [class*='minify-indicators'] {
     // All styles for minified Indicators should go in here
     .c-indicator:not(.no-minify) {
-        overflow: hidden; // Solves width problem in Safari as well as collapsing bubbles problem
+        border: 1px solid transparent; // Hack to make minified sizing work in Safari. Have no idea why this works.
+        overflow: visible;
+        transition: all;
 
         @include hover() {
             background: $colorIndicatorBgHov;
-            overflow: visible;
+            transition: all 250ms ease-in 200ms;
 
             .c-indicator__label {
                 box-shadow: $colorIndicatorMenuBgShdw;
                 transform: scale(1.0);
-                transition: all 100ms ease-out 100ms;
+                overflow: visible;
+                //transition: all 100ms ease-out 100ms;
             }
         }
         .c-indicator__label {
@@ -99,7 +102,7 @@
             position: absolute;
             transform-origin: 90% 0;
             transform: scale(0.0);
-            overflow: visible;
+            overflow: hidden;
             z-index: 50;
 
             &:before {


### PR DESCRIPTION
### Changes
- Fix Inspector `__content` to properly use flex column layout;
- Change `u-angular-object-view-wrapper` to `display: contents`;
- Fix `gl-plot` to properly use `flex: 1 1 auto` instead of width and height;
- Fix collapsed Status area indicators width problem;

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y

See #3192 for testing notes.
