### PR TITLE
[Browse Bar] Object names editable, even if object itself is not

### DIFF
--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -20,7 +20,7 @@
             </div>
             <span
                 class="l-browse-bar__object-name c-object-label__name c-input-inline"
-                contenteditable
+                :contenteditable="type.creatable"
                 @blur="updateName"
                 @keydown.enter.prevent
                 @keyup.enter.prevent="updateNameOnEnterKeyPress"


### PR DESCRIPTION
Non creatable object names are currently able to be "edited" in the browse bar. Nothing happens as they are unable to be persisted, but it throws a persistence error.

closes #2634

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y