### PR TITLE
Fixed minor issues in Code Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,7 +182,7 @@ The following guidelines are provided for anyone contributing source code to the
 1. Avoid the use of "magic" values.
    eg.
    ```JavaScript
-   Const UNAUTHORIZED = 401
+   const UNAUTHORIZED = 401;
    if (responseCode === UNAUTHORIZED)
    ```
    is preferable to


### PR DESCRIPTION
There was a missing semi-colon in a code example (oops!) and incorrect capitalization of the `const` keyword (overzealous word processor).

### Author Checklist
1. Changes address original issue? N/A this is a two character change to docs
2. Unit tests included and/or updated with changes? N/A docs only
3. Command line build passes? N/A Changed docs only
4. Changes have been smoke-tested? N/A Docs only
5. Testing instructions included? N/A