### PR TITLE
[Snapshots] Are holding on to outdated domainObjects when clicking on preview #3078

### DIFF
--- a/src/plugins/notebook/components/notebook-embed.vue
+++ b/src/plugins/notebook/components/notebook-embed.vue
@@ -248,7 +248,8 @@ export default {
         previewEmbed() {
             const self = this;
             const previewAction = new PreviewAction(self.openmct);
-            previewAction.invoke(JSON.parse(self.embed.objectPath));
+            this.openmct.objects.get(self.embed.domainObject.identifier)
+                .then(domainObject => previewAction.invoke([domainObject]));
         },
         removeEmbed(success) {
             if (!success) {

--- a/src/plugins/notebook/utils/notebook-entries.js
+++ b/src/plugins/notebook/utils/notebook-entries.js
@@ -95,8 +95,7 @@ export const createNewEmbed = (snapshotMeta, snapshot = '') => {
         id: 'embed-' + date,
         name,
         snapshot,
-        type,
-        objectPath: JSON.stringify(objectPath)
+        type
     };
 }
 

--- a/src/ui/preview/preview-header.vue
+++ b/src/ui/preview/preview-header.vue
@@ -27,18 +27,13 @@
 
 
 <script>
-import ContextMenuDropDown from '../../ui/components/contextMenuDropDown.vue';
-import NotebookMenuSwitcher from '@/plugins/notebook/components/notebook-menu-switcher.vue';
 import ViewSwitcher from '../../ui/layout/ViewSwitcher.vue';
 
 export default {
     inject: [
-        'openmct',
-        'objectPath'
+        'openmct'
     ],
     components: {
-        ContextMenuDropDown,
-        NotebookMenuSwitcher,
         ViewSwitcher
     },
     props: {
@@ -55,12 +50,6 @@ export default {
             }
         },
         hideViewSwitcher: {
-            type: Boolean,
-            default: () => {
-                return false;
-            }
-        },
-        showNotebookMenuSwitcher: {
             type: Boolean,
             default: () => {
                 return false;

--- a/src/ui/preview/preview-header.vue
+++ b/src/ui/preview/preview-header.vue
@@ -10,7 +10,6 @@
             <span class="l-browse-bar__object-name c-object-label__name">
                 {{ domainObject.name }}
             </span>
-            <context-menu-drop-down :object-path="objectPath" />
         </div>
     </div>
     <div class="l-browse-bar__end">
@@ -20,12 +19,6 @@
                 :views="views"
                 :current-view="currentView"
                 @setView="setView"
-            />
-            <NotebookMenuSwitcher v-if="showNotebookMenuSwitcher"
-                                  :domain-object="domainObject"
-                                  :ignore-link="true"
-                                  :object-path="objectPath"
-                                  class="c-notebook-snapshot-menubutton"
             />
         </div>
     </div>


### PR DESCRIPTION
#### Resolves: #3078 and #3250

#### Testing Instructions:

1. Build a display layout, add a few items.
2. Take a snapshot and save it in the snapshots container.
3. Make changes and save to display layout that you created in Step 1.
4. Navigate away from the display layout.
5. Click on the preview action from the snapshot in the snapshot container.
6. Notice the preview is of the time the snapshot was taken, not the current domainObject state

#### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y 
Unit tests included and/or updated with changes? | N/A 
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y

#### ScreenShots:
<img width="1157" alt="Screen Shot 2020-07-29 at 3 43 32 PM" src="https://user-images.githubusercontent.com/1292612/88861225-61001280-d1b2-11ea-91d0-559af691ee51.png">
