### PR TITLE
[Navigation Tree] Race condition on checking document readystate

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -265,11 +265,7 @@ export default {
     async mounted() {
 
         // only reliable way to get final tree top margin
-        document.onreadystatechange = () => {
-            if (document.readyState === "complete") {
-                this.mainTreeTopMargin = this.getElementStyleValue(this.$refs.mainTree, 'marginTop');
-            }
-        };
+        this.readyStateCheck();
 
         this.backwardsCompatibilityCheck();
 
@@ -323,8 +319,21 @@ export default {
     destroyed() {
         window.removeEventListener('resize', this.handleWindowResize);
         this.stopObservingAncestors();
+        document.removeEventListener('readystatechange', this.setTreeTopMargin);
     },
     methods: {
+        readyStateCheck() {
+            if (document.readyState !== 'complete') {
+                document.addEventListener('readystatechange', this.setTreeTopMargin);
+            } else {
+                this.setTreeTopMargin();
+            }
+        },
+        setTreeTopMargin() {
+            if (document.readyState === 'complete') {
+                this.mainTreeTopMargin = this.getElementStyleValue(this.$refs.mainTree, 'marginTop');
+            }
+        },
         updateVisibleItems() {
             if (this.updatingView) {
                 return;

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -122,11 +122,7 @@ export default {
         let objectComposition = this.openmct.composition.get(this.node.object);
 
         // only reliable way to get final item height
-        if (document.readyState !== "complete") {
-            this.readyStateChecks();
-        } else {
-            this.emitHeight();
-        }
+        this.readyStateCheck();
 
         this.domainObject = this.node.object;
         let removeListener = this.openmct.objects.observe(this.domainObject, '*', (newObject) => {
@@ -142,17 +138,18 @@ export default {
     },
     destroyed() {
         this.openmct.router.off('change:path', this.highlightIfNavigated);
+        document.removeEventListener('readystatechange', this.emitHeight);
     },
     methods: {
-        readyStateChecks() {
-            document.onreadystatechange = () => {
-                if (document.readyState === "complete") {
-                    this.emitHeight();
-                }
-            };
+        readyStateCheck() {
+            if (document.readyState !== 'complete') {
+                document.addEventListener('readystatechange', this.emitHeight);
+            } else {
+                this.emitHeight();
+            }
         },
         emitHeight() {
-            if (this.shouldEmitHeight) {
+            if (this.shouldEmitHeight && document.readyState === 'complete') {
                 this.$emit('emittedHeight', this.$el.offsetHeight);
             }
         },

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -122,13 +122,11 @@ export default {
         let objectComposition = this.openmct.composition.get(this.node.object);
 
         // only reliable way to get final item height
-        document.onreadystatechange = () => {
-            if (document.readyState === "complete") {
-                if (this.shouldEmitHeight) {
-                    this.$emit('emittedHeight', this.$el.offsetHeight);
-                }
-            }
-        };
+        if (document.readyState !== "complete") {
+            this.readyStateChecks();
+        } else {
+            this.emitHeight();
+        }
 
         this.domainObject = this.node.object;
         let removeListener = this.openmct.objects.observe(this.domainObject, '*', (newObject) => {
@@ -146,6 +144,18 @@ export default {
         this.openmct.router.off('change:path', this.highlightIfNavigated);
     },
     methods: {
+        readyStateChecks() {
+            document.onreadystatechange = () => {
+                if (document.readyState === "complete") {
+                    this.emitHeight();
+                }
+            };
+        },
+        emitHeight() {
+            if (this.shouldEmitHeight) {
+                this.$emit('emittedHeight', this.$el.offsetHeight);
+            }
+        },
         buildPathString(parentPath) {
             return [parentPath, this.openmct.objects.makeKeyString(this.node.object.identifier)].join('/');
         },


### PR DESCRIPTION
Seems readystate was already set to complete before the tree-item was loaded. Because of that, it was not pulling in the itemHeight correctly and it was hanging on load. 

Currently checking for readystate complete before registering event and handling accordingly.

closes #3429 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? pending navigation tree tests
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes