### PR TITLE
[#3389] Set the persisted timestamp of objects to date.now while saving it

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -200,17 +200,19 @@ define([
         } else if (hasAlreadyBeenPersisted(domainObject)) {
             result = Promise.resolve(true);
         } else {
+            const persistedTime = Date.now();
             if (domainObject.persisted === undefined) {
-                domainObject.persisted = domainObject.modified;
                 result = new Promise((resolve) => {
                     savedResolve = resolve;
                 });
+                domainObject.persisted = persistedTime;
                 provider.create(domainObject).then((response) => {
-                    this.mutate(domainObject, 'persisted', domainObject.modified);
+                    this.mutate(domainObject, 'persisted', persistedTime);
                     savedResolve(response);
                 });
             } else {
-                this.mutate(domainObject, 'persisted', domainObject.modified);
+                domainObject.persisted = persistedTime;
+                this.mutate(domainObject, 'persisted', persistedTime);
                 result = provider.update(domainObject);
             }
         }

--- a/src/plugins/persistence/couch/pluginSpec.js
+++ b/src/plugins/persistence/couch/pluginSpec.js
@@ -33,14 +33,15 @@ describe('the plugin', () => {
     let provider;
     let testSpace = 'testSpace';
     let testPath = '/test/db';
-    let mockDomainObject = {
-        identifier: {
-            namespace: '',
-            key: 'some-value'
-        }
-    };
+    let mockDomainObject;
 
     beforeEach((done) => {
+        mockDomainObject = {
+            identifier: {
+                namespace: '',
+                key: 'some-value'
+            }
+        };
         openmct = createOpenMct(false);
         openmct.install(new CouchPlugin(testSpace, testPath));
 


### PR DESCRIPTION
Resolves #3389 
A domain object's persisted timestamp should not depend on it's modified timestamp. Especially during creation of the object.

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes
