### PR TITLE
Make Clear Data Indicator an optional install

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,10 @@
         openmct.install(openmct.plugins.LADTable());
         openmct.install(openmct.plugins.Filters(['table', 'telemetry.plot.overlay']));
         openmct.install(openmct.plugins.ObjectMigration());
-        openmct.install(openmct.plugins.ClearData(['table', 'telemetry.plot.overlay', 'telemetry.plot.stacked']));
+        openmct.install(openmct.plugins.ClearData(
+            ['table', 'telemetry.plot.overlay', 'telemetry.plot.stacked'],
+            {indicator: true}
+        ));
         openmct.start();
     </script>
 </html>

--- a/src/plugins/clearData/plugin.js
+++ b/src/plugins/clearData/plugin.js
@@ -29,24 +29,28 @@ define([
     ClearDataAction,
     Vue
 ) {
-    return function plugin(appliesToObjects) {
+    return function plugin(appliesToObjects, options = {indicator: true}) {
+        let installIndicator = options.indicator;
+
         appliesToObjects = appliesToObjects || [];
 
         return function install(openmct) {
-            let component = new Vue ({
-                    provide: {
-                        openmct
-                    },
-                    components: {
-                        GlobalClearIndicator: GlobaClearIndicator.default
-                    },
-                    template: '<GlobalClearIndicator></GlobalClearIndicator>'
-                }),
-                indicator = {
-                    element: component.$mount().$el
-                };
+            if (installIndicator) {
+                let component = new Vue ({
+                        provide: {
+                            openmct
+                        },
+                        components: {
+                            GlobalClearIndicator: GlobaClearIndicator.default
+                        },
+                        template: '<GlobalClearIndicator></GlobalClearIndicator>'
+                    }),
+                    indicator = {
+                        element: component.$mount().$el
+                    };
 
-            openmct.indicators.add(indicator);
+                openmct.indicators.add(indicator);
+            }
 
             openmct.contextMenu.registerAction(new ClearDataAction.default(openmct, appliesToObjects));
         };


### PR DESCRIPTION
## Overview
Addresses #3212

We need to make the indicator an option install to allow VISTA to create its own Clear Data Indicator that will include a global staleness message.

## Author Checklist
Changes address original issue? No Issue filed
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? N/A