### PR TITLE
[Open MCT] Changing Default Root Object Name

### DIFF
--- a/src/api/objects/RootObjectProvider.js
+++ b/src/api/objects/RootObjectProvider.js
@@ -29,7 +29,7 @@ class RootObjectProvider {
                     key: "ROOT",
                     namespace: ""
                 },
-                name: 'The root object',
+                name: 'Open MCT',
                 type: 'root',
                 composition: []
             };

--- a/src/api/objects/test/RootObjectProviderSpec.js
+++ b/src/api/objects/test/RootObjectProviderSpec.js
@@ -22,7 +22,7 @@
 import RootObjectProvider from '../RootObjectProvider';
 
 describe('RootObjectProvider', function () {
-    // let rootRegistry;
+    const ROOT_NAME = 'Open MCT';
     let rootObjectProvider;
     let roots = ['some root'];
     let rootRegistry = {
@@ -43,7 +43,7 @@ describe('RootObjectProvider', function () {
                 key: "ROOT",
                 namespace: ""
             },
-            name: 'The root object',
+            name: ROOT_NAME,
             type: 'root',
             composition: ['some root']
         });


### PR DESCRIPTION
Changed the default root object name from "The Root Object" to "Open MCT". Makes things a bit nicer for fresh installs of Open MCT that have more than one root child. The root name is still about to be changed using the DefaultRootName plugin.

closes #3349 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? Yes
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes