### PR TITLE
[Navigation Tree] Animation fixes

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -41,7 +41,7 @@
             <!-- loading -->
             <li
                 v-if="isLoading"
-                :style="emptyStyles()"
+                :style="leftPaddingStyle()"
                 class="c-tree__item c-tree-and-search__loading loading"
             >
                 <span class="c-tree__item__label">Loading...</span>
@@ -78,7 +78,7 @@
                         />
                         <li
                             v-if="visibleItems.length === 0 && !noVisibleItems"
-                            :style="emptyStyles()"
+                            :style="leftPaddingStyle()"
                             class="c-tree__item c-tree__item--empty"
                         >
                             No items
@@ -632,7 +632,7 @@ export default {
                 overflow: this.noScroll ? 'hidden' : 'scroll'
             };
         },
-        emptyStyles() {
+        leftPaddingStyle() {
             let offset = ((this.ancestors.length + 1) * 10);
 
             return {

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -41,7 +41,7 @@
             <!-- loading -->
             <li
                 v-if="isLoading"
-                :style="leftPaddingStyle()"
+                :style="indicatorLeftOffset"
                 class="c-tree__item c-tree-and-search__loading loading"
             >
                 <span class="c-tree__item__label">Loading...</span>
@@ -78,7 +78,7 @@
                         />
                         <li
                             v-if="visibleItems.length === 0 && !noVisibleItems"
-                            :style="leftPaddingStyle()"
+                            :style="indicatorLeftOffset"
                             class="c-tree__item c-tree__item--empty"
                         >
                             No items
@@ -168,7 +168,14 @@ export default {
         },
         itemLeftOffset() {
             return this.activeSearch ? '0px' : this.ancestors.length * 10 + 'px';
-        }
+        },
+        indicatorLeftOffset() {
+            let offset = ((this.ancestors.length + 1) * 10);
+
+            return {
+                paddingLeft: offset + 'px'
+            };
+        },
     },
     watch: {
         syncTreeNavigation() {
@@ -630,13 +637,6 @@ export default {
             return {
                 height: this.availableContainerHeight + 'px',
                 overflow: this.noScroll ? 'hidden' : 'scroll'
-            };
-        },
-        leftPaddingStyle() {
-            let offset = ((this.ancestors.length + 1) * 10);
-
-            return {
-                paddingLeft: offset + 'px'
             };
         },
         childrenIn(el, done) {

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -175,7 +175,7 @@ export default {
             return {
                 paddingLeft: offset + 'px'
             };
-        },
+        }
     },
     watch: {
         syncTreeNavigation() {


### PR DESCRIPTION
This PR fixes 3 issues:

1. "No Items" and "Loading" indicators showing at the same time.
2. Padding for "Loading" indicator.
3. Locking navigation while loading (previously if loading was taking a while, you could navigate up or down the tree or even sync to the currently viewed object, which would be jarring as those requests would happen right after the original navigation request was finished loading)

closes: #3320 
closes: #3370 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes (in #3320)