### PR TITLE
[Plot] make plot zoom in/out consistent (#3286)

### DIFF
--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -345,6 +345,8 @@ define([
     };
 
     MCTPlotController.prototype.zoom = function (zoomDirection, zoomFactor) {
+        let zoomRatio = zoomFactor * 3;
+
         var currentXaxis = this.$scope.xAxis.get('displayRange'),
             currentYaxis = this.$scope.yAxis.get('displayRange');
 
@@ -359,6 +361,11 @@ define([
 
         var xAxisDist = (currentXaxis.max - currentXaxis.min) * zoomFactor,
             yAxisDist = (currentYaxis.max - currentYaxis.min) * zoomFactor;
+
+        if (zoomDirection === 'out') {
+            xAxisDist = xAxisDist / zoomRatio;
+            yAxisDist = yAxisDist / zoomRatio;
+        }
 
         if (zoomDirection === 'in') {
             this.$scope.xAxis.set('displayRange', {


### PR DESCRIPTION
Author Checklist:
Changes address original issue? Yes
Unit tests included and/or updated with changes? No
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes

To test:
1. Add a sine wave generator to the workspace
2. zoom in once
3. zoom out once
4. The expected zoom position of both X and Y axes should be that of the original zoom position prior to step 2 of this test.
