### PR TITLE
[Legacy Persistence Adapter] readObject to handle possibility of two arguments

### DIFF
--- a/src/adapter/services/LegacyPersistenceAdapter.js
+++ b/src/adapter/services/LegacyPersistenceAdapter.js
@@ -20,8 +20,6 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import objectUtils from 'objectUtils';
-
 export default class LegacyPersistenceAdapter {
     constructor(openmct) {
         this.openmct = openmct;

--- a/src/adapter/services/LegacyPersistenceAdapter.js
+++ b/src/adapter/services/LegacyPersistenceAdapter.js
@@ -39,8 +39,15 @@ export default class LegacyPersistenceAdapter {
         return this.openmct.objects.save(legacyDomainObject.useCapability('adapter'));
     }
 
-    readObject(keystring) {
-        let identifier = objectUtils.parseKeyString(keystring);
+    readObject() {
+        let keystring = arguments[0];
+        let identifier;
+
+        if (arguments[1]) {
+            keystring = [arguments[0], arguments[1]].join(':');
+        }
+
+        identifier = objectUtils.parseKeyString(keystring);
 
         return this.openmct.legacyObject(this.openmct.objects.get(identifier));
     }

--- a/src/adapter/services/LegacyPersistenceAdapter.js
+++ b/src/adapter/services/LegacyPersistenceAdapter.js
@@ -39,15 +39,11 @@ export default class LegacyPersistenceAdapter {
         return this.openmct.objects.save(legacyDomainObject.useCapability('adapter'));
     }
 
-    readObject() {
-        let keystring = arguments[0];
-        let identifier;
-
-        if (arguments[1]) {
-            keystring = [arguments[0], arguments[1]].join(':');
-        }
-
-        identifier = objectUtils.parseKeyString(keystring);
+    readObject(space, key) {
+        const identifier = {
+            namespace: space,
+            key: key
+        };
 
         return this.openmct.legacyObject(this.openmct.objects.get(identifier));
     }


### PR DESCRIPTION
Updated LegacyPersistenceAdapter's readObject method to handle the possibility of receiving the key string in pieces and if so, assembling it before creating an identifier.

related: NIRVSSOMCT-216

## Testing
verify legacy items are being indexed correctly (currently will not be)

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? N/A
Testing instructions included? Yes