### PR TITLE
Update namespace of object after location selected

### DIFF
--- a/platform/commonUI/edit/src/creation/CreateWizard.js
+++ b/platform/commonUI/edit/src/creation/CreateWizard.js
@@ -112,11 +112,22 @@ define(
                 formModel = this.createModel(formValue);
 
             formModel.location = parent.getId();
+
+            this.updateNamespaceFromParent(parent);
+
             this.domainObject.useCapability("mutation", function () {
                 return formModel;
             });
 
             return this.domainObject;
+        };
+
+        /** @private */
+        CreateWizard.prototype.updateNamespaceFromParent = function (parent) {
+            let childIdentifier = this.domainObject.useCapability('adapter').identifier;
+            let parentIdentifier = parent.useCapability('adapter').identifier;
+            childIdentifier.namespace = parentIdentifier.namespace;
+            this.domainObject.id = this.openmct.objects.makeKeyString(childIdentifier);
         };
 
         /**


### PR DESCRIPTION
Fixes https://github.com/nasa/openmct/issues/3363

Have made a minor change to the CreateWizard to update the namespace of newly created objects after the save location is selected.

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A - tests are disabled for CreateWizard
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? 