### PR TITLE
Strip mct namespace from ids when getting models from cache

### DIFF
--- a/platform/core/src/models/CachingModelDecorator.js
+++ b/platform/core/src/models/CachingModelDecorator.js
@@ -21,8 +21,8 @@
  *****************************************************************************/
 
 define(
-    [],
-    function () {
+    ['objectUtils'],
+    function (utils) {
 
         /**
          * The caching model decorator maintains a cache of loaded domain
@@ -40,10 +40,14 @@ define(
 
         CachingModelDecorator.prototype.getModels = function (ids) {
             var loadFromCache = ids.filter(function cached(id) {
-                    return this.cacheService.has(id);
+                    let identifier = utils.parseKeyString(id);
+
+                    return this.cacheService.has(identifier.key);
                 }, this),
                 loadFromService = ids.filter(function notCached(id) {
-                    return !this.cacheService.has(id);
+                    let identifier = utils.parseKeyString(id);
+
+                    return !this.cacheService.has(identifier.key);
                 }, this);
 
             if (!loadFromCache.length) {
@@ -53,7 +57,8 @@ define(
             return this.modelService.getModels(loadFromService)
                 .then(function (modelResults) {
                     loadFromCache.forEach(function (id) {
-                        modelResults[id] = this.cacheService.get(id);
+                        let identifier = utils.parseKeyString(id);
+                        modelResults[id] = this.cacheService.get(identifier.key);
                     }, this);
 
                     return modelResults;


### PR DESCRIPTION
Resolves #3457
When models are stored in the cache, they are not keyed by their namespace:key. They only use the key.
When models are being retrieved from the cache, they should also only be using the key and not the namespace to get the model.

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? N/A
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes