### PR TITLE
UI enhancements

### DIFF
--- a/platform/commonUI/dialog/res/templates/dialog.html
+++ b/platform/commonUI/dialog/res/templates/dialog.html
@@ -31,13 +31,13 @@
     </mct-form>
 </div>
 <div class="c-overlay__button-bar">
-    <a class='c-button c-button--major'
+    <button class='c-button c-button--major'
        ng-class="{ disabled: !createForm.$valid }"
        ng-click="ngModel.confirm()">
         OK
-    </a>
-    <a class='c-button  '
+    </button>
+    <button class='c-button  '
        ng-click="ngModel.cancel()">
         Cancel
-    </a>
+    </button>
 </div>

--- a/platform/commonUI/dialog/res/templates/overlay-options.html
+++ b/platform/commonUI/dialog/res/templates/overlay-options.html
@@ -31,13 +31,13 @@
         </mct-include>
     </div>
     <div class="c-overlay__button-bar">
-        <a ng-repeat="option in ngModel.dialog.options"
+        <button ng-repeat="option in ngModel.dialog.options"
            href=''
            class="s-button lg"
            title="{{option.description}}"
            ng-click="ngModel.confirm(option.key)"
            ng-class="{ major: $first, subtle: !$first }">
             {{option.name}}
-        </a>
+        </button>
     </div>
 </mct-container>

--- a/platform/search/res/templates/search.html
+++ b/platform/search/res/templates/search.html
@@ -29,9 +29,9 @@
                        type="text" tabindex="10000"
                        ng-model="ngModel.input"
                        ng-keyup="controller.search()"/>
-                <a class="c-search__clear-input clear-icon icon-x-in-circle"
+                <button class="c-search__clear-input clear-icon icon-x-in-circle"
                    ng-class="{show: !(ngModel.input === '' || ngModel.input === undefined)}"
-                   ng-click="ngModel.input = ''; controller.search()"></a>
+                   ng-click="ngModel.input = ''; controller.search()"></button>
                 <!-- To prevent double triggering of clicks on click away, render
                    non-clickable version of the button when menu active-->
                 <a ng-if="!toggle.isActive()" class="menu-icon context-available"
@@ -45,16 +45,16 @@
                 </mct-include>
             </div>
 
-            <a class="c-button c-search__btn-cancel"
+            <button class="c-button c-search__btn-cancel"
                ng-show="!(ngModel.input === '' || ngModel.input === undefined)"
                ng-click="ngModel.input = ''; ngModel.checkAll = true; menuController.checkAll(); controller.search()">
-                Cancel</a>
+                Cancel</button>
         </div>
 
         <div class="active-filter-display flex-elem holder"
              ng-class="{invisible: ngModel.filtersString === '' || ngModel.filtersString === undefined || !ngModel.search}">
-            <a class="clear-filters icon-x-in-circle s-icon-button"
-               ng-click="ngModel.checkAll = true; menuController.checkAll()"></a>Filtered by: {{ ngModel.filtersString }}
+            <button class="clear-filters icon-x-in-circle s-icon-button"
+               ng-click="ngModel.checkAll = true; menuController.checkAll()"></button>Filtered by: {{ ngModel.filtersString }}
         </div>
 
         <div class="flex-elem holder results-msg" ng-model="ngModel" ng-show="!loading && ngModel.search">
@@ -72,7 +72,7 @@
                                 ng-model="ngModel"
                                 class="l-flex-row flex-elem grows">
             </mct-representation>
-            <a class="load-more-button s-button vsm" ng-if="controller.areMore()" ng-click="controller.loadMore()">More Results</a>
+            <button class="load-more-button s-button vsm" ng-if="controller.areMore()" ng-click="controller.loadMore()">More Results</button>
         </div>
     </div>
 </div>

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -128,6 +128,11 @@ body.desktop {
                 @include overlaySizing($overlayOuterMarginFullscreen);
                 padding: $interiorMargin $lrPad;
             }
