### PR TITLE
Realtime Imagery Timestamp Parsing Issue

### DIFF
--- a/src/plugins/imagery/components/ImageryViewLayout.vue
+++ b/src/plugins/imagery/components/ImageryViewLayout.vue
@@ -228,8 +228,8 @@ export default {
         subscribe() {
             this.unsubscribe = this.openmct.telemetry
                 .subscribe(this.domainObject, (datum) => {
-                    let parsedTimestamp = this.timeFormat.parse(datum[this.timeKey]),
-                        bounds = this.openmct.time.bounds();
+                    let parsedTimestamp = this.timeFormat.parse(datum);
+                    let bounds = this.openmct.time.bounds();
 
                     if(parsedTimestamp >= bounds.start && parsedTimestamp <= bounds.end) {
                         this.updateHistory(datum);


### PR DESCRIPTION
Fixing issue in imagery plugin where realtime data was being parsed based specifically on the current time system as opposed to parsing the datum itself and letting the telemetry api handle figuring out the details.

Closes #3234 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes