### PR TITLE
CSS and markup refactoring to support addition of 'suspect' telemetry

### DIFF
--- a/platform/commonUI/general/res/templates/label.html
+++ b/platform/commonUI/general/res/templates/label.html
@@ -20,12 +20,12 @@
  at runtime from the About dialog for additional information.
 -->
 <div class="c-object-label"
-     ng-class="{ 'is-missing': model.status === 'missing' }"
+     ng-class="{ 'is-status--missing': model.status === 'missing' }"
 >
     <div class="c-object-label__type-icon {{type.getCssClass()}}"
          ng-class="{ 'l-icon-link':location.isLink() }"
     >
-        <span class="is-missing__indicator" title="This item is missing"></span>
+        <span class="is-status__indicator" title="This item is missing or suspect"></span>
     </div>
     <div class='c-object-label__name'>{{model.name}}</div>
 </div>

--- a/src/plugins/displayLayout/components/TelemetryView.vue
+++ b/src/plugins/displayLayout/components/TelemetryView.vue
@@ -35,8 +35,8 @@
         :style="styleObject"
         @contextmenu.prevent.stop="showContextMenu"
     >
-        <div class="is-missing__indicator"
-             title="This item is missing"
+        <div class="is-status__indicator"
+             title="This item is missing or suspect"
         ></div>
         <div
             v-if="showLabel"
