### PR TITLE
Defers legacy mutation of object till after a creation happens.

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
             openmct.legacyRegistry.enable.bind(openmct.legacyRegistry)
         );
 
-        openmct.install(openmct.plugins.LocalStorage());
+        // openmct.install(openmct.plugins.LocalStorage());
+        openmct.install(openmct.plugins.CouchDB('http://localhost:5984/openmct'));
         openmct.install(openmct.plugins.Espresso());
         openmct.install(openmct.plugins.MyItems());
         openmct.install(openmct.plugins.Generator());

--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@
             openmct.legacyRegistry.enable.bind(openmct.legacyRegistry)
         );
 
-        // openmct.install(openmct.plugins.LocalStorage());
-        openmct.install(openmct.plugins.CouchDB('http://localhost:5984/openmct'));
+        openmct.install(openmct.plugins.LocalStorage());
         openmct.install(openmct.plugins.Espresso());
         openmct.install(openmct.plugins.MyItems());
         openmct.install(openmct.plugins.Generator());

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -192,6 +192,7 @@ define([
      */
     ObjectAPI.prototype.save = function (domainObject) {
         let provider = this.getProvider(domainObject.identifier);
+        let savedResolve;
         let result;
 
         if (!this.isPersistable(domainObject)) {
@@ -200,8 +201,14 @@ define([
             result = Promise.resolve(true);
         } else {
             if (domainObject.persisted === undefined) {
-                this.mutate(domainObject, 'persisted', domainObject.modified);
-                result = provider.create(domainObject);
+                domainObject.persisted = domainObject.modified;
+                result = new Promise((resolve) => {
+                    savedResolve = resolve;
+                });
+                provider.create(domainObject).then((response) => {
+                    this.mutate(domainObject, 'persisted', domainObject.modified);
+                    savedResolve(response);
+                });
             } else {
                 this.mutate(domainObject, 'persisted', domainObject.modified);
                 result = provider.update(domainObject);

--- a/src/api/objects/ObjectAPISpec.js
+++ b/src/api/objects/ObjectAPISpec.js
@@ -32,6 +32,7 @@ describe("The Object API", () => {
                     "create",
                     "update"
                 ]);
+                mockProvider.create.and.returnValue(Promise.resolve(true));
                 objectAPI.addProvider(TEST_NAMESPACE, mockProvider);
             });
             it("Calls 'create' on provider if object is new", () => {

--- a/src/plugins/displayLayout/components/DisplayLayout.vue
+++ b/src/plugins/displayLayout/components/DisplayLayout.vue
@@ -630,9 +630,14 @@ export default {
             object.identifier = identifier;
             object.location = parentKeyString;
 
-            this.openmct.objects.save(object);
+            let savedResolve;
+            this.openmct.objects.save(object).then(() => {
+                savedResolve(object);
+            });
 
-            return object;
+            return new Promise((resolve) => {
+                savedResolve = resolve;
+            });
         },
         convertToTelemetryView(identifier, position) {
             this.openmct.objects.get(identifier).then((domainObject) => {
@@ -679,10 +684,10 @@ export default {
                 }
 
                 if (copy.type === 'subobject-view') {
-                    let newDomainObject = this.createNewDomainObject(domainObject, domainObject.composition, domainObject.type, 'duplicate', domainObject);
-
-                    newDomainObjectsArray.push(newDomainObject);
-                    copy.identifier = newDomainObject.identifier;
+                    this.createNewDomainObject(domainObject, domainObject.composition, domainObject.type, 'duplicate', domainObject).then((newDomainObject) => {
+                        newDomainObjectsArray.push(newDomainObject);
+                        copy.identifier = newDomainObject.identifier;
+                    });
                 }
 
                 offsetKeys.forEach(key => {
@@ -719,12 +724,12 @@ export default {
                 name: 'Merged Telemetry Views',
                 identifier: firstDomainObject.identifier
             };
-            let newDomainObject = this.createNewDomainObject(mockDomainObject, identifiers, viewType);
-
-            this.composition.add(newDomainObject);
-            this.addItem('subobject-view', newDomainObject, position);
-            this.removeItem(selection);
-            this.initSelectIndex = this.layoutItems.length - 1;
+            this.createNewDomainObject(mockDomainObject, identifiers, viewType).then((newDomainObject) => {
+                this.composition.add(newDomainObject);
+                this.addItem('subobject-view', newDomainObject, position);
+                this.removeItem(selection);
+                this.initSelectIndex = this.layoutItems.length - 1;
+            });
         },
         mergeMultipleOverlayPlots(selection, viewType) {
             let overlayPlots = selection.map(selectedItem => selectedItem[0].context.item);
@@ -736,21 +741,22 @@ export default {
                 name: 'Merged Overlay Plots',
                 identifier: firstOverlayPlot.identifier
             };
-            let newDomainObject = this.createNewDomainObject(mockDomainObject, overlayPlotIdentifiers, viewType);
-            let newDomainObjectKeyString = this.openmct.objects.makeKeyString(newDomainObject.identifier);
-            let internalDomainObjectKeyString = this.openmct.objects.makeKeyString(this.internalDomainObject.identifier);
+            this.createNewDomainObject(mockDomainObject, overlayPlotIdentifiers, viewType).then((newDomainObject) => {
+                let newDomainObjectKeyString = this.openmct.objects.makeKeyString(newDomainObject.identifier);
+                let internalDomainObjectKeyString = this.openmct.objects.makeKeyString(this.internalDomainObject.identifier);
 
-            this.composition.add(newDomainObject);
-            this.addItem('subobject-view', newDomainObject, position);
+                this.composition.add(newDomainObject);
+                this.addItem('subobject-view', newDomainObject, position);
 
-            overlayPlots.forEach(overlayPlot => {
-                if (overlayPlot.location === internalDomainObjectKeyString) {
-                    this.openmct.objects.mutate(overlayPlot, 'location', newDomainObjectKeyString);
-                }
+                overlayPlots.forEach(overlayPlot => {
+                    if (overlayPlot.location === internalDomainObjectKeyString) {
+                        this.openmct.objects.mutate(overlayPlot, 'location', newDomainObjectKeyString);
+                    }
+                });
+
+                this.removeItem(selection);
+                this.initSelectIndex = this.layoutItems.length - 1;
             });
-
-            this.removeItem(selection);
-            this.initSelectIndex = this.layoutItems.length - 1;
         },
         getTelemetryIdentifiers(domainObject) {
             let method = TELEMETRY_IDENTIFIER_FUNCTIONS[domainObject.type];
@@ -768,10 +774,10 @@ export default {
             let layoutType = 'subobject-view';
 
             if (layoutItem.type === 'telemetry-view') {
-                let newDomainObject = this.createNewDomainObject(domainObject, [domainObject.identifier], viewType);
-
-                this.composition.add(newDomainObject);
-                this.addItem(layoutType, newDomainObject, position);
+                this.createNewDomainObject(domainObject, [domainObject.identifier], viewType).then((newDomainObject) => {
+                    this.composition.add(newDomainObject);
+                    this.addItem(layoutType, newDomainObject, position);
+                });
             } else {
                 this.getTelemetryIdentifiers(domainObject).then((identifiers) => {
                     if (viewType === 'telemetry-view') {
@@ -782,10 +788,10 @@ export default {
                             this.convertToTelemetryView(identifier, [positionX, positionY]);
                         });
                     } else {
-                        let newDomainObject = this.createNewDomainObject(domainObject, identifiers, viewType);
-
-                        this.composition.add(newDomainObject);
-                        this.addItem(layoutType, newDomainObject, position);
+                        this.createNewDomainObject(domainObject, identifiers, viewType).then((newDomainObject) => {
+                            this.composition.add(newDomainObject);
+                            this.addItem(layoutType, newDomainObject, position);
+                        });
                     }
                 });
             }

--- a/src/plugins/newFolderAction/newFolderAction.js
+++ b/src/plugins/newFolderAction/newFolderAction.js
@@ -71,10 +71,12 @@ export default class NewFolderAction {
 
             folderType.definition.initialize(objectModel);
             objectModel.name = name || 'New Folder';
+            objectModel.modified = Date.now();
 
-            this._openmct.objects.save(objectModel);
+            this._openmct.objects.save(objectModel).then(() => {
+                composition.add(objectModel);
+            });
 
-            composition.add(objectModel);
         });
     }
     appliesTo(objectPath) {

--- a/src/plugins/newFolderAction/pluginSpec.js
+++ b/src/plugins/newFolderAction/pluginSpec.js
@@ -79,7 +79,7 @@ describe("the plugin", () => {
 
             spyOn(openmct.$injector, 'get').and.returnValue(mockDialogService);
             spyOn(compositionAPI, 'get').and.returnValue(mockComposition);
-            spyOn(openmct.objects, 'save');
+            spyOn(openmct.objects, 'save').and.returnValue(Promise.resolve(true));
 
             newFolderAction.invoke(mockObjectPath);
         });


### PR DESCRIPTION
Resolves #3371 

This change defers legacy mutation/persistence of the object till after it is created via the objects.save api.

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? Yes
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes