### PR TITLE
Cancelling out of edit reverts the object correctly

### DIFF
--- a/src/adapter/services/LegacyPersistenceAdapter.js
+++ b/src/adapter/services/LegacyPersistenceAdapter.js
@@ -20,6 +20,8 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
+import utils from 'objectUtils';
+
 export default class LegacyPersistenceAdapter {
     constructor(openmct) {
         this.openmct = openmct;
@@ -33,8 +35,13 @@ export default class LegacyPersistenceAdapter {
         return Promise.resolve(Object.keys(this.openmct.objects.providers));
     }
 
-    updateObject(legacyDomainObject) {
-        return this.openmct.objects.save(legacyDomainObject.useCapability('adapter'));
+    updateObject(space, key, legacyDomainObject) {
+        let object = utils.toNewFormat(legacyDomainObject, {
+            namespace: space,
+            key: key
+        });
+
+        return this.openmct.objects.save(object);
     }
 
     readObject(space, key) {

--- a/src/plugins/persistence/couch/plugin.js
+++ b/src/plugins/persistence/couch/plugin.js
@@ -22,9 +22,10 @@
 
 import CouchObjectProvider from './CouchObjectProvider';
 const NAMESPACE = '';
+const PERSISTENCE_SPACE = 'mct';
 
 export default function CouchPlugin(url) {
     return function install(openmct) {
-        openmct.objects.addProvider(NAMESPACE, new CouchObjectProvider(openmct, url, NAMESPACE));
+        openmct.objects.addProvider(PERSISTENCE_SPACE, new CouchObjectProvider(openmct, url, NAMESPACE));
     };
 }

--- a/src/plugins/persistence/couch/pluginSpec.js
+++ b/src/plugins/persistence/couch/pluginSpec.js
@@ -38,7 +38,7 @@ describe('the plugin', () => {
     beforeEach((done) => {
         mockDomainObject = {
             identifier: {
-                namespace: '',
+                namespace: 'mct',
                 key: 'some-value'
             }
         };


### PR DESCRIPTION
Resolves #3425 
Sends new style object to the object API for save when calling it from legacy persistence adapter

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? Yes
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes