### PR TITLE
Remove the modified and persisted keys from duplicates

### DIFF
--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -612,6 +612,13 @@ export default {
                 object.composition.push(...composition);
             }
 
+            if (object.modified || object.persisted) {
+                object.modified = undefined;
+                object.persisted = undefined;
+                delete object.modified;
+                delete object.persisted;
+            }
+
             object.name = objectName;
             object.identifier = identifier;
             object.location = parentKeyString;


### PR DESCRIPTION
Having these keys in the duplicate causes persistence providers to think that the object was already persisted in the past, causing 404 not found (because they are new domainObjects that never existed in the persistence store).

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? N/A