### PR TITLE
Sanding and polishing 3 Dot Menu

### DIFF
--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -126,7 +126,7 @@ button {
 
 .c-icon-button {
     [class*='label'] {
-        opacity: 0.6;
+        opacity: 0.8;
     }
 
     &--mixed {
@@ -468,9 +468,6 @@ select {
 
     > * {
         flex: 0 0 auto;
-        //+ * {
-        //    margin-top: $interiorMarginSm;
-        //}
     }
 }
 
@@ -500,8 +497,8 @@ select {
             min-width: 1em;
         }
 
-        &:not([class]):before {
-             content: ''; // Add this element so that menu items without an icon still indent properly
+        &:not([class*='icon']):before {
+             content: ''; // Enable :before so that menu items without an icon still indent properly
         }
     }
 }

--- a/src/ui/components/object-frame.scss
+++ b/src/ui/components/object-frame.scss
@@ -9,6 +9,7 @@
         justify-content: space-between;
         align-items: center;
         margin-bottom: $interiorMarginSm;
+        overflow: hidden;
         padding: 3px;
 
         .c-object-label {
@@ -35,6 +36,7 @@
     /*************************** FRAME CONTROLS */
     &__frame-controls {
         display: flex;
+        flex: 0 0 auto;
 
         &__btns,
         &__more {


### PR DESCRIPTION
Closes #3532  - see issue for testing notes. Stems from #3298 and #3325.

### Changes
- Increased opacity of `c-icon-button` labels;
- Fixed CSS selector targeting no-icon menu items;
- Hide overflow in `c-so-view` header element to prevent icons extending outside very small layout frames;

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N/A
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
