### PR TITLE
[Navigation Tree] Fix tree loading issue

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -312,6 +312,7 @@ export default {
             this.backwardsCompatibilityCheck();
             await this.calculateHeights();
 
+            return;
         },
         backwardsCompatibilityCheck() {
             let oldTreeExpanded = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD));

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -305,7 +305,6 @@ export default {
     destroyed() {
         window.removeEventListener('resize', this.handleWindowResize);
         this.stopObservingAncestors();
-        // document.removeEventListener('readystatechange', this.onReadyState);
     },
     methods: {
         async initialize() {
@@ -315,18 +314,6 @@ export default {
             await this.calculateHeights();
 
         },
-        // readyStateCheck() {
-        //     if (document.readyState !== 'complete') {
-        //         // document.addEventListener('readystatechange', this.onReadyState);
-        //     } else {
-        //         // this.onReadyState();
-        //     }
-        // },
-        // onReadyState() {
-        //     if (document.readyState === 'complete') {
-        //         this.observeMainTreeSize();
-        //     }
-        // },
         backwardsCompatibilityCheck() {
             let oldTreeExpanded = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY__TREE_EXPANDED__OLD));
 
@@ -814,13 +801,6 @@ export default {
                             - this.$refs.search.offsetHeight
                             - this.mainTreeTopMargin;
                         this.itemHeight = this.getElementStyleValue(this.$refs.dummyItem, 'height');
-                        console.log({...{
-                            mainMargin: this.mainTreeTopMargin,
-                            mainTreeHeight: this.mainTreeHeight,
-                            itemHeight: this.itemHeight,
-                            el: this.$el,
-                            elOffset: this.$el.offsetHeight
-                        }});
 
                         resolve();
                     } else {

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -32,7 +32,6 @@
 
     <!-- main tree -->
     <div
-        id="mainTree"
         ref="mainTree"
         class="c-tree-and-search__tree c-tree"
     >


### PR DESCRIPTION
Changed calculate heights function to return a promise ONCE all heights (over 0) have been returned. This way the tree will wait til it has the appropriate information to proceed.

close #3492 

## Author Checklist
Changes address original issue? Yes
Unit tests included and/or updated with changes? Separate issue
Command line build passes? Yes
Changes have been smoke-tested? Yes
Testing instructions included? Yes