### PR TITLE
Removing use of ChromeHeadless and using FirefoxHeadless for Circle CI builds

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,7 +23,7 @@
 /*global module,process*/
 
 const devMode = process.env.NODE_ENV !== 'production';
-const browsers = [process.env.NODE_ENV === 'debug' ? 'ChromeDebugging' : 'ChromeHeadless'];
+const browsers = [process.env.NODE_ENV === 'debug' ? 'ChromeDebugging' : 'FirefoxHeadless'];
 const coverageEnabled = process.env.COVERAGE === 'true';
 const reporters = ['progress', 'html'];
 
@@ -95,6 +95,7 @@ module.exports = (config) => {
             stats: 'errors-only',
             logLevel: 'warn'
         },
-        singleRun: true
+        singleRun: true,
+        browserNoActivityTimeout: 90000
     });
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsdoc": "^3.3.2",
     "karma": "^2.0.3",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.3.0",
     "karma-cli": "^1.0.1",
     "karma-coverage": "^1.1.2",
     "karma-coverage-istanbul-reporter": "^2.1.1",


### PR DESCRIPTION
Resolves #3214

### Changes

- Removes use of ChromeHeadless for test coverage runs
- Using FirefoxHeadless instead for test coverage runs 
- Added npm dependency for karma-firefox-launcher
- Increased browserNoActivityTimeout to 90000 in karma config

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A This is a build fix.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y

