### PR TITLE
Various Conditionals bug fixes

### DIFF
--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -75,7 +75,8 @@ export default class Condition extends EventEmitter {
             return;
         }
 
-        if (this.isTelemetryUsed(datum.id)) {
+        // if all the criteria in this condition have no telemetry, we want to force the condition result to evaluate
+        if (this.hasNoTelemetry() || this.isTelemetryUsed(datum.id)) {
 
             this.criteria.forEach(criterion => {
                 if (this.isAnyOrAllTelemetry(criterion)) {
@@ -91,6 +92,12 @@ export default class Condition extends EventEmitter {
 
     isAnyOrAllTelemetry(criterion) {
         return (criterion.telemetry && (criterion.telemetry === 'all' || criterion.telemetry === 'any'));
+    }
+
+    hasNoTelemetry() {
+        return this.criteria.every((criterion) => {
+            return !this.isAnyOrAllTelemetry(criterion) && criterion.telemetry === '';
+        });
     }
 
     isTelemetryUsed(id) {

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -250,10 +250,17 @@ export default class Condition extends EventEmitter {
     }
 
     getTriggerDescription() {
-        return {
-            conjunction: TRIGGER_CONJUNCTION[this.trigger],
-            prefix: `${TRIGGER_LABEL[this.trigger]}: `
-        };
+        if (this.trigger) {
+            return {
+                conjunction: TRIGGER_CONJUNCTION[this.trigger],
+                prefix: `${TRIGGER_LABEL[this.trigger]}: `
+            };
+        } else {
+            return {
+                conjunction: '',
+                prefix: ''
+            };
+        }
     }
 
     requestLADConditionResult() {

--- a/src/plugins/condition/StyleRuleManager.js
+++ b/src/plugins/condition/StyleRuleManager.js
@@ -86,6 +86,7 @@ export default class StyleRuleManager extends EventEmitter {
     updateObjectStyleConfig(styleConfiguration) {
         if (!styleConfiguration || !styleConfiguration.conditionSetIdentifier) {
             this.initialize(styleConfiguration || {});
+            this.applyStaticStyle();
             this.destroy();
         } else {
             let isNewConditionSet = !this.conditionSetIdentifier
@@ -158,7 +159,6 @@ export default class StyleRuleManager extends EventEmitter {
     }
 
     destroy() {
-        this.applyStaticStyle();
         if (this.stopProvidingTelemetry) {
             this.stopProvidingTelemetry();
             delete this.stopProvidingTelemetry;


### PR DESCRIPTION
Resolves #3523 Don't apply styles on destroy as destroy should not have any side effects
Resolves #3326 Don't display undefined when conditions are loading
Resolves #3143 Force recalculation of condition set result if telemetry is removed.

### Author Checklist:
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y
