### PR TITLE
[VIPEROMCT-16] Handle delayed telemetry requests correctly for conditions

### DIFF
--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -127,7 +127,7 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
 
         if (validatedData) {
             if (this.isStalenessCheck()) {
-                if (this.stalenessSubscription[validatedData.id]) {
+                if (this.stalenessSubscription && this.stalenessSubscription[validatedData.id]) {
                     this.stalenessSubscription[validatedData.id].update(validatedData);
                 }
                 this.telemetryDataCache[validatedData.id] = false;

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -142,12 +142,14 @@ export default class TelemetryCriterion extends EventEmitter {
             };
         }
 
+        let telemetryObject = this.telemetryObject;
+
         return this.openmct.telemetry.request(
             this.telemetryObject,
             options
         ).then(results => {
             const latestDatum = results.length ? results[results.length - 1] : {};
-            const normalizedDatum = this.createNormalizedDatum(latestDatum, this.telemetryObject);
+            const normalizedDatum = this.createNormalizedDatum(latestDatum, telemetryObject);
 
             return {
                 id: this.id,


### PR DESCRIPTION
Creates a closure for telemetryObject so that requests can resolve correctly even if the telemetryObject is destroyed

 Resolves VIPEROMCT-16

**Author Checklist**

- Changes address original issue? Yes
- Unit tests included and/or updated with changes? Yes
- Command line build passes? Yes
- Changes have been smoke-tested? Yes
- Testing instructions included? Yes