@@ -134,7 +134,7 @@ export default {
     },
     computed: {
         statusClass() {
-            return `is-${this.status}`;
+            return (this.status) ? `is-status--${this.status}` : '';
         },
         showLabel() {
             let displayMode = this.item.displayMode;

--- a/src/plugins/displayLayout/components/telemetry-view.scss
+++ b/src/plugins/displayLayout/components/telemetry-view.scss
@@ -29,12 +29,12 @@
 
     @include isMissing($absPos: true);
 
-    .is-missing__indicator {
+    .is-status__indicator {
         top: 0;
         left: 0;
     }
 
-    &.is-missing {
+    &.is-status--missing {
         border: $borderMissing;
     }
 }

--- a/src/plugins/folderView/components/GridItem.vue
+++ b/src/plugins/folderView/components/GridItem.vue
@@ -26,8 +26,8 @@
         </div>
     </div>
     <div class="c-grid-item__controls">
-        <div class="is-missing__indicator"
-             title="This item is missing"
+        <div class="is-status__indicator"
+             title="This item is missing or suspect"
         ></div>
         <div
             class="icon-people"

--- a/src/plugins/folderView/components/ListItem.vue
+++ b/src/plugins/folderView/components/ListItem.vue
@@ -15,8 +15,8 @@
                 class="c-object-label__type-icon c-list-item__name__type-icon"
                 :class="item.type.cssClass"
             >
-                <span class="is-missing__indicator"
-                      title="This item is missing"
+                <span class="is-status__indicator"
+                      title="This item is missing or suspect"
                 ></span>
             </div>
             <div class="c-object-label__name c-list-item__name__name">{{ item.model.name }}</div>

--- a/src/plugins/folderView/components/grid-view.scss
+++ b/src/plugins/folderView/components/grid-view.scss
@@ -41,7 +41,7 @@
         }
     }
 
-    &.is-missing {
+    &.is-status--missing {
         @include isMissing();
 
         [class*='__type-icon'],

--- a/src/plugins/folderView/components/status-listener.js
+++ b/src/plugins/folderView/components/status-listener.js
@@ -8,7 +8,7 @@ export default {
     },
     computed: {
         statusClass() {
-            return `is-${this.status}`;
+            return (this.status) ? `is-status--${this.status}` : '';
         }
     },
     data() {

--- a/src/plugins/plot/res/templates/mct-plot.html
+++ b/src/plugins/plot/res/templates/mct-plot.html
@@ -40,7 +40,7 @@
                 <div class="c-state-indicator__alert-cursor-lock icon-cursor-lock" title="Cursor is point locked. Click anywhere in the plot to unlock."></div>
                 <div class="plot-legend-item"
                      ng-class="{
-                        'is-missing': series.domainObject.status === 'missing'
+                        'is-status--missing': series.domainObject.status === 'missing'
                     }"
                      ng-repeat="series in series track by $index"
                 >
@@ -48,7 +48,7 @@
                         <span class="plot-series-color-swatch"
                               ng-style="{ 'background-color': series.get('color').asHexString() }">
                         </span>
-                        <span class="is-missing__indicator" title="This item is missing"></span>
+                        <span class="is-status__indicator" title="This item is missing or suspect"></span>
                         <span class="plot-series-name">{{ series.nameWithUnit() }}</span>
                     </div>
                     <div class="plot-series-value hover-value-enabled value-to-display-{{ legend.get('valueToShowWhenCollapsed') }} {{ series.closest.mctLimitState.cssClass }}"
@@ -95,14 +95,14 @@
                     <tr ng-repeat="series in series"
                         class="plot-legend-item"
                         ng-class="{
-                            'is-missing': series.domainObject.status === 'missing'
+                            'is-status--missing': series.domainObject.status === 'missing'
                         }"
                     >
                         <td class="plot-series-swatch-and-name">
                             <span class="plot-series-color-swatch"
                                   ng-style="{ 'background-color': series.get('color').asHexString() }">
                             </span>
-                            <span class="is-missing__indicator" title="This item is missing"></span>
+                            <span class="is-status__indicator" title="This item is missing or suspect"></span>
                             <span class="plot-series-name">{{ series.get('name') }}</span>
                         </td>
 

--- a/src/plugins/tabs/components/tabs.vue
+++ b/src/plugins/tabs/components/tabs.vue
@@ -34,8 +34,8 @@
                 <div class="c-object-label__type-icon"
                      :class="tab.type.definition.cssClass"
                 >
-                    <span class="is-missing__indicator"
-                          title="This item is missing"
+                    <span class="is-status__indicator"
+                          title="This item is missing or suspect"
                     ></span>
                 </div>
                 <span class="c-button__label c-object-label__name">{{ tab.domainObject.name }}</span>

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -59,12 +59,12 @@ mct-plot {
     }
 
     /*********************** MISSING ITEM INDICATORS */
-    .is-missing__indicator {
+    .is-status__indicator {
         display: none;
     }
-    .is-missing {
+    .is-status--missing {
         @include isMissing();
-        .is-missing__indicator {
+        .is-status__indicator {
             font-size: 0.8em;
         }
     }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -137,8 +137,12 @@
     .is-status__indicator {
         display: none ;
         text-shadow: $colorBodyBg 0 0 2px;
-        color: $colorAlert;
         font-family: symbolsfont;
+
+        &[class^='is-status'] .is-status__indicator,
+        [class^='is-status'] .is-status__indicator {
+            display: block !important;
+        }
 
         @if $absPos {
             position: absolute;
@@ -150,13 +154,18 @@
 @mixin isMissing($absPos: false) {
     @include isStatus($absPos);
 
-    &.is-status--missing .is-status__indicator,
-    .is-status--missing .is-status__indicator {
-        display: block !important;
+    .is-status__indicator:before {
+        color: $colorAlert;
+        content: $glyph-icon-alert-triangle;
+    }
+}
 
-        &:before {
-            content: $glyph-icon-alert-triangle;
-        }
+@mixin isSuspect($absPos: false) {
+    @include isStatus($absPos);
+
+    .is-status__indicator:before {
+        color: $colorWarningLo;
+        content: $glyph-icon-alert-rect;
     }
 }
 

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -129,31 +129,35 @@
     }
 }
 
-@mixin isMissing($absPos: false) {
+@mixin isStatus($absPos: false) {
+    // Supports CSS classing as follows:
+    // is-status--missing, is-status--suspect, etc.
     // Common styles to be applied to tree items, object labels, grid and list item views
-    //opacity: 0.7;
-    //pointer-events: none; // Don't think we can do this, as disables title hover on icon element
 
-    .is-missing__indicator {
+    .is-status__indicator {
         display: none ;
         text-shadow: $colorBodyBg 0 0 2px;
         color: $colorAlert;
         font-family: symbolsfont;
 
-        &:before {
-            content: $glyph-icon-alert-triangle;
-        }
-    }
-
-    @if $absPos {
-        .is-missing__indicator {
+        @if $absPos {
             position: absolute;
             z-index: 3;
         }
     }
+}
 
-    &.is-missing .is-missing__indicator,
-    .is-missing .is-missing__indicator { display: block !important; }
+@mixin isMissing($absPos: false) {
+    @include isStatus($absPos);
+
+    &.is-status--missing .is-status__indicator,
+    .is-status--missing .is-status__indicator {
+        display: block !important;
+
+        &:before {
+            content: $glyph-icon-alert-triangle;
+        }
+    }
 }
 
 @mixin bgDiagonalStripes($c: yellow, $a: 0.1, $d: 40px) {

--- a/src/ui/components/ObjectFrame.vue
+++ b/src/ui/components/ObjectFrame.vue
@@ -40,8 +40,8 @@
             <div class="c-object-label__type-icon"
                  :class="cssClass"
             >
-                <span class="is-missing__indicator"
-                      title="This item is missing"
+                <span class="is-status__indicator"
+                      title="This item is missing or suspect"
                 ></span>
             </div>
             <div class="c-object-label__name">
@@ -85,8 +85,8 @@
         </div>
     </div>
 
-    <div class="is-missing__indicator"
-         title="This item is missing"
+    <div class="is-status__indicator"
+         title="This item is missing or suspect"
     ></div>
     <object-view
         ref="objectView"
@@ -153,7 +153,7 @@ export default {
     },
     computed: {
         statusClass() {
-            return `is-${this.status}`;
+            return (this.status) ? `is-status--${this.status}` : '';
         }
     },
     mounted() {

--- a/src/ui/components/ObjectLabel.vue
+++ b/src/ui/components/ObjectLabel.vue
@@ -11,8 +11,8 @@
         class="c-tree__item__type-icon c-object-label__type-icon"
         :class="typeClass"
     >
-        <span class="is-missing__indicator"
-              title="This item is missing"
+        <span class="is-status__indicator"
+              title="This item is missing or suspect"
         ></span>
     </div>
     <div class="c-tree__item__name c-object-label__name">
@@ -60,7 +60,7 @@ export default {
             return type.definition.cssClass;
         },
         statusClass() {
-            return `is-${this.status}`;
+            return (this.status) ? `is-status--${this.status}` : '';
         }
     },
     mounted() {

--- a/src/ui/components/object-frame.scss
+++ b/src/ui/components/object-frame.scss
@@ -110,10 +110,10 @@
             }
         }
 
-        &.is-missing {
+        &.is-status--missing {
             @include isMissing($absPos: true);
 
-            .is-missing__indicator {
+            .is-status__indicator {
                 top: $interiorMargin;
                 left: $interiorMargin;
             }
@@ -145,7 +145,7 @@
         > .c-so-view__view-large { display: block; }
     }
 
-    &.is-missing {
+    &.is-status--missing {
         border: $borderMissing;
     }
 }

--- a/src/ui/components/object-label.scss
+++ b/src/ui/components/object-label.scss
@@ -21,7 +21,7 @@
         font-size: 1.1em;
     }
 
-    &.is-missing {
+    &.is-status--missing {
         @include isMissing($absPos: true);
 
         [class*='__type-icon']:before,
@@ -29,7 +29,7 @@
             opacity: $opacityMissing;
         }
 
-        .is-missing__indicator {
+        .is-status__indicator {
             right: -3px;
             top: -3px;
             transform: scale(0.7);

--- a/src/ui/inspector/ObjectName.vue
+++ b/src/ui/inspector/ObjectName.vue
@@ -2,13 +2,13 @@
 <div class="c-inspector__header">
     <div v-if="!multiSelect"
          class="c-inspector__selected c-object-label"
-         :class="{'is-missing': isMissing }"
+         :class="{'is-status--missing': isMissing }"
     >
         <div class="c-object-label__type-icon"
              :class="typeCssClass"
         >
-            <span class="is-missing__indicator"
-                  title="This item is missing"
+            <span class="is-status__indicator"
+                  title="This item is missing or suspect"
             ></span>
         </div>
         <span v-if="!singleSelectNonObject"

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -14,8 +14,8 @@
             <div class="c-object-label__type-icon"
                  :class="type.cssClass"
             >
-                <span class="is-missing__indicator"
-                      title="This item is missing"
+                <span class="is-status__indicator"
+                      title="This item is missing or suspect"
                 ></span>
             </div>
             <span
@@ -152,7 +152,7 @@ export default {
     },
     computed: {
         statusClass() {
-            return `is-${this.status}`;
+            return (this.status) ? `is-status--${this.status}` : '';
         },
         currentView() {
             return this.views.filter(v => v.key === this.viewKey)[0] || {};

--- a/src/ui/layout/layout.scss
+++ b/src/ui/layout/layout.scss
@@ -385,7 +385,7 @@
         margin-left: $interiorMarginLg;
         min-width: 0;
 
-        .is-missing__indicator {
+        .is-status__indicator {
             right: -5px !important;
             top: -4px !important;
         }


### PR DESCRIPTION
- Significant refactoring of CSS classing: `is-missing` is now `is-status--missing` and `is-missing__indicator` is now simply `is-status__indicator`, allowing the wrapping `is-missing--*` class to control what is displayed;
- New SCSS mixin `@isStatus`, and changes to mixin `@isMissing` to support new `is-status--suspect` class;
- Changed titling for missing objects from 'This item is missing' to 'This item is missing or suspect'. **IMPORTANT NOTE** This is temporary and should be replaced with a more robust approach to titling that allows title strings to be defined in configuration and dynamically applied;
- Refactored computed property `statusClass` across multiple components to return an empty string when status is undefined - this was previously erroneously returning `is-undefined` in that circumstance;
- Removed commented code;

Still todo: `is-status--suspect` and new icon glyph.