+
+            &__close-button {
+                top: 7px;
+                right: $interiorMarginSm;
+            }
         }
 
         .l-browse-bar {

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -36,6 +36,7 @@
         font-size: 1.25em;
         position: absolute;
         top: $p; right: $p;
+        z-index: 99;
     }
 
     &__contents {
@@ -43,7 +44,7 @@
         display: flex;
         flex-direction: column;
         outline: none;
-        overflow: hidden;
+        overflow: auto;
     }
 
     &__top-bar {
@@ -100,7 +101,6 @@ body.desktop {
     }
 
     // Overlay types, styling for desktop. Appended to .l-overlay-wrapper element.
-    .l-overlay-large,
     .l-overlay-small,
     .l-overlay-fit {
         .c-overlay__outer {
@@ -118,8 +118,20 @@ body.desktop {
 
     .l-overlay-large {
         // Default
-        .c-overlay__outer {
-            @include overlaySizing($overlayOuterMarginLg);
+        $lrPad: $interiorMarginLg;
+        .c-overlay {
+            &__blocker {
+                display: none;
+            }
+
+            &__outer {
+                @include overlaySizing($overlayOuterMarginFullscreen);
+                padding: $interiorMargin $lrPad;
+            }
+        }
+
+        .l-browse-bar {
+            margin-right: $lrPad + 10px; // Don't cover close button
         }
     }
 

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -88,6 +88,10 @@
     .c-click-icon {
         filter: $overlayBrightnessAdjust;
     }
+
+    .c-object-label__name {
+        filter: $objectLabelNameFilter;
+    }
 }
 
 body.desktop {
@@ -118,7 +122,9 @@ body.desktop {
 
     .l-overlay-large {
         // Default
-        $lrPad: $interiorMarginLg;
+        $pad: $interiorMarginLg;
+        $tbPad: floor($pad * 0.8);
+        $lrPad: $pad;
         .c-overlay {
             &__blocker {
                 display: none;
@@ -126,17 +132,18 @@ body.desktop {
 
             &__outer {
                 @include overlaySizing($overlayOuterMarginFullscreen);
-                padding: $interiorMargin $lrPad;
+                padding: $tbPad $lrPad;
             }
 
             &__close-button {
-                top: 7px;
+                top: $pad;
                 right: $interiorMarginSm;
             }
         }
 
         .l-browse-bar {
-            margin-right: $lrPad + 10px; // Don't cover close button
+            margin-right: $lrPad + $pad; // Don't cover close button
+            margin-bottom: $interiorMargin;
         }
     }
 

--- a/src/plugins/displayLayout/components/LayoutFrame.vue
+++ b/src/plugins/displayLayout/components/LayoutFrame.vue
@@ -25,7 +25,8 @@
     class="l-layout__frame c-frame"
     :class="{
         'no-frame': !item.hasFrame,
-        'u-inspectable': inspectable
+        'u-inspectable': inspectable,
+        'is-in-small-container': size.width < 600 || size.height < 600
     }"
     :style="style"
 >
@@ -61,6 +62,13 @@ export default {
         }
     },
     computed: {
+        size() {
+            let {x, y, width, height} = this.item;
+            return {
+                width: (this.gridSize[0] * width),
+                height: (this.gridSize[1] * height)
+            };
+        },
         style() {
             let {x, y, width, height} = this.item;
             return {

--- a/src/plugins/displayLayout/components/LayoutFrame.vue
+++ b/src/plugins/displayLayout/components/LayoutFrame.vue
@@ -63,7 +63,7 @@ export default {
     },
     computed: {
         size() {
-            let {x, y, width, height} = this.item;
+            let {width, height} = this.item;
             return {
                 width: (this.gridSize[0] * width),
                 height: (this.gridSize[1] * height)

--- a/src/plugins/displayLayout/components/LineView.vue
+++ b/src/plugins/displayLayout/components/LineView.vue
@@ -22,7 +22,7 @@
 
 <template>
 <div
-    class="l-layout__frame c-frame no-frame"
+    class="l-layout__frame c-frame no-frame c-line-view"
     :class="[styleClass]"
     :style="style"
 >
@@ -31,9 +31,15 @@
         height="100%"
     >
         <line
+            class="c-line-view__hover-indicator"
+            v-bind="linePosition"
+            vector-effect="non-scaling-stroke"
+        />
+        <line
+            class="c-line-view__line"
             v-bind="linePosition"
             :stroke="stroke"
-            stroke-width="2"
+            vector-effect="non-scaling-stroke"
         />
     </svg>
 
@@ -49,7 +55,11 @@
             class="c-frame-edit__handle"
             :class="startHandleClass"
             @mousedown="startDrag($event, 'start')"
-        ></div>
+        >
+            <span class="c-handle-info">
+                {{ dragPosition }}
+            </span>
+        </div>
         <div
             class="c-frame-edit__handle"
             :class="endHandleClass"
@@ -68,14 +78,18 @@ const START_HANDLE_QUADRANTS = {
     1: 'c-frame-edit__handle--sw',
     2: 'c-frame-edit__handle--se',
     3: 'c-frame-edit__handle--ne',
-    4: 'c-frame-edit__handle--nw'
+    4: 'c-frame-edit__handle--nw',
+    5: 'c-frame-edit__handle--ne',
+    6: 'c-frame-edit__handle--se'
 };
 
 const END_HANDLE_QUADRANTS = {
     1: 'c-frame-edit__handle--ne',
     2: 'c-frame-edit__handle--nw',
     3: 'c-frame-edit__handle--sw',
-    4: 'c-frame-edit__handle--se'
+    4: 'c-frame-edit__handle--se',
+    5: 'c-frame-edit__handle--sw',
+    6: 'c-frame-edit__handle--nw'
 };
 
 export default {
@@ -158,6 +172,12 @@ export default {
         },
         vectorQuadrant() {
             let {x, y, x2, y2} = this.position;
+            if (x2 === x) {
+                return 5; // Vertical line
+            }
+            if (y2 === y) {
+                return 6; // Horizontal line
+            }
             if (x2 > x) {
                 if (y2 < y) {
                     return 1;
@@ -170,21 +190,27 @@ export default {
             return 3;
         },
         linePosition() {
-            return this.vectorQuadrant % 2 !== 0
-                // odd vectorQuadrant slopes up
-                ? {
-                    x1: '0%',
-                    y1: '100%',
-                    x2: '100%',
-                    y2: '0%'
-                }
-                // even vectorQuadrant slopes down
-                : {
-                    x1: '0%',
-                    y1: '0%',
-                    x2: '100%',
-                    y2: '100%'
-                };
+            let pos = {};
+            switch(this.vectorQuadrant) {
+            case 1:
+            case 3:
+                // slopes up
+                pos = {x1: '0%', y1: '100%', x2: '100%', y2: '0%'};
+                break;
+            case 5:
+                // vertical
+                pos = {x1: '0%', y1: '0%', x2: '0%', y2: '100%'};
+                break;
+            case 6:
+                // horizontal
+                pos = {x1: '0%', y1: '0%', x2: '100%', y2: '0%'};
+                break;
+            default:
+                // slopes down
+                pos = {x1: '0%', y1: '0%', x2: '100%', y2: '100%'};
+                break;
+            }
+            return pos;
         }
     },
     watch: {

--- a/src/plugins/displayLayout/components/LineView.vue
+++ b/src/plugins/displayLayout/components/LineView.vue
@@ -289,7 +289,7 @@ export default {
         },
         calculateDragPosition(pxDeltaX, pxDeltaY) {
             let gridDeltaX = Math.round(pxDeltaX / this.gridSize[0]);
-            let gridDeltaY = Math.round(pxDeltaY / this.gridSize[0]); // TODO: should this be gridSize[1]?
+            let gridDeltaY = Math.round(pxDeltaY / this.gridSize[1]);
             let {x, y, x2, y2} = this.item;
             let dragPosition = {x, y, x2, y2};
 

--- a/src/plugins/displayLayout/components/LineView.vue
+++ b/src/plugins/displayLayout/components/LineView.vue
@@ -56,9 +56,6 @@
             :class="startHandleClass"
             @mousedown="startDrag($event, 'start')"
         >
-            <span class="c-handle-info">
-                {{ dragPosition }}
-            </span>
         </div>
         <div
             class="c-frame-edit__handle"
@@ -235,8 +232,7 @@ export default {
             layoutItem: this.item,
             index: this.index
         };
-        this.removeSelectable = this.openmct.selection.selectable(
-            this.$el, this.context, this.initSelect);
+        this.removeSelectable = this.openmct.selection.selectable(this.$el, this.context, this.initSelect);
     },
     destroyed() {
         if (this.removeSelectable) {

--- a/src/plugins/displayLayout/components/LineView.vue
+++ b/src/plugins/displayLayout/components/LineView.vue
@@ -250,12 +250,17 @@ export default {
             document.body.addEventListener('mousemove', this.continueDrag);
             document.body.addEventListener('mouseup', this.endDrag);
             this.startPosition = [event.pageX, event.pageY];
-            this.dragPosition = {
-                x: this.item.x,
-                y: this.item.y,
-                x2: this.item.x2,
-                y2: this.item.y2
-            };
+            let {x, y, x2, y2} = this.item;
+            this.dragPosition = {x, y, x2, y2};
+            if (x === x2 || y === y2) {
+                if (y > y2 || x < x2) {
+                    if (this.dragging === 'start') {
+                        this.dragging = 'end';
+                    } else if (this.dragging === 'end') {
+                        this.dragging = 'start';
+                    }
+                }
+            }
             event.preventDefault();
         },
         continueDrag(event) {

--- a/src/plugins/displayLayout/components/box-and-line-views.scss
+++ b/src/plugins/displayLayout/components/box-and-line-views.scss
@@ -1,0 +1,55 @@
+.c-box-view {
+    border-width: $drawingObjBorderW !important;
+    display: flex;
+    align-items: stretch;
+
+    .c-frame & {
+        @include abs();
+    }
+}
+
+.c-line-view {
+    &.c-frame {
+        border: none !important;
+        box-shadow: none !important;
+    }
+
+    .c-frame-edit {
+        border: none;
+    }
+
+    .c-handle-info {
+        background: rgba(#999, 0.2);
+        padding: 2px;
+        position: absolute;
+        top: 5px; left: 5px;
+        white-space: nowrap;
+    }
+
+    svg {
+        // Prevent clipping when line is horizontal and vertical
+        min-height: 1px;
+        min-width: 1px;
+        // Must use !important to counteract setting in normalize.min.css
+        overflow: visible;
+    }
+
+    &__line {
+        stroke-linecap: round;
+        stroke-width: $drawingObjBorderW;
+    }
+
+    &__hover-indicator {
+        display: none;
+        stroke: $editFrameColorHov;
+        stroke-width: $drawingObjBorderW + 4;
+    }
+
+    .is-editing & {
+        &:hover {
+            [class*='__hover-indicator'] {
+                display: inline;
+            }
+        }
+    }
+}

--- a/src/plugins/displayLayout/components/box-and-line-views.scss
+++ b/src/plugins/displayLayout/components/box-and-line-views.scss
@@ -10,7 +10,6 @@
 
 .c-line-view {
     &.c-frame {
-        border: none !important;
         box-shadow: none !important;
     }
 
@@ -41,6 +40,7 @@
 
     &__hover-indicator {
         display: none;
+        opacity: 0.5;
         stroke: $editFrameColorHov;
         stroke-width: $drawingObjBorderW + 4;
     }

--- a/src/plugins/displayLayout/components/box-view.scss
+++ b/src/plugins/displayLayout/components/box-view.scss
@@ -1,8 +1,0 @@
-.c-box-view {
-    display: flex;
-    align-items: stretch;
-
-    .c-frame & {
-        @include abs();
-    }
-}

--- a/src/plugins/displayLayout/components/layout-frame.scss
+++ b/src/plugins/displayLayout/components/layout-frame.scss
@@ -7,6 +7,15 @@
     > *:first-child {
         flex: 1 1 auto;
     }
+
+    &.is-in-small-container {
+        background: rgba(blue, 0.1);
+
+        //.c-control-bar,
+        //.c-telemetry-table__headers__filter {
+        //    display: none;
+        //}
+    }
 }
 
 .c-frame-edit__move {

--- a/src/plugins/displayLayout/components/layout-frame.scss
+++ b/src/plugins/displayLayout/components/layout-frame.scss
@@ -9,12 +9,7 @@
     }
 
     &.is-in-small-container {
-        background: rgba(blue, 0.1);
-
-        //.c-control-bar,
-        //.c-telemetry-table__headers__filter {
-        //    display: none;
-        //}
+        //background: rgba(blue, 0.1);
     }
 }
 

--- a/src/plugins/displayLayout/components/layout-frame.scss
+++ b/src/plugins/displayLayout/components/layout-frame.scss
@@ -65,7 +65,7 @@
     .l-layout {
         /******************* 0 - 1 ITEM SELECTED */
         &:not(.is-multi-selected) {
-            > .l-layout__frame[s-selected] {
+            > .l-layout__frame {
                 > .c-so-view.has-complex-content {
                     > .c-so-view__local-controls {
                         transition: transform $transOutTime ease-in-out;
@@ -93,7 +93,7 @@
                             $lrOffset: 25%;
                             @include grippy($editFrameMovebarColorFg);
                             content: '';
-                            display: block;
+                            display: none;
                             position: absolute;
                             top: $tbOffset;
                             right: $lrOffset;
@@ -120,6 +120,13 @@
                             transition-delay: 0s;
                             height: $editFrameMovebarH;
                         }
+                    }
+                }
+            }
+            > .l-layout__frame[s-selected] {
+                > .c-so-view.has-complex-content {
+                    + .c-frame-edit__move:before {
+                        display: block;
                     }
                 }
             }

--- a/src/plugins/imagery/components/ImageryViewLayout.vue
+++ b/src/plugins/imagery/components/ImageryViewLayout.vue
@@ -31,11 +31,11 @@
         <div class="c-imagery__control-bar">
             <div class="c-imagery__timestamp">{{ getTime() }}</div>
             <div class="h-local-controls flex-elem">
-                <a
+                <button
                     class="c-button icon-pause pause-play"
                     :class="{'is-paused': paused()}"
                     @click="paused(!paused())"
-                ></a>
+                ></button>
             </div>
         </div>
     </div>

--- a/src/plugins/imagery/components/imagery-view-layout.scss
+++ b/src/plugins/imagery/components/imagery-view-layout.scss
@@ -42,6 +42,7 @@
         height: 135px;
         overflow-x: auto;
         overflow-y: hidden;
+        padding-bottom: $interiorMarginSm;
 
         &.is-paused {
             background: rgba($colorPausedBg, 0.4);

--- a/src/plugins/imagery/components/imagery-view-layout.scss
+++ b/src/plugins/imagery/components/imagery-view-layout.scss
@@ -99,7 +99,7 @@
 .c-imagery {
     .h-local-controls--overlay-content {
         position: absolute;
-        right: $interiorMargin; top: $interiorMargin;
+        left: $interiorMargin; top: $interiorMargin;
         z-index: 2;
         background: $colorLocalControlOvrBg;
         border-radius: $basicCr;

--- a/src/plugins/plot/res/templates/mct-plot.html
+++ b/src/plugins/plot/res/templates/mct-plot.html
@@ -21,8 +21,11 @@
 -->
 <div class="gl-plot plot-legend-{{legend.get('position')}} {{legend.get('expanded')? 'plot-legend-expanded' : 'plot-legend-collapsed'}}">
     <div class="c-plot-legend gl-plot-legend"
-         ng-class="{ 'hover-on-plot': !!highlights.length }"
-         ng-show="legend.get('position') !== 'hidden'">
+         ng-class="{
+            'hover-on-plot': !!highlights.length,
+            'is-legend-hidden': legend.get('hideLegendWhenSmall')
+        }"
+    >
         <div class="c-plot-legend__view-control gl-plot-legend__view-control c-disclosure-triangle is-enabled"
             ng-class="{ 'c-disclosure-triangle--expanded': legend.get('expanded') }"
             ng-click="legend.set('expanded', !legend.get('expanded'));">
@@ -134,7 +137,7 @@
                     {{option.name}}
                 </option>
             </select>
-            
+
 
             <mct-ticks axis="yAxis">
                 <div ng-repeat="tick in ticks track by tick.value"

--- a/src/plugins/plot/res/templates/mct-plot.html
+++ b/src/plugins/plot/res/templates/mct-plot.html
@@ -34,10 +34,11 @@
         <div class="c-plot-legend__wrapper">
 
             <!-- COLLAPSED PLOT LEGEND -->
-            <div class="plot-wrapper-collapsed-legend"
-                 ng-class="{'icon-cursor-lock': !!lockHighlightPoint}">
+            <div class="plot-wrapper-collapsed-legend">
                 <div class="plot-legend-item"
-                      ng-repeat="series in series track by $index">
+                    ng-repeat="series in series track by $index"
+                    ng-class="{'icon-cursor-lock': !!lockHighlightPoint}"
+                >
                     <div class="plot-series-swatch-and-name">
                         <span class="plot-series-color-swatch"
                               ng-style="{ 'background-color': series.get('color').asHexString() }">
@@ -151,17 +152,15 @@
         </div>
         <div class="gl-plot-wrapper-display-area-and-x-axis"
              ng-style="{
-                     left: (tickWidth + 30) + 'px'
-                 }">
-            <div class="l-state-indicators">
-                <span class="l-state-indicators__alert-no-lad t-object-alert t-alert-unsynced icon-alert-triangle"
-                      title="This plot is not currently displaying the latest data. Reset pan/zoom to view latest data."></span>
-                <span class="l-state-indicators__alert-cursor-lock icon-cursor-lock"
-                      title="Telemetry point selection is locked. Click anywhere in the plot to unlock."
-                      ng-if="lockHighlightPoint"></span>
-            </div>
+                 left: (tickWidth + 30) + 'px'
+             }">
 
             <div class="gl-plot-display-area has-local-controls has-cursor-guides">
+                <div class="l-state-indicators">
+                    <span class="l-state-indicators__alert-no-lad t-object-alert t-alert-unsynced icon-alert-triangle"
+                          title="This plot is not currently displaying the latest data. Reset pan/zoom to view latest data."></span>
+                </div>
+
                 <mct-ticks axis="xAxis">
                     <div class="gl-plot-hash hash-v"
                          ng-repeat="tick in ticks track by tick.value"

--- a/src/plugins/plot/res/templates/mct-plot.html
+++ b/src/plugins/plot/res/templates/mct-plot.html
@@ -121,7 +121,7 @@
     <div class="plot-wrapper-axis-and-display-area flex-elem grows">
         <div class="gl-plot-axis-area gl-plot-y has-local-controls"
              ng-style="{
-                 width: (tickWidth + 30) + 'px'
+                 width: (tickWidth + 20) + 'px'
              }">
 
             <div class="gl-plot-label gl-plot-y-label"
@@ -152,7 +152,7 @@
         </div>
         <div class="gl-plot-wrapper-display-area-and-x-axis"
              ng-style="{
-                 left: (tickWidth + 30) + 'px'
+                 left: (tickWidth + 20) + 'px'
              }">
 
             <div class="gl-plot-display-area has-local-controls has-cursor-guides">

--- a/src/plugins/plot/res/templates/plot-options-browse.html
+++ b/src/plugins/plot/res/templates/plot-options-browse.html
@@ -116,6 +116,11 @@
             </li>
             <li class="grid-row">
                 <div class="grid-cell label"
+                     title="Hide the legend when the plot is small">Hide when plot small</div>
+                <div class="grid-cell value">{{ config.legend.get('hideLegendWhenSmall') ? "Yes" : "No" }}</div>
+            </li>
+            <li class="grid-row">
+                <div class="grid-cell label"
                      title="Show the legend expanded by default">Expand by Default</div>
                 <div class="grid-cell value">{{ config.legend.get('expandByDefault') ? "Yes" : "No" }}</div>
             </li>

--- a/src/plugins/plot/res/templates/plot-options-edit.html
+++ b/src/plugins/plot/res/templates/plot-options-edit.html
@@ -174,13 +174,17 @@
                      title="The position of the legend relative to the plot display area.">Position</div>
                 <div class="grid-cell value">
                     <select ng-model="form.position">
-                        <option value="hidden">Hidden</option>
                         <option value="top">Top</option>
                         <option value="right">Right</option>
                         <option value="bottom">Bottom</option>
                         <option value="left">Left</option>
                     </select>
                 </div>
+            </li>
+            <li class="grid-row">
+                <div class="grid-cell label"
+                     title="Hide the legend when the plot is small">Hide when plot small</div>
+                <div class="grid-cell value"><input type="checkbox" ng-model="form.hideLegendWhenSmall"/></div>
             </li>
             <li class="grid-row">
                 <div class="grid-cell label"

--- a/src/plugins/plot/res/templates/stacked-plot.html
+++ b/src/plugins/plot/res/templates/stacked-plot.html
@@ -54,7 +54,7 @@
                 item: telemetryObject.useCapability('adapter'),
                 oldItem: telemetryObject
             }">
-            <mct-overlay-plot domain-object="telemetryObject" plot-type="stacked"></mct-overlay-plot>
+            <mct-overlay-plot domain-object="telemetryObject"></mct-overlay-plot>
         </div>
     </div>
 </div>

--- a/src/plugins/plot/res/templates/stacked-plot.html
+++ b/src/plugins/plot/res/templates/stacked-plot.html
@@ -54,7 +54,7 @@
                 item: telemetryObject.useCapability('adapter'),
                 oldItem: telemetryObject
             }">
-            <mct-overlay-plot domain-object="telemetryObject"></mct-overlay-plot>
+            <mct-overlay-plot domain-object="telemetryObject" plot-type="stacked"></mct-overlay-plot>
         </div>
     </div>
 </div>

--- a/src/plugins/plot/src/configuration/LegendModel.js
+++ b/src/plugins/plot/src/configuration/LegendModel.js
@@ -48,6 +48,7 @@ define([
             return {
                 position: 'top',
                 expandByDefault: false,
+                hideLegendWhenSmall: false,
                 valueToShowWhenCollapsed: 'nearestValue',
                 showTimestampWhenExpanded: true,
                 showValueWhenExpanded: true,

--- a/src/plugins/plot/src/inspector/PlotLegendFormController.js
+++ b/src/plugins/plot/src/inspector/PlotLegendFormController.js
@@ -33,6 +33,11 @@ define([
                 objectPath: 'configuration.legend.position'
             },
             {
+                modelProp: 'hideLegendWhenSmall',
+                coerce: Boolean,
+                objectPath: 'configuration.legend.hideLegendWhenSmall'
+            },
+            {
                 modelProp: 'expandByDefault',
                 coerce: Boolean,
                 objectPath: 'configuration.legend.expandByDefault'

--- a/src/plugins/telemetryTable/components/table.scss
+++ b/src/plugins/telemetryTable/components/table.scss
@@ -169,7 +169,9 @@
 }
 
 .is-paused {
-    box-shadow: inset $colorPausedBg 0 0 1px 1px;
+    .c-table__body-w {
+        border: 1px solid rgba($colorPausedBg, 0.8);
+    }
 }
 
 /******************************* LEGACY */

--- a/src/plugins/telemetryTable/components/table.scss
+++ b/src/plugins/telemetryTable/components/table.scss
@@ -158,9 +158,11 @@
     }
 }
 
-.paused {
-    border: 1px solid #ff9900;
+.is-paused {
+    box-shadow: inset $colorPausedBg 0 0 1px 1px;
 }
+
+
 
 /******************************* LEGACY */
 .s-status-taking-snapshot,

--- a/src/plugins/telemetryTable/components/table.scss
+++ b/src/plugins/telemetryTable/components/table.scss
@@ -54,6 +54,16 @@
                 width: 100%;
             }
         }
+
+        &__filter {
+            .c-table__search {
+                padding-top: 0;
+                padding-bottom: 0;
+            }
+            .is-in-small-container & {
+                display: none;
+            }
+        }
     }
 
     &__headers__label {
@@ -138,7 +148,7 @@
     }
 }
 
-/******************************* EDITING */
+/******************************* SPECIFIC CASE WRAPPERS */
 .is-editing {
     .c-telemetry-table__headers__labels {
         th[draggable],
@@ -161,8 +171,6 @@
 .is-paused {
     box-shadow: inset $colorPausedBg 0 0 1px 1px;
 }
-
-
 
 /******************************* LEGACY */
 .s-status-taking-snapshot,

--- a/src/plugins/telemetryTable/components/table.scss
+++ b/src/plugins/telemetryTable/components/table.scss
@@ -96,6 +96,10 @@
         height: 0; // Fixes Chrome 73 overflow bug
         overflow-x: auto;
         overflow-y: scroll;
+
+        .is-editing & {
+            pointer-events: none;
+        }
     }
 
     /******************************* TABLES */

--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -20,7 +20,9 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 <template>
-<div class="c-table-wrapper">
+<div class="c-table-wrapper"
+     :class="{ 'is-paused': paused }"
+>
     <!-- main contolbar  start-->
     <div v-if="!marking.useAlternateControlBar"
          class="c-table-control-bar c-control-bar"
@@ -125,7 +127,7 @@
         class="c-table c-telemetry-table c-table--filterable c-table--sortable has-control-bar"
         :class="{
             'loading': loading,
-            'paused' : paused
+            'is-paused' : paused
         }"
     >
         <div :style="{ 'max-width': widthWithScroll, 'min-width': '150px'}">

--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -29,6 +29,7 @@
     >
         <button
             v-if="allowExport"
+            v-show="!markedRows.length"
             class="c-button icon-download labeled"
             title="Export this view's data"
             @click="exportAllDataAsCSV()"

--- a/src/styles/_constants-espresso.scss
+++ b/src/styles/_constants-espresso.scss
@@ -98,7 +98,7 @@ $sideBarHeaderBg: rgba($colorBodyFg, 0.2);
 $sideBarHeaderFg: rgba($colorBodyFg, 0.7);
 
 // Status colors, mainly used for messaging and item ancillary symbols
-$colorStatusFg: #999;
+$colorStatusFg: #888;
 $colorStatusDefault: #ccc;
 $colorStatusInfo: #60ba7b;
 $colorStatusInfoFilter: invert(58%) sepia(44%) saturate(405%) hue-rotate(85deg) brightness(102%) contrast(92%);
@@ -205,9 +205,9 @@ $colorBtnMajorBg: $colorKey;
 $colorBtnMajorBgHov: $colorKeyHov;
 $colorBtnMajorFg: $colorKeyFg;
 $colorBtnMajorFgHov: pushBack($colorBtnMajorFg, 10%);
-$colorBtnCautionBg: #f16f6f;
+$colorBtnCautionBg: $colorStatusAlert;
 $colorBtnCautionBgHov: #f1504e;
-$colorBtnCautionFg: $colorBtnFg;
+$colorBtnCautionFg: $colorBtnBg;
 $colorBtnActiveBg: $colorOk;
 $colorBtnActiveFg: $colorOkFg;
 $colorBtnSelectedBg: $colorSelectedBg;

--- a/src/styles/_constants-espresso.scss
+++ b/src/styles/_constants-espresso.scss
@@ -84,6 +84,10 @@ $filterHov: brightness(1.3); // Tree, location items
 $colorSelectedBg: pushBack($colorKey, 10%);
 $colorSelectedFg: pullForward($colorBodyFg, 20%);
 
+// Object labels
+$objectLabelTypeIconOpacity: 0.7;
+$objectLabelNameFilter: brightness(1.3);
+
 // Layout
 $shellMainPad: 4px 0;
 $shellPanePad: $interiorMargin, 7px;

--- a/src/styles/_constants-espresso.scss
+++ b/src/styles/_constants-espresso.scss
@@ -331,7 +331,7 @@ $shdwItemText: none;
 $colorTabBorder: pullForward($colorBodyBg, 10%);
 $colorTabBodyBg: $colorBodyBg;
 $colorTabBodyFg: pullForward($colorBodyFg, 20%);
-$colorTabHeaderBg: rgba($colorBodyFg, 0.2);
+$colorTabHeaderBg: rgba($colorBodyFg, 0.15);
 $colorTabHeaderFg: $colorBodyFg;
 $colorTabHeaderBorder: $colorBodyBg;
 $colorTabGroupHeaderBg: pullForward($colorBodyBg, 5%);
@@ -349,7 +349,7 @@ $stylePlotHash: dashed;
 $colorPlotAreaBorder: $colorInteriorBorder;
 $colorPlotLabelFg: pushBack($colorPlotFg, 20%);
 $legendHoverValueBg: rgba($colorBodyFg, 0.2);
-$legendTableHeadBg: rgba($colorBodyFg, 0.15);
+$legendTableHeadBg: $colorTabHeaderBg;
 
 // Tree
 $colorTreeBg: transparent;

--- a/src/styles/_constants-maelstrom.scss
+++ b/src/styles/_constants-maelstrom.scss
@@ -87,6 +87,8 @@ $colorAHov: #fff;
 $filterHov: brightness(1.3); // Tree, location items
 $colorSelectedBg: pushBack($colorKey, 10%);
 $colorSelectedFg: pullForward($colorBodyFg, 20%);
+$objectLabelTypeIconOpacity: 0.7;
+$objectLabelNameFilter: brightness(1.3);
 
 // Layout
 $shellMainPad: 4px 0;

--- a/src/styles/_constants-maelstrom.scss
+++ b/src/styles/_constants-maelstrom.scss
@@ -87,6 +87,8 @@ $colorAHov: #fff;
 $filterHov: brightness(1.3); // Tree, location items
 $colorSelectedBg: pushBack($colorKey, 10%);
 $colorSelectedFg: pullForward($colorBodyFg, 20%);
+
+// Object labels
 $objectLabelTypeIconOpacity: 0.7;
 $objectLabelNameFilter: brightness(1.3);
 
@@ -207,9 +209,9 @@ $colorBtnMajorBg: $colorKey;
 $colorBtnMajorBgHov: $colorKeyHov;
 $colorBtnMajorFg: $colorKeyFg;
 $colorBtnMajorFgHov: pushBack($colorBtnMajorFg, 10%);
-$colorBtnCautionBg: #f16f6f;
+$colorBtnCautionBg: $colorStatusAlert;
 $colorBtnCautionBgHov: #f1504e;
-$colorBtnCautionFg: $colorBtnFg;
+$colorBtnCautionFg: $colorBtnBg;
 $colorBtnActiveBg: $colorOk;
 $colorBtnActiveFg: $colorOkFg;
 $colorBtnSelectedBg: $colorSelectedBg;
@@ -337,7 +339,7 @@ $shdwItemText: none;
 $colorTabBorder: pullForward($colorBodyBg, 10%);
 $colorTabBodyBg: $colorBodyBg;
 $colorTabBodyFg: pullForward($colorBodyFg, 20%);
-$colorTabHeaderBg: rgba($colorBodyFg, 0.2);
+$colorTabHeaderBg: rgba($colorBodyFg, 0.15);
 $colorTabHeaderFg: $colorBodyFg;
 $colorTabHeaderBorder: $colorBodyBg;
 $colorTabGroupHeaderBg: pullForward($colorBodyBg, 5%);

--- a/src/styles/_constants-snow.scss
+++ b/src/styles/_constants-snow.scss
@@ -83,8 +83,8 @@ $colorAHov: $colorKey;
 $filterHov: brightness(1.3); // Tree, location items
 $colorSelectedBg: pushBack($colorKey, 40%);
 $colorSelectedFg: pullForward($colorBodyFg, 10%);
-$objectLabelTypeIconOpacity: 0.7;
-$objectLabelNameFilter: brightness(0.7); // TODO: VERIFY IN THEME!
+$objectLabelTypeIconOpacity: 0.5;
+$objectLabelNameFilter: brightness(0.5);
 
 // Layout
 $shellMainPad: 4px 0;
@@ -222,7 +222,7 @@ $colorDisclosureCtrlHov: rgba($colorBodyFg, 0.7);
 $btnStdH: 24px;
 $colorCursorGuide: rgba(black, 0.6);
 $shdwCursorGuide: rgba(white, 0.4) 0 0 2px;
-$colorLocalControlOvrBg: rgba($colorBodyFg, 0.8);
+$colorLocalControlOvrBg: rgba($colorBodyBg, 0.8);
 $colorSelectBg: $colorBtnBg; // This must be a solid color, not a gradient, due to usage of SVG bg in selects
 $colorSelectFg: $colorBtnFg;
 $colorSelectArw: lighten($colorBtnBg, 20%);

--- a/src/styles/_constants-snow.scss
+++ b/src/styles/_constants-snow.scss
@@ -80,9 +80,11 @@ $uiColor: #289fec; // Resize bars, splitter bars, etc.
 $colorInteriorBorder: rgba($colorBodyFg, 0.2);
 $colorA: #999;
 $colorAHov: $colorKey;
-$filterHov: brightness(1.3); // Tree, location items
+$filterHov: brightness(0.8) contrast(2); // Tree, location items
 $colorSelectedBg: pushBack($colorKey, 40%);
 $colorSelectedFg: pullForward($colorBodyFg, 10%);
+
+// Object labels
 $objectLabelTypeIconOpacity: 0.5;
 $objectLabelNameFilter: brightness(0.5);
 

--- a/src/styles/_constants-snow.scss
+++ b/src/styles/_constants-snow.scss
@@ -83,6 +83,8 @@ $colorAHov: $colorKey;
 $filterHov: brightness(1.3); // Tree, location items
 $colorSelectedBg: pushBack($colorKey, 40%);
 $colorSelectedFg: pullForward($colorBodyFg, 10%);
+$objectLabelTypeIconOpacity: 0.7;
+$objectLabelNameFilter: brightness(0.7); // TODO: VERIFY IN THEME!
 
 // Layout
 $shellMainPad: 4px 0;

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -89,6 +89,8 @@ $messageIconD: 80px;
 $messageListIconD: 32px;
 /*************** Tables */
 $tableResizeColHitareaD: 6px;
+/*************** Misc */
+$drawingObjBorderW: 3px;
 
 /************************** MOBILE */
 $mobileMenuIconD: 24px; // Used

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -43,7 +43,7 @@ $treeTypeIconW: 18px;
 $overlayOuterMarginFullscreen: 0%;
 $overlayOuterMarginDialog: 20%;
 $overlayInnerMargin: 25px;
-$mainViewPad: 2px;
+$mainViewPad: 0px;
 /*************** Items */
 $itemPadLR: 5px;
 $gridItemDesk: 175px;
@@ -56,7 +56,7 @@ $tabularTdPadTB: 2px;
 $plotYBarW: 60px;
 $plotYLabelMinH: 20px;
 $plotYLabelW: 10px;
-$plotXBarH: 35px;
+$plotXBarH: 32px;
 $plotLegendH: 20px;
 $plotLegendWidthCollapsed: 20%;
 $plotLegendWidthExpanded: 50%;

--- a/src/styles/_constants.scss
+++ b/src/styles/_constants.scss
@@ -40,7 +40,6 @@ $inputTextP: $inputTextPTopBtm $inputTextPLeftRight;
 $menuLineH: 1.5rem;
 $treeItemIndent: 16px;
 $treeTypeIconW: 18px;
-$overlayOuterMarginLg: 5%;
 $overlayOuterMarginFullscreen: 0%;
 $overlayOuterMarginDialog: 20%;
 $overlayInnerMargin: 25px;

--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -57,11 +57,6 @@ button {
         line-height: 90%;
         padding: 3px 10px;
 
-        @include hover() {
-            background: $colorBtnBgHov;
-            color: $colorBtnFgHov;
-        }
-
         @include desktop() {
             font-size: 6px;
         }

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -206,10 +206,6 @@ body.desktop .has-local-controls {
     &:hover {
         box-shadow: $browseSelectableShdwHov;
     }
-
-    &[s-selected] {
-        border: $browseSelectedBorder;
-    }
 }
 
 /**************************** EDITING */

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -259,7 +259,7 @@ mct-plot {
         align-items: center;
         position: absolute;
         top: $m;
-        right: $m;
+        left: $m;
         z-index: 9;
 
         &__reset {
@@ -272,15 +272,18 @@ mct-plot {
             top: $m;
             right: $m;
         }
+
+        .c-button {
+            box-shadow: $colorLocalControlOvrBg 0 0 0 2px;
+        }
     }
 
     .l-state-indicators {
         color: $colorPausedBg;
         position: absolute;
-        display: block;
-        font-size: 1.5em;
-        pointer-events: none;
-        top: $interiorMarginSm;
+        cursor: help;
+        font-size: 1.2em;
+        bottom: $interiorMarginSm;
         left: $interiorMarginSm;
         z-index: 2;
 
@@ -526,7 +529,6 @@ mct-plot {
 
         .plot-legend-item {
             display: flex;
-            align-items: center;
             justify-content: stretch;
             &:not(:first-child) {
                 margin-left: $interiorMarginLg;
@@ -607,7 +609,7 @@ mct-plot {
                 overflow-y: auto;
             }
             .plot-legend-item {
-                margin-bottom: 1px;
+                margin-bottom: $interiorMarginSm;
                 margin-left: 0;
                 flex-wrap: wrap;
                 .plot-series-swatch-and-name {

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Open MCT, Copyright (c) 2014-2018, United States Government
+ * Open MCT, Copyright (c) 2014-2020, United States Government
  * as represented by the Administrator of the National Aeronautics and Space
  * Administration. All rights reserved.
  *
@@ -54,10 +54,7 @@ mct-plot {
 }
 
 .c-plot {
-    //$p: $mainViewPad;
     @include abs($mainViewPad);
-    //position: absolute;
-    //top: $p; right: $p; bottom: $p; left: $p;
 
     display: flex;
     flex-direction: column;
@@ -99,9 +96,9 @@ mct-plot {
     }
 
     .is-in-small-container & {
-            .c-control-bar {
-                display: none;
-            }
+        .c-control-bar {
+            display: none;
+        }
     }
 }
 
@@ -197,9 +194,7 @@ mct-plot {
         &.gl-plot-y-label {
             display: block;
             left: 0; top: 0; right: auto; bottom: 0;
-            padding-left: 5px;
             text-orientation: mixed;
-            //overflow: hidden;
             writing-mode: vertical-lr;
             &:before {
                 // Icon denoting configurability
@@ -371,12 +366,6 @@ mct-plot {
     z-index: -10;
 
     .l-view-section {
-        //$m: $interiorMargin;
-        //top: $m !important;
-        //right: $m;
-        //bottom: $m;
-        //left: $m;
-
         .s-status-timeconductor-unsynced .holder-plot {
             .t-object-alert.t-alert-unsynced {
                 display: none;
@@ -518,6 +507,11 @@ mct-plot {
     flex: 1 1 auto;
 }
 
+.plot-legend-top .gl-plot-legend { margin-bottom: $interiorMargin; }
+.plot-legend-bottom .gl-plot-legend { margin-top: $interiorMargin; }
+.plot-legend-left .gl-plot-legend { margin-right: $interiorMargin; }
+.plot-legend-right .gl-plot-legend { margin-left: $interiorMargin; }
+
 .gl-plot,
 .c-plot {
     &.plot-legend-collapsed .plot-wrapper-expanded-legend { display: none; }
@@ -638,8 +632,6 @@ mct-plot {
             order: 1;
         }
     }
-
-    &.plot-legend-right { margin-left: $interiorMargin; }
 }
 
 /***************** STACKED PLOT LEGEND OVERRIDES */

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -62,7 +62,7 @@ mct-plot {
     display: flex;
     flex-direction: column;
 
-    .l-control-bar {
+    .c-control-bar {
         flex: 0 0 auto;
         margin-bottom: $interiorMargin;
     }
@@ -96,6 +96,12 @@ mct-plot {
                 display: block;
             }
         }
+    }
+
+    .is-in-small-container & {
+            .c-control-bar {
+                display: none;
+            }
     }
 }
 
@@ -441,7 +447,21 @@ mct-plot {
         @include propertiesHeader();
         margin-bottom: $interiorMarginSm;
     }
+
+    .is-in-small-container & {
+        &.is-legend-hidden {
+            display: none;
+        }
+    }
 }
+
+.c-plot--stacked {
+    .is-legend-hidden {
+        // Always show the legend in a stacked plot
+        display: flex !important;
+    }
+}
+
 
 .gl-plot-legend {
     display: flex;
@@ -498,17 +518,13 @@ mct-plot {
     flex: 1 1 auto;
 }
 
-.gl-plot {
+.gl-plot,
+.c-plot {
     &.plot-legend-collapsed .plot-wrapper-expanded-legend { display: none; }
     &.plot-legend-expanded .plot-wrapper-collapsed-legend { display: none; }
 
     &.plot-legend-collapsed .icon-cursor-lock::before { padding-right: 5px; }
     &.plot-legend-expanded .icon-cursor-lock::before { padding-right: 5px; }
-
-    &.plot-legend-top .gl-plot-legend { margin-bottom: $interiorMargin; }
-    &.plot-legend-bottom .gl-plot-legend { margin-top: $interiorMargin; }
-    &.plot-legend-right .gl-plot-legend { margin-left: $interiorMargin; }
-    &.plot-legend-left .gl-plot-legend { margin-right: $interiorMargin; }
 
     /***************** GENERAL STYLES, COLLAPSED */
     &.plot-legend-collapsed {
@@ -551,8 +567,10 @@ mct-plot {
 
     /***************** TOP OR BOTTOM */
     &.plot-legend-top,
-    &.plot-legend-bottom {
+    &.plot-legend-bottom,
+    &.plot-legend-hidden {
         // General styles when legend is on the top or bottom
+        // -hidden included for legacy plots
         flex-direction: column;
 
         &.plot-legend-collapsed {
@@ -569,6 +587,7 @@ mct-plot {
     &.plot-legend-left,
     &.plot-legend-right {
         // General styles when legend is on left or right
+
         .gl-plot-legend {
             max-height: inherit;
         }
@@ -619,6 +638,33 @@ mct-plot {
             order: 1;
         }
     }
+
+    &.plot-legend-right { margin-left: $interiorMargin; }
+}
+
+/***************** STACKED PLOT LEGEND OVERRIDES */
+.c-plot--stacked {
+    // Always show the legend on top, ignore any position setting
+    .c-plot,
+    .gl-plot {
+        flex-direction: column !important;
+
+        .c-plot-legend,
+        .gl-plot-legend {
+            margin: 0;
+            margin-bottom: $interiorMargin;
+            order: 1 !important;
+            width: 100% !important;
+
+            .plot-wrapper-collapsed-legend {
+                flex-direction: row !important;
+            }
+        }
+        .plot-wrapper-axis-and-display-area {
+            order: 2 !important;
+        }
+    }
+
 }
 
 /***************** CURSOR GUIDES */

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -342,11 +342,11 @@ mct-plot {
 
 .gl-plot-tick {
     &.gl-plot-x-tick-label {
-        top: $interiorMargin;
+        top: $interiorMarginSm;
     }
     &.gl-plot-y-tick-label {
-        right: $interiorMargin;
-        left: $interiorMargin;
+        right: $interiorMarginSm;
+        left: auto;
     }
 }
 

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -449,7 +449,7 @@ mct-plot {
     }
 
     &__view-control {
-        padding-top: 2px;
+        padding-top: 4px;
         margin-right: $interiorMarginSm;
     }
 

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -29,15 +29,18 @@ mct-plot {
     .gl-plot.child-frame {
         &:hover {
             background: rgba($editUIColorBg, 0.1);
-            box-shadow: inset rgba($editUIColorBg, 0.8) 0 0 0 1px;
+            box-shadow: inset rgba($editUIColorBg, 0.3) 0 0 0 1px;
         }
 
         &[s-selected] {
-            border: 1px solid $editUIColorFg !important;
-            color: $editUIColorFg !important;
-            box-shadow: $editFrameSelectedShdw;
+            background: rgba($editUIColorBg, 0.2);
+            box-shadow: inset rgba($editUIColorBg, 0.8) 0 0 0 1px;
             z-index: 2;
         }
+    }
+
+    .plot-wrapper-axis-and-display-area {
+        pointer-events: none;
     }
 }
 

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -62,12 +62,9 @@ mct-plot {
     display: flex;
     flex-direction: column;
 
-    > * + * {
-        margin-top: $interiorMargin;
-    }
-
     .l-control-bar {
         flex: 0 0 auto;
+        margin-bottom: $interiorMargin;
     }
 
     .l-view-section {

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -416,28 +416,18 @@
     }
 
     @include hover() {
-        background: $colorBtnBgHov;
-        color: $colorBtnFgHov;
+        filter: $filterHov;
     }
 
     &[class*="--major"],
     &[class*='is-active']{
         background: $colorBtnMajorBg;
         color: $colorBtnMajorFg;
-
-        @include hover() {
-            background: $colorBtnMajorBgHov;
-            color: $colorBtnMajorFgHov;
-        }
     }
 
     &[class*='--caution'] {
-        background: $colorBtnCautionBg;
-        color: $colorBtnCautionFg;
-
-        &:hover {
-            background: $colorBtnCautionBgHov;
-        }
+        background: $colorBtnCautionBg !important;
+        color: $colorBtnCautionFg !important;
     }
 }
 

--- a/src/styles/_status.scss
+++ b/src/styles/_status.scss
@@ -184,13 +184,6 @@ tr {
     }
 }
 
-/*************************************************** BUTTONS */
-.c-button {
-    &.s-status-caution {
-        background: $colorStatusAlert !important;
-    }
-}
-
 .s-status {
     &--partial {
         // Partially completed things, such as a file downloading or process that's running

--- a/src/styles/_status.scss
+++ b/src/styles/_status.scss
@@ -184,6 +184,13 @@ tr {
     }
 }
 
+/*************************************************** BUTTONS */
+.c-button {
+    &.s-status-caution {
+        background: $colorStatusAlert !important;
+    }
+}
+
 .s-status {
     &--partial {
         // Partially completed things, such as a file downloading or process that's running

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -92,14 +92,16 @@ div.c-table {
         flex: 1 1 auto;
     }
 
-    > * + * {
-        margin-top: $interiorMarginSm;
+    &:not(.is-paused) {
+        // TODO: SHOW BUTTONS WHEN IN SMALL CONTAINER AND PAUSED
+        background: green;
     }
 }
 
 .c-table-control-bar {
     display: flex;
     flex: 0 0 auto;
+    margin-bottom: $interiorMarginSm; // This approach to allow margin to go away when control bar is hidden
 
     > * + * {
         margin-left: $interiorMarginSm;

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -92,16 +92,21 @@ div.c-table {
         flex: 1 1 auto;
     }
 
-    &:not(.is-paused) {
-        // TODO: SHOW BUTTONS WHEN IN SMALL CONTAINER AND PAUSED
-        background: green;
+    .is-in-small-container & {
+        &:not(.is-paused) {
+            .c-table-control-bar {
+                display: none;
+            }
+        }
     }
+
 }
 
 .c-table-control-bar {
     display: flex;
     flex: 0 0 auto;
-    margin-bottom: $interiorMarginSm; // This approach to allow margin to go away when control bar is hidden
+    //margin-bottom: $interiorMarginSm; // This approach to allow margin to go away when control bar is hidden
+    padding: $interiorMarginSm 0;
 
     > * + * {
         margin-left: $interiorMarginSm;

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -98,8 +98,15 @@ div.c-table {
                 display: none;
             }
         }
+        .c-table-control-bar {
+            .c-click-icon,
+            .c-button {
+                &__label {
+                    display: none;
+                }
+            }
+        }
     }
-
 }
 
 .c-table-control-bar {

--- a/src/styles/vue-styles.scss
+++ b/src/styles/vue-styles.scss
@@ -3,7 +3,7 @@
 @import "../plugins/condition/components/conditionals.scss";
 @import "../plugins/conditionWidget/components/condition-widget.scss";
 @import "../plugins/condition/components/inspector/conditional-styles.scss";
-@import "../plugins/displayLayout/components/box-view.scss";
+@import "../plugins/displayLayout/components/box-and-line-views";
 @import "../plugins/displayLayout/components/display-layout.scss";
 @import "../plugins/displayLayout/components/edit-marquee.scss";
 @import "../plugins/displayLayout/components/image-view.scss";

--- a/src/ui/components/ObjectFrame.vue
+++ b/src/ui/components/ObjectFrame.vue
@@ -28,9 +28,10 @@
     }"
 >
     <div class="c-so-view__header">
-        <div class="c-object-label"
-             :class="[cssClass, classList]"
-        >
+        <div class="c-object-label">
+            <div class="c-object-label__type-icon"
+                 :class="[cssClass, classList]"
+            ></div>
             <div class="c-object-label__name">
                 {{ domainObject && domainObject.name }}
             </div>

--- a/src/ui/components/ObjectFrame.vue
+++ b/src/ui/components/ObjectFrame.vue
@@ -129,8 +129,11 @@ export default {
         getOverlayElement(childElement) {
             const fragment = new DocumentFragment();
             const header = this.getPreviewHeader();
+            const wrapper = document.createElement('div');
+            wrapper.classList.add('l-preview-window__object-view');
+            wrapper.append(childElement);
             fragment.append(header);
-            fragment.append(childElement);
+            fragment.append(wrapper);
 
             return fragment;
         },

--- a/src/ui/components/object-frame.scss
+++ b/src/ui/components/object-frame.scss
@@ -54,7 +54,7 @@
         // View Large button
         box-shadow: $colorLocalControlOvrBg 0 0 0 2px;
         position: absolute;
-        top: $interiorMarginSm; right: $interiorMarginSm;
+        top: $interiorMargin; right: $interiorMargin;
         z-index: 10;
     }
 

--- a/src/ui/components/object-frame.scss
+++ b/src/ui/components/object-frame.scss
@@ -6,25 +6,21 @@
     &__header {
         flex: 0 0 auto;
         display: flex;
+        font-size: 1.05em;
         align-items: center;
-        margin-bottom: $interiorMargin;
+        margin-bottom: $interiorMarginSm;
+        padding: 1px 2px;
 
-        &__icon {
-            flex: 0 0 auto;
-            margin-right: $interiorMarginSm;
-            opacity: 0.5;
-        }
-
-        &__name {
-            @include headerFont(1em);
-            @include ellipsize();
-            flex: 0 1 auto;
+        .c-object-label {
+            &__name {
+                filter: $objectLabelNameFilter;
+            }
         }
     }
 
     &:not(.c-so-view--no-frame) {
         border: $browseFrameBorder;
-        padding: $interiorMargin;
+        padding: 0 $interiorMarginSm;
 
         .is-editing & {
             background: rgba($colorBodyBg, 0.8);
@@ -41,8 +37,16 @@
         // View Large button
         box-shadow: $colorLocalControlOvrBg 0 0 0 2px;
         position: absolute;
-        top: $interiorMargin; right: $interiorMargin;
+        top: $interiorMarginSm; right: $interiorMarginSm;
         z-index: 10;
+    }
+
+    .c-click-icon,
+    .c-button {
+        // Shrink buttons a bit when they appear in a frame
+        border-radius: $smallCr !important;
+        font-size: 0.9em;
+        padding: 3px 5px;
     }
 
     &__view-large {
@@ -53,7 +57,6 @@
         > .c-so-view__view-large { display: block; }
     }
 
-    /*************************** OBJECT VIEW */
     &__object-view {
         flex: 1 1 auto;
         height: 0; // Chrome 73 overflow bug fix
@@ -65,13 +68,6 @@
                 @include abs();
             }
         }
-    }
-
-    .c-click-icon,
-    .c-button {
-        // Shrink buttons a bit when they appear in a frame
-        font-size: 0.9em;
-        padding: 3px 5px;
     }
 }
 

--- a/src/ui/components/object-frame.scss
+++ b/src/ui/components/object-frame.scss
@@ -35,16 +35,14 @@
         > .c-so-view__header {
             display: none;
         }
-
-        > .c-so-view__local-controls {
-            top: $interiorMarginSm; right: $interiorMarginSm;
-        }
     }
 
     &__local-controls {
+        // View Large button
+        box-shadow: $colorLocalControlOvrBg 0 0 0 2px;
         position: absolute;
         top: $interiorMargin; right: $interiorMargin;
-        z-index: 2;
+        z-index: 10;
     }
 
     &__view-large {

--- a/src/ui/components/object-label.scss
+++ b/src/ui/components/object-label.scss
@@ -18,7 +18,7 @@
         display: block;
         flex: 0 0 auto;
         font-size: 1.1em;
-        opacity: 0.6;
+        opacity: $objectLabelTypeIconOpacity;
         margin-right: $interiorMargin;
     }
 }

--- a/src/ui/inspector/ObjectName.vue
+++ b/src/ui/inspector/ObjectName.vue
@@ -1,19 +1,23 @@
 <template>
 <div class="c-inspector__header">
     <div v-if="!multiSelect && !singleSelectNonObject"
-         class="c-inspector__selected-w c-object-label"
-         :class="typeCssClass"
+         class="c-inspector__selected c-object-label"
     >
-        <span class="c-inspector__selected c-object-label__name">{{ item.name }}</span>
+        <span class="c-object-label__type-icon"
+              :class="typeCssClass"
+        ></span>
+        <span class="c-object-label__name">{{ item.name }}</span>
     </div>
     <div v-if="singleSelectNonObject"
-         class="c-inspector__selected-w  c-object-label"
-         :class="typeCssClass"
+         class="c-inspector__selected c-inspector__selected--non-domain-object  c-object-label"
     >
-        <span class="c-inspector__selected  c-object-label__name c-inspector__selected--non-domain-object">Layout Object</span>
+        <span class="c-object-label__type-icon"
+              :class="typeCssClass"
+        ></span>
+        <span class="c-object-label__name">Layout Object</span>
     </div>
     <div v-if="multiSelect"
-         class="c-inspector__multiple-selected-w"
+         class="c-inspector__multiple-selected"
     >
         {{ itemsSelected }} items selected
     </div>

--- a/src/ui/inspector/inspector.scss
+++ b/src/ui/inspector/inspector.scss
@@ -8,13 +8,13 @@
         margin-top: $interiorMargin;
     }
 
-    &__selected-w,
-    &__multiple-selected-w {
+    &__selected,
+    &__multiple-selected {
         @include headerFont(1.1em);
         padding: $interiorMarginSm 0;
     }
 
-    &__multiple-selected-w {
+    &__multiple-selected {
         $p: $interiorMarginLg;
         background: rgba($colorWarningLo, 0.3);
         border-radius: $basicCr;
@@ -25,10 +25,11 @@
     }
 
     &__selected {
-        @include ellipsize();
-        flex: 1 1 auto;
+        .c-object-label__name {
+            filter: $objectLabelNameFilter;
+        }
 
-        &--non-domain-object {
+        &--non-domain-object .c-object-label__name {
             font-style: italic;
         }
     }

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -45,7 +45,7 @@
                 :title="lockedOrUnlocked"
                 class="c-button"
                 :class="{
-                    'icon-lock': domainObject.locked,
+                    'icon-lock s-status-caution': domainObject.locked,
                     'icon-unlocked': !domainObject.locked
                 }"
                 @click="toggleLock(!domainObject.locked)"

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -45,7 +45,7 @@
                 :title="lockedOrUnlocked"
                 class="c-button"
                 :class="{
-                    'icon-lock s-status-caution': domainObject.locked,
+                    'icon-lock c-button--caution': domainObject.locked,
                     'icon-unlocked': !domainObject.locked
                 }"
                 @click="toggleLock(!domainObject.locked)"

--- a/src/ui/layout/layout.scss
+++ b/src/ui/layout/layout.scss
@@ -350,6 +350,10 @@
         flex: 0 1 auto;
     }
 
+    .c-object-label__name {
+        filter: $objectLabelNameFilter;
+    }
+
     &__object-name--w {
         @include headerFont(1.4em);
         min-width: 0;

--- a/src/ui/layout/layout.scss
+++ b/src/ui/layout/layout.scss
@@ -313,6 +313,13 @@
 
     &__actions,
     &__end {
+        .c-button {
+            &[class*='icon-']:before {
+                min-width: 1em;
+                text-align: center;
+            }
+        }
+
         > * + * {
             margin-left: $interiorMargin;
         }

--- a/src/ui/preview/preview-header.vue
+++ b/src/ui/preview/preview-header.vue
@@ -1,11 +1,13 @@
 <template>
-<div class="l-browse-bar">
+<div class="c-preview-header l-browse-bar">
     <div class="l-browse-bar__start">
         <div
-            class="l-browse-bar__object-name--w"
-            :class="type.cssClass"
+            class="l-browse-bar__object-name--w c-object-label"
         >
-            <span class="l-browse-bar__object-name">
+            <div class="c-object-label__type-icon"
+                 :class="type.cssClass"
+            ></div>
+            <span class="l-browse-bar__object-name c-object-label__name">
                 {{ domainObject.name }}
             </span>
             <context-menu-drop-down :object-path="objectPath" />

--- a/src/ui/preview/preview.scss
+++ b/src/ui/preview/preview.scss
@@ -13,11 +13,9 @@
     }
 
     &__object-view {
-        background: $colorBodyBg;
-        border: 1px solid $colorInteriorBorder;
         flex: 1 1 auto;
+        height: 0; // Chrome 73
         overflow: auto;
-        padding: $interiorMargin;
 
         > div:not([class]) {
             // Target an immediate child div without a class and make it display: contents


### PR DESCRIPTION
### Overview
A variety of tweaks and refinements based on user requests. Fixes #3176. Test notes are in #3176.

### Changes
#### Overlay
- Large overlay now displays fullscreen, spacing and margins have been tightened up;
- Fixed ObjectFrame getOverlayElement method, added a wrapper div around the viewed object to properly control resulting layout in the overlay;
- Simplified Preview CSS to remove background, border and padding;

**_Full-screen overlay_**

<img width="1712" alt="Screen Shot 2020-07-20 at 4 51 19 PM" src="https://user-images.githubusercontent.com/1056412/87997329-a41eff00-caa9-11ea-9dc8-22b66e36cb25.png">

#### Display Layout
- Introduced `is-in-small-container` that allows Display Layout frame elements to optimize their display when "small". Small is set to 600 x 600 px, if either dimension of a frame is within that size than the new class is applied.
- Significant improvements to lines in Display Layouts, code enhanced to properly handle horizontal and vertical lines; 
- Increased border-width for lines and boxes;
- Layout frames now hide button text labels when small;
- Layout frames spacing tightened up and improved;
- Show Display Layout frame "-move" bar on hover rather than select, to make it easier to select items with hidden frames, and only show -move bar's drag grippy when that frame is selected;
- `pointer-events: none` applied to table's body and plot's plot areas when placed in a Layout and being edited, prevents distracting interactions (plot zoom/pan, table row selection) when selecting and moving elements in a Layout;
- Better layout for plot local controls and warning icons, avoids collisions with the View Large button when Layout frame is hidden;

**_New layout of plot local controls_**

<img width="327" alt="Screen Shot 2020-07-20 at 5 01 28 PM" src="https://user-images.githubusercontent.com/1056412/87997704-b0578c00-caaa-11ea-9a75-1fe177d3f97e.png">

**_Thicker borders, better horizontal and vertical lines_**
<img width="1712" alt="Screen Shot 2020-07-20 at 4 44 30 PM" src="https://user-images.githubusercontent.com/1056412/87998099-ca459e80-caab-11ea-9c27-1b0da304c744.png">

#### Telemetry Tables
- Refined `is-paused` styling in Telemetry Tables;
- Hide table buttons and header filter inputs when table is in small container. In this mode, buttons are still displayed if one or more rows are selected;
- Now hide Telemetry Tables 'Export Data' button if rows are selected, which use a separate export button;

**_Table buttons when in small container_**
<img width="1712" alt="Screen Shot 2020-07-20 at 4 58 05 PM" src="https://user-images.githubusercontent.com/1056412/87997591-61115b80-caaa-11ea-9129-954d665a47f2.png">

#### Plots
- Plots can now hide their legends when in a small container;
- "Hide legend" configuration now changed to "Hide legend when small".
- Tightened up margins and spacing in plot axis areas;

**_Legend changes_**
<img width="1712" alt="Screen Shot 2020-07-20 at 4 47 38 PM" src="https://user-images.githubusercontent.com/1056412/87998001-7dfa5e80-caab-11ea-80d7-c82caa7e9135.png">

#### Other
- Contrast enhancements and markup normalization for `c-object-label` elements in main view, Layout frames, Inspector and overlay;
- Layout tweaks to add space between scrollbar and thumbs in Imagery view;
- Refined hover styles for `c-button`, simplified and normalized hover styling;
- Converted a number of old `<a>` tags to `<buttons>` to normalize styling and use the appropriate control;
- Edit lock button is now colored when locked;

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
