### PR TITLE
[MCT Tree] Testathon Fixes

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -214,7 +214,7 @@ export default {
             this.setContainerHeight();
         },
         allTreeItems() {
-            // catches an edge case race condition
+            // catches an edge case race condition and when new items are added (ex. folder)
             if (!this.isLoading) {
                 this.setContainerHeight();
             }
@@ -435,12 +435,7 @@ export default {
         },
         addChild(child) {
             let item = this.buildTreeItem(child);
-
             this.allTreeItems.push(item);
-            // if a new item was added after initial composition load
-            if (!this.isLoading) {
-                this.setContainerHeight();
-            }
         },
         removeChild(identifier) {
             let removeId = this.openmct.objects.makeKeyString(identifier);

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -212,10 +212,17 @@ export default {
         },
         searchResultItems() {
             this.setContainerHeight();
+        },
+        allTreeItems() {
+            // catches an edge case race condition
+            if (!this.isLoading) {
+                this.setContainerHeight();
+            }
         }
     },
     async mounted() {
         this.backwardsCompatibilityCheck();
+
         let savedPath = this.getSavedNavigatedPath();
         this.searchService = this.openmct.$injector.get('searchService');
         window.addEventListener('resize', this.handleWindowResize);
@@ -428,7 +435,9 @@ export default {
         },
         addChild(child) {
             let item = this.buildTreeItem(child);
+
             this.allTreeItems.push(item);
+            // if a new item was added after initial composition load
             if (!this.isLoading) {
                 this.setContainerHeight();
             }
@@ -440,6 +449,7 @@ export default {
             this.setContainerHeight();
         },
         finishLoading() {
+            console.log('DONE LOADING FOOL');
             if (this.jumpPath) {
                 this.jumpToPath();
             }
@@ -548,17 +558,21 @@ export default {
             this.$refs.scrollable.scrollTop = 0;
             this.setContainerHeight();
         },
-        handleReset(node) {
+        async handleReset(node) {
+            this.visibleItems = [];
+            await this.$nextTick(); // prevents "ghost" image of visibleItems
             this.childrenSlideClass = 'slide-right';
             this.ancestors.splice(this.ancestors.indexOf(node) + 1);
             this.getAllChildren(node);
             this.setCurrentNavigatedPath();
         },
-        handleExpanded(node) {
+        async handleExpanded(node) {
             if (this.activeSearch) {
                 return;
             }
 
+            this.visibleItems = [];
+            await this.$nextTick(); // prevents "ghost" image of visibleItems
             this.childrenSlideClass = 'slide-left';
             let newParent = this.buildTreeItem(node);
             this.ancestors.push(newParent);

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -95,7 +95,8 @@
 import treeItem from './tree-item.vue';
 import search from '../components/search.vue';
 
-const LOCAL_STORAGE_KEY__TREE_EXPANDED = 'mct-tree-expanded';
+const LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD = 'mct-tree-expanded';
+const LOCAL_STORAGE_KEY__EXPANDED_TREE_NODE = 'mct-expanded-tree-node';
 const ROOT_PATH = '/browse/';
 const ITEM_BUFFER = 5;
 const RECHECK_DELAY = 100;
@@ -214,6 +215,7 @@ export default {
         }
     },
     async mounted() {
+        this.backwardsCompatibilityCheck();
         let savedPath = this.getSavedNavigatedPath();
         this.searchService = this.openmct.$injector.get('searchService');
         window.addEventListener('resize', this.handleWindowResize);
@@ -569,11 +571,11 @@ export default {
             this.setCurrentNavigatedPath();
         },
         getSavedNavigatedPath() {
-            return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED));
+            return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD));
         },
         setCurrentNavigatedPath() {
             if (!this.searchValue) {
-                localStorage.setItem(LOCAL_STORAGE_KEY__TREE_EXPANDED, JSON.stringify(this.currentNavigatedPath));
+                localStorage.setItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD, JSON.stringify(this.currentNavigatedPath));
             }
         },
         currentPathIsActivePath() {
@@ -628,6 +630,10 @@ export default {
             let index = styleString.indexOf('px');
 
             return Number(styleString.slice(0, index));
+        },
+        backwardsCompatibilityCheck() {
+            let oldTreeExpanded = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD));
+            console.log(oldTreeExpanded);
         }
     }
 };

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -448,11 +448,6 @@ export default {
             this.isLoading = false;
         },
         async jumpToPath(saveExpandedPath = false) {
-            // check for older implementations of tree storage and reformat if necessary
-            if (Array.isArray(this.jumpPath)) {
-                this.jumpPath = this.jumpPath[0];
-            }
-
             // switching back and forth between multiple root children can cause issues,
             // this checks for one of those issues
             if (this.jumpPath.key) {

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -449,7 +449,6 @@ export default {
             this.setContainerHeight();
         },
         finishLoading() {
-            console.log('DONE LOADING FOOL');
             if (this.jumpPath) {
                 this.jumpToPath();
             }

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -571,11 +571,11 @@ export default {
             this.setCurrentNavigatedPath();
         },
         getSavedNavigatedPath() {
-            return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD));
+            return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__EXPANDED_TREE_NODE));
         },
         setCurrentNavigatedPath() {
             if (!this.searchValue) {
-                localStorage.setItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD, JSON.stringify(this.currentNavigatedPath));
+                localStorage.setItem(LOCAL_STORAGE_KEY__EXPANDED_TREE_NODE, JSON.stringify(this.currentNavigatedPath));
             }
         },
         currentPathIsActivePath() {
@@ -633,7 +633,10 @@ export default {
         },
         backwardsCompatibilityCheck() {
             let oldTreeExpanded = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD));
-            console.log(oldTreeExpanded);
+
+            if (oldTreeExpanded) {
+                localStorage.removeItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD);
+            }
         }
     }
 };


### PR DESCRIPTION
Fixes 3 issues found during testathon on 08/24.

1. issue where switching to new tree clashes with old local storage information (removed old info, added new local storage key)
2. closes #3321 created a backup check that covers race conditions (which is what I suspect the problem was) as well as new items being added to the tree after initial composition load
3. closes #3320 cleared the visibleItems array (one populating children) then added vue's nextTick to ensure ghost image is gone before new children slide in

Testing instructions are still valid in #3060