### PR TITLE
Reverting when cancelling out of edits works for both legacy and new object providers

### DIFF
--- a/platform/core/src/capabilities/PersistenceCapability.js
+++ b/platform/core/src/capabilities/PersistenceCapability.js
@@ -153,10 +153,11 @@ define(["objectUtils"],
                 return this.$q.when(true);
             }
 
-            return this.persistenceService.readObject(
-                this.getSpace(),
-                this.getKey()
-            ).then(updateModel);
+            return this.openmct.objects.get(domainObject.getId()).then((newStyleObject) => {
+                let oldStyleObject = this.openmct.legacyObject(newStyleObject);
+
+                return updateModel(oldStyleObject.getModel());
+            });
         };
 
         /**

--- a/platform/core/test/capabilities/PersistenceCapabilitySpec.js
+++ b/platform/core/test/capabilities/PersistenceCapabilitySpec.js
@@ -116,8 +116,6 @@ define(
                     legacyObject: function (object) {
                         return {
                             getModel: function () {
-                                console.log(object);
-
                                 return object;
                             }
                         };

--- a/src/adapter/services/LegacyObjectAPIInterceptor.js
+++ b/src/adapter/services/LegacyObjectAPIInterceptor.js
@@ -128,7 +128,14 @@ define([
     };
 
     ObjectServiceProvider.prototype.get = function (key) {
-        const keyString = utils.makeKeyString(key);
+        let keyString = utils.makeKeyString(key);
+        const space = this.getSpace(keyString);
+
+        let identifier = utils.parseKeyString(keyString);
+        // We assign to the space for legacy persistence providers since they register themselves using a defaultSpace.
+        // This is the way to make everyone happy.
+        identifier.namespace = space;
+        keyString = utils.makeKeyString(identifier);
 
         return this.objectService.getObjects([keyString])
             .then(function (results) {

--- a/src/plugins/persistence/couch/plugin.js
+++ b/src/plugins/persistence/couch/plugin.js
@@ -22,7 +22,7 @@
 
 import CouchObjectProvider from './CouchObjectProvider';
 const NAMESPACE = '';
-const PERSISTENCE_SPACE = 'mct';
+const PERSISTENCE_SPACE = '';
 
 export default function CouchPlugin(url) {
     return function install(openmct) {

--- a/src/plugins/persistence/couch/pluginSpec.js
+++ b/src/plugins/persistence/couch/pluginSpec.js
@@ -38,7 +38,7 @@ describe('the plugin', () => {
     beforeEach((done) => {
         mockDomainObject = {
             identifier: {
-                namespace: 'mct',
+                namespace: '',
                 key: 'some-value'
             }
         };


### PR DESCRIPTION
For new object providers, we call openmct.objects.get when we revert changes made to an object
For legacy persistence providers, we ensure that the defaultSpace they were registered with is honored when we 'get' objects.

Resolves #3425 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? Yes
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes
