### PR TITLE
Disallow editor Edit mode when object is locked

### DIFF
--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -53,7 +53,9 @@ export default {
     mounted() {
         this.currentObject = this.object;
         this.updateView();
-        this.$el.addEventListener('dragover', this.onDragOver);
+        this.$el.addEventListener('dragover', this.onDragOver, {
+            capture: true
+        });
         this.$el.addEventListener('drop', this.editIfEditable, {
             capture: true
         });
@@ -234,7 +236,6 @@ export default {
             }
         },
         onDragOver(event) {
-            console.log('onDragOver');
             if (this.hasComposableDomainObject(event)) {
                 if (this.isEditingAllowed()) {
                     event.preventDefault();

--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -269,6 +269,7 @@ export default {
             if (provider &&
                 provider.canEdit &&
                 provider.canEdit(this.currentObject) &&
+                this.isEditingAllowed() &&
                 !this.openmct.editor.isEditing()) {
                 this.openmct.editor.edit();
             }

--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -234,6 +234,7 @@ export default {
             }
         },
         onDragOver(event) {
+            console.log('onDragOver');
             if (this.hasComposableDomainObject(event)) {
                 if (this.isEditingAllowed()) {
                     event.preventDefault();


### PR DESCRIPTION
When checking if an object can be in edit mode also check if it's locked
Also, use capture phase for onDragOver so that we can check for locked state before any children can handle that event.

Resolves #3204 
Resolves NIRVSSOMCT-179

**Author Checklist**

- Changes address original issue? Yes
- Unit tests included and/or updated with changes? No
- Command line build passes? Yes
- Changes have been smoke-tested? Yes
- Testing instructions included? Yes
