### PR TITLE
[Navigation Tree] Prevent showing "no items" while still loading

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -222,7 +222,6 @@ export default {
         }
     },
     async mounted() {
-        console.log('sup');
         this.backwardsCompatibilityCheck();
 
         let savedPath = this.getSavedNavigatedPath();
@@ -629,7 +628,6 @@ export default {
         },
         childrenIn(el, done) {
             // still needing this timeout for some reason
-            // this.hideNoItemsText = true;
             window.setTimeout(this.setContainerHeight, RECHECK_DELAY);
             done();
         },

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -76,7 +76,7 @@
                             @expanded="handleExpanded"
                         />
                         <li
-                            v-if="visibleItems.length === 0 && !isLoading"
+                            v-if="visibleItems.length === 0 && !hideNoItemsText"
                             :style="emptyStyles()"
                             class="c-tree__item c-tree__item--empty"
                         >
@@ -140,7 +140,8 @@ export default {
             getChildHeight: false,
             settingChildrenHeight: false,
             isMobile: isMobile.mobileName,
-            multipleRootChildren: false
+            multipleRootChildren: false,
+            hideNoItemsText: false
         };
     },
     computed: {
@@ -221,6 +222,7 @@ export default {
         }
     },
     async mounted() {
+        console.log('sup');
         this.backwardsCompatibilityCheck();
 
         let savedPath = this.getSavedNavigatedPath();
@@ -318,6 +320,7 @@ export default {
                         this.noScroll = true;
                     }
 
+                    this.hideNoItemsText = false;
                     this.updatevisibleItems();
                 });
             } else {
@@ -565,6 +568,7 @@ export default {
                 return;
             }
 
+            this.hideNoItemsText = true;
             this.visibleItems = [];
             await this.$nextTick(); // prevents "ghost" image of visibleItems
             this.childrenSlideClass = 'slide-left';
@@ -625,6 +629,7 @@ export default {
         },
         childrenIn(el, done) {
             // still needing this timeout for some reason
+            // this.hideNoItemsText = true;
             window.setTimeout(this.setContainerHeight, RECHECK_DELAY);
             done();
         },

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -76,7 +76,7 @@
                             @expanded="handleExpanded"
                         />
                         <li
-                            v-if="visibleItems.length === 0"
+                            v-if="visibleItems.length === 0 && !isLoading"
                             :style="emptyStyles()"
                             class="c-tree__item c-tree__item--empty"
                         >

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -76,7 +76,7 @@
                             @expanded="handleExpanded"
                         />
                         <li
-                            v-if="visibleItems.length === 0 && !hideNoItemsText"
+                            v-if="visibleItems.length === 0 && !noVisibleItems"
                             :style="emptyStyles()"
                             class="c-tree__item c-tree__item--empty"
                         >
@@ -141,7 +141,7 @@ export default {
             settingChildrenHeight: false,
             isMobile: isMobile.mobileName,
             multipleRootChildren: false,
-            hideNoItemsText: false
+            noVisibleItems: false
         };
     },
     computed: {
@@ -319,7 +319,7 @@ export default {
                         this.noScroll = true;
                     }
 
-                    this.hideNoItemsText = false;
+                    this.noVisibleItems = false;
                     this.updatevisibleItems();
                 });
             } else {
@@ -567,7 +567,7 @@ export default {
                 return;
             }
 
-            this.hideNoItemsText = true;
+            this.noVisibleItems = true;
             this.visibleItems = [];
             await this.$nextTick(); // prevents "ghost" image of visibleItems
             this.childrenSlideClass = 'slide-left';


### PR DESCRIPTION
There were some cases where the tree is still loading, and the "No Items" notification was showing (seems related to dictionaries). Added a special flag for hiding the no items text, as the isLoading was not reliable in that respect.

Closes #3320 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes