### PR TITLE
remove console output from annotation cancelation (#3185)

### DIFF
--- a/src/plugins/notebook/components/notebook-embed.vue
+++ b/src/plugins/notebook/components/notebook-embed.vue
@@ -154,8 +154,6 @@ export default {
                             self.embed.snapshot = snapshotObject;
                             self.updateEmbed(self.embed);
                         };
-                    } else {
-                        console.log('You cancelled the annotation!!!');
                     }
 
                     done(true);


### PR DESCRIPTION
Removes console output when notebook snapshot thumbnail annotation canceled

Author Checklist:
    Changes address original issue? Yes
    Unit tests included and/or updated with changes? No
    Command line build passes? Yes
    Changes have been smoke-tested? Yes
