### PR TITLE
[Menu API] All our drop down menus should use the new menu api #3607

### DIFF
--- a/src/api/menu/MenuAPI.js
+++ b/src/api/menu/MenuAPI.js
@@ -38,7 +38,7 @@ class MenuAPI {
         this._showObjectMenu = this._showObjectMenu.bind(this);
     }
 
-    showMenu(x, y, actions, onDestroy) {
+    showMenu(x, y, actions, onDestroy, menuOptions = {}) {
         if (this.menuComponent) {
             this.menuComponent.dismiss();
         }
@@ -47,7 +47,8 @@ class MenuAPI {
             x,
             y,
             actions,
-            onDestroy
+            onDestroy,
+            ...menuOptions
         };
 
         this.menuComponent = new Menu(options);

--- a/src/api/menu/MenuAPI.js
+++ b/src/api/menu/MenuAPI.js
@@ -41,8 +41,8 @@ class MenuAPI {
         this._showObjectMenu = this._showObjectMenu.bind(this);
     }
 
-    showMenu(x, y, actions, menuOptions, onDestroy) {
-        this._createMenuComponent(x, y, actions, menuOptions, onDestroy);
+    showMenu(x, y, actions, menuOptions) {
+        this._createMenuComponent(x, y, actions, menuOptions);
 
         this.menuComponent.showMenu();
     }

--- a/src/api/menu/MenuAPI.js
+++ b/src/api/menu/MenuAPI.js
@@ -23,6 +23,24 @@
 import Menu, { MENU_PLACEMENT } from './menu.js';
 
 /**
+ * Popup Menu options
+ * @typedef {Object} MenuOptions
+ * @property {String} menuClass Class for popup menu
+ * @property {MENU_PLACEMENT} placement Placement for menu relative to click
+ * @property {Function} onDestroy callback function: invoked when menu is destroyed
+ */
+
+/**
+ * Popup Menu Item/action
+ * @typedef {Object} Action
+ * @property {String} cssClass Class for menu item
+ * @property {Boolean} isDisabled adds disable class if true
+ * @property {String} name Menu item text
+ * @property {String} description Menu item description
+ * @property {Function} callBack callback function: invoked when item is clicked
+ */
+
+/**
  * The MenuAPI allows the addition of new context menu actions, and for the context menu to be launched from
  * custom HTML elements.
  * @interface MenuAPI
@@ -41,12 +59,26 @@ class MenuAPI {
         this._showObjectMenu = this._showObjectMenu.bind(this);
     }
 
+    /**
+     * Show popup menu
+     * @param {number} x x-coordinates for popup
+     * @param {number} y x-coordinates for popup
+     * @param {Array.<Action>|Array.<Array.<Action>>} actions collection of actions{@link Action} or collection of groups of actions {@link Action}
+     * @param {MenuOptions} [menuOptions] [Optional] The {@link MenuOptions} options for Menu
+     */
     showMenu(x, y, actions, menuOptions) {
         this._createMenuComponent(x, y, actions, menuOptions);
 
         this.menuComponent.showMenu();
     }
 
+    /**
+     * Show popup menu with description of item on hover
+     * @param {number} x x-coordinates for popup
+     * @param {number} y x-coordinates for popup
+     * @param {Array.<Action>|Array.<Array.<Action>>} actions collection of actions {@link Action} or collection of groups of actions {@link Action}
+     * @param {MenuOptions} [menuOptions] [Optional] The {@link MenuOptions} options for Menu
+     */
     showSuperMenu(x, y, actions, menuOptions) {
         this._createMenuComponent(x, y, actions, menuOptions);
 

--- a/src/api/menu/MenuAPI.js
+++ b/src/api/menu/MenuAPI.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import Menu from './menu.js';
+import Menu, { MENU_PLACEMENT } from './menu.js';
 
 /**
  * The MenuAPI allows the addition of new context menu actions, and for the context menu to be launched from
@@ -33,12 +33,32 @@ class MenuAPI {
     constructor(openmct) {
         this.openmct = openmct;
 
+        this.menuPlacement = MENU_PLACEMENT;
         this.showMenu = this.showMenu.bind(this);
+        this.showSuperMenu = this.showSuperMenu.bind(this);
+
         this._clearMenuComponent = this._clearMenuComponent.bind(this);
         this._showObjectMenu = this._showObjectMenu.bind(this);
     }
 
-    showMenu(x, y, actions, onDestroy, menuOptions = {}) {
+    showMenu(x, y, actions, menuOptions, onDestroy) {
+        this._createMenuComponent(x, y, actions, menuOptions, onDestroy);
+
+        this.menuComponent.showMenu();
+    }
+
+    showSuperMenu(x, y, actions, menuOptions) {
+        this._createMenuComponent(x, y, actions, menuOptions);
+
+        this.menuComponent.showSuperMenu();
+    }
+
+    _clearMenuComponent() {
+        this.menuComponent = undefined;
+        delete this.menuComponent;
+    }
+
+    _createMenuComponent(x, y, actions, menuOptions = {}) {
         if (this.menuComponent) {
             this.menuComponent.dismiss();
         }
@@ -47,17 +67,11 @@ class MenuAPI {
             x,
             y,
             actions,
-            onDestroy,
             ...menuOptions
         };
 
         this.menuComponent = new Menu(options);
         this.menuComponent.once('destroy', this._clearMenuComponent);
-    }
-
-    _clearMenuComponent() {
-        this.menuComponent = undefined;
-        delete this.menuComponent;
     }
 
     _showObjectMenu(objectPath, x, y, actionsToBeIncluded) {

--- a/src/api/menu/MenuAPISpec.js
+++ b/src/api/menu/MenuAPISpec.js
@@ -22,10 +22,11 @@
 
 import MenuAPI from './MenuAPI';
 import Menu from './menu';
-import { createOpenMct, resetApplicationState } from '../../utils/testing';
+import { createOpenMct, createMouseEvent, resetApplicationState } from '../../utils/testing';
 
 describe ('The Menu API', () => {
     let openmct;
+    let element;
     let menuAPI;
     let actionsArray;
     let x;
@@ -33,21 +34,37 @@ describe ('The Menu API', () => {
     let result;
     let onDestroy;
 
-    beforeEach(() => {
+    beforeEach((done) => {
+        const appHolder = document.createElement('div');
+        appHolder.style.display = 'block';
+        appHolder.style.width = '1920px';
+        appHolder.style.height = '1080px';
+
         openmct = createOpenMct();
+
+        element = document.createElement('div');
+        element.style.display = 'block';
+        element.style.width = '1920px';
+        element.style.height = '1080px';
+
+        openmct.on('start', done);
+        openmct.startHeadless(appHolder);
+
         menuAPI = new MenuAPI(openmct);
         actionsArray = [
             {
+                key: 'test-css-class-1',
                 name: 'Test Action 1',
-                cssClass: 'test-css-class-1',
+                cssClass: 'icon-clock',
                 description: 'This is a test action',
                 callBack: () => {
                     result = 'Test Action 1 Invoked';
                 }
             },
             {
+                key: 'test-css-class-2',
                 name: 'Test Action 2',
-                cssClass: 'test-css-class-2',
+                cssClass: 'icon-clock',
                 description: 'This is a test action',
                 callBack: () => {
                     result = 'Test Action 2 Invoked';
@@ -133,6 +150,64 @@ describe ('The Menu API', () => {
 
                 expect(onDestroy).toHaveBeenCalled();
             });
+        });
+    });
+
+    describe("superMenu method", () => {
+        it("creates a superMenu", () => {
+            menuAPI.showSuperMenu(x, y, actionsArray);
+
+            const superMenu = document.querySelector('.c-super-menu__menu');
+
+            expect(superMenu).not.toBeNull();
+        });
+
+        it("Mouse over a superMenu shows correct description", (done) => {
+            menuAPI.showSuperMenu(x, y, actionsArray);
+
+            const superMenu = document.querySelector('.c-super-menu__menu');
+            const superMenuItem = superMenu.querySelector('li');
+            const mouseOverEvent = createMouseEvent('mouseover');
+
+            superMenuItem.dispatchEvent(mouseOverEvent);
+            const itemDescription = document.querySelector('.l-item-description__description');
+
+            setTimeout(() => {
+                expect(itemDescription.innerText).toEqual(actionsArray[0].description);
+                expect(superMenu).not.toBeNull();
+                done();
+            }, 300);
+        });
+    });
+
+    describe("Menu Placements", () => {
+        it("default menu position BOTTOM_RIGHT", () => {
+            menuAPI.showMenu(x, y, actionsArray);
+
+            const menu = document.querySelector('.c-menu');
+
+            const boundingClientRect = menu.getBoundingClientRect();
+            const left = boundingClientRect.left;
+            const top = boundingClientRect.top;
+
+            expect(left).toEqual(x);
+            expect(top).toEqual(y);
+        });
+
+        it("menu position BOTTOM_RIGHT", () => {
+            const menuOptions = {
+                placement: openmct.menus.menuPlacement.BOTTOM_RIGHT
+            };
+
+            menuAPI.showMenu(x, y, actionsArray, menuOptions);
+
+            const menu = document.querySelector('.c-menu');
+            const boundingClientRect = menu.getBoundingClientRect();
+            const left = boundingClientRect.left;
+            const top = boundingClientRect.top;
+
+            expect(left).toEqual(x);
+            expect(top).toEqual(y);
         });
     });
 });

--- a/src/api/menu/MenuAPISpec.js
+++ b/src/api/menu/MenuAPISpec.js
@@ -76,7 +76,11 @@ describe ('The Menu API', () => {
             beforeEach(() => {
                 onDestroy = jasmine.createSpy('onDestroy');
 
-                menuAPI.showMenu(x, y, actionsArray, onDestroy);
+                const menuOptions = {
+                    onDestroy
+                };
+
+                menuAPI.showMenu(x, y, actionsArray, menuOptions);
                 vueComponent = menuAPI.menuComponent.component;
                 menuComponent = document.querySelector(".c-menu");
 

--- a/src/api/menu/components/Menu.vue
+++ b/src/api/menu/components/Menu.vue
@@ -1,8 +1,12 @@
 <template>
-<div class="c-menu">
-    <ul v-if="actions.length && actions[0].length">
+<div class="c-menu"
+     :class="[options.menuClass, { 'c-super-menu': options.isShowDescription }]"
+>
+    <ul v-if="options.actions.length && options.actions[0].length"
+        :class="{ 'c-super-menu__menu': options.isShowDescription }"
+    >
         <template
-            v-for="(actionGroups, index) in actions"
+            v-for="(actionGroups, index) in options.actions"
         >
             <li
                 v-for="action in actionGroups"
@@ -10,11 +14,13 @@
                 :class="[action.cssClass, action.isDisabled ? 'disabled' : '']"
                 :title="action.description"
                 @click="action.callBack"
+                @mouseover="toggleItemDescription(action)"
+                @mouseleave="toggleItemDescription()"
             >
                 {{ action.name }}
             </li>
             <div
-                v-if="index !== actions.length - 1"
+                v-if="index !== options.actions.length - 1"
                 :key="index"
                 class="c-menu__section-separator"
             >
@@ -28,25 +34,61 @@
         </template>
     </ul>
 
-    <ul v-else>
+    <ul v-else
+        :class="{ 'c-super-menu__menu': options.isShowDescription }"
+    >
         <li
-            v-for="action in actions"
+            v-for="action in options.actions"
             :key="action.name"
             :class="action.cssClass"
             :title="action.description"
             @click="action.callBack"
+            @mouseover="toggleItemDescription(action)"
+            @mouseleave="toggleItemDescription()"
         >
             {{ action.name }}
         </li>
-        <li v-if="actions.length === 0">
+        <li v-if="options.actions.length === 0">
             No actions defined.
         </li>
     </ul>
+
+    <div v-if="options.isShowDescription"
+         class="c-super-menu__item-description"
+    >
+        <div :class="['l-item-description__icon', 'bg-' + hoveredItem.cssClass]"></div>
+        <div class="l-item-description__name">
+            {{ hoveredItem.name }}
+        </div>
+        <div class="l-item-description__description">
+            {{ hoveredItem.description }}
+        </div>
+    </div>
 </div>
 </template>
 
 <script>
 export default {
-    inject: ['actions']
+    inject: ['options'],
+    data: function () {
+        return {
+            hoveredItem: {}
+        };
+    },
+    methods: {
+        toggleItemDescription(action = {}) {
+            if (!this.options.isShowDescription) {
+                return;
+            }
+
+            const hoveredItem = {
+                name: action.name,
+                description: action.description,
+                cssClass: action.cssClass
+            };
+
+            this.hoveredItem = Object.assign({}, this.hoveredItem, hoveredItem);
+        }
+    }
 };
 </script>

--- a/src/api/menu/components/SuperMenu.vue
+++ b/src/api/menu/components/SuperMenu.vue
@@ -1,8 +1,10 @@
 <template>
 <div class="c-menu"
-     :class="options.menuClass"
+     :class="[options.menuClass, 'c-super-menu']"
 >
-    <ul v-if="options.actions.length && options.actions[0].length">
+    <ul v-if="options.actions.length && options.actions[0].length"
+        class="c-super-menu__menu"
+    >
         <template
             v-for="(actionGroups, index) in options.actions"
         >
@@ -12,6 +14,8 @@
                 :class="[action.cssClass, action.isDisabled ? 'disabled' : '']"
                 :title="action.description"
                 @click="action.callBack"
+                @mouseover="toggleItemDescription(action)"
+                @mouseleave="toggleItemDescription()"
             >
                 {{ action.name }}
             </li>
@@ -30,13 +34,17 @@
         </template>
     </ul>
 
-    <ul v-else>
+    <ul v-else
+        class="c-super-menu__menu"
+    >
         <li
             v-for="action in options.actions"
             :key="action.name"
             :class="action.cssClass"
             :title="action.description"
             @click="action.callBack"
+            @mouseover="toggleItemDescription(action)"
+            @mouseleave="toggleItemDescription()"
         >
             {{ action.name }}
         </li>
@@ -44,11 +52,37 @@
             No actions defined.
         </li>
     </ul>
+
+    <div class="c-super-menu__item-description">
+        <div :class="['l-item-description__icon', 'bg-' + hoveredItem.cssClass]"></div>
+        <div class="l-item-description__name">
+            {{ hoveredItem.name }}
+        </div>
+        <div class="l-item-description__description">
+            {{ hoveredItem.description }}
+        </div>
+    </div>
 </div>
 </template>
 
 <script>
 export default {
-    inject: ['options']
+    inject: ['options'],
+    data: function () {
+        return {
+            hoveredItem: {}
+        };
+    },
+    methods: {
+        toggleItemDescription(action = {}) {
+            const hoveredItem = {
+                name: action.name,
+                description: action.description,
+                cssClass: action.cssClass
+            };
+
+            this.hoveredItem = Object.assign({}, this.hoveredItem, hoveredItem);
+        }
+    }
 };
 </script>

--- a/src/api/menu/menu.js
+++ b/src/api/menu/menu.js
@@ -21,35 +21,33 @@
  *****************************************************************************/
 import EventEmitter from 'EventEmitter';
 import MenuComponent from './components/Menu.vue';
+import SuperMenuComponent from './components/SuperMenu.vue';
 import Vue from 'vue';
+
+export const MENU_PLACEMENT = {
+    TOP: 'top',
+    TOP_LEFT: 'top-left',
+    TOP_RIGHT: 'top-right',
+    BOTTOM: 'bottom',
+    BOTTOM_LEFT: 'bottom-left',
+    BOTTOM_RIGHT: 'bottom-right',
+    LEFT: 'left',
+    RIGHT: 'right'
+};
 
 class Menu extends EventEmitter {
     constructor(options) {
         super();
 
         this.options = options;
-
-        this.component = new Vue({
-            provide: {
-                options
-            },
-            components: {
-                MenuComponent
-            },
-            provide: {
-                actions: options.actions
-            },
-            template: '<menu-component />'
-        });
-
         if (options.onDestroy) {
             this.once('destroy', options.onDestroy);
         }
 
         this.dismiss = this.dismiss.bind(this);
         this.show = this.show.bind(this);
-
-        this.show();
+        this.showMenu = this.showMenu.bind(this);
+        this.showSuperMenu = this.showSuperMenu.bind(this);
     }
 
     dismiss() {
@@ -63,7 +61,7 @@ class Menu extends EventEmitter {
         this.component.$mount();
         document.body.appendChild(this.component.$el);
 
-        let position = this._calculatePopupPosition(this.options.x, this.options.y, this.component.$el);
+        let position = this._calculatePopupPosition(this.component.$el);
 
         this.component.$el.style.left = `${position.x}px`;
         this.component.$el.style.top = `${position.y}px`;
@@ -71,11 +69,97 @@ class Menu extends EventEmitter {
         document.addEventListener('click', this.dismiss);
     }
 
+    showMenu() {
+        this.component = new Vue({
+            provide: {
+                options: this.options
+            },
+            components: {
+                MenuComponent
+            },
+            template: '<menu-component />'
+        });
+
+        this.show();
+    }
+
+    showSuperMenu() {
+        this.component = new Vue({
+            provide: {
+                options: this.options
+            },
+            components: {
+                SuperMenuComponent
+            },
+            template: '<super-menu-component />'
+        });
+
+        this.show();
+    }
+
     /**
      * @private
      */
-    _calculatePopupPosition(eventPosX, eventPosY, menuElement) {
+    _calculatePopupPosition(menuElement) {
         let menuDimensions = menuElement.getBoundingClientRect();
+
+        if (!this.options.placement) {
+            this.options.placement = MENU_PLACEMENT.BOTTOM_RIGHT;
+        }
+
+        const menuPosition = this._getMenuPositionBasedOnPlacement(menuDimensions);
+
+        return this._preventMenuOverflow(menuPosition, menuDimensions);
+    }
+
+    /**
+     * @private
+     */
+    _getMenuPositionBasedOnPlacement(menuDimensions) {
+        let eventPosX = this.options.x;
+        let eventPosY = this.options.y;
+
+        // Adjust popup menu based on placement
+        switch (this.options.placement) {
+        case MENU_PLACEMENT.TOP:
+            eventPosX = this.options.x - Math.floor(menuDimensions.width / 2);
+            eventPosY = this.options.y - menuDimensions.height;
+            break;
+        case MENU_PLACEMENT.BOTTOM:
+            eventPosX = this.options.x - Math.floor(menuDimensions.width / 2);
+            break;
+        case MENU_PLACEMENT.LEFT:
+            eventPosX = this.options.x - menuDimensions.width;
+            eventPosY = this.options.y - Math.floor(menuDimensions.height / 2);
+            break;
+        case MENU_PLACEMENT.RIGHT:
+            eventPosY = this.options.y - Math.floor(menuDimensions.height / 2);
+            break;
+        case MENU_PLACEMENT.TOP_LEFT:
+            eventPosX = this.options.x - menuDimensions.width;
+            eventPosY = this.options.y - menuDimensions.height;
+            break;
+        case MENU_PLACEMENT.TOP_RIGHT:
+            eventPosY = this.options.y - menuDimensions.height;
+            break;
+        case MENU_PLACEMENT.BOTTOM_LEFT:
+            eventPosX = this.options.x - menuDimensions.width;
+            break;
+        case MENU_PLACEMENT.BOTTOM_RIGHT:
+            break;
+        }
+
+        return {
+            x: eventPosX,
+            y: eventPosY
+        };
+    }
+
+    /**
+     * @private
+     */
+    _preventMenuOverflow(menuPosition, menuDimensions) {
+        let { x: eventPosX, y: eventPosY } = menuPosition;
         let overflowX = (eventPosX + menuDimensions.width) - document.body.clientWidth;
         let overflowY = (eventPosY + menuDimensions.height) - document.body.clientHeight;
 
@@ -85,6 +169,14 @@ class Menu extends EventEmitter {
 
         if (overflowY > 0) {
             eventPosY = eventPosY - overflowY;
+        }
+
+        if (eventPosX < 0) {
+            eventPosX = 0;
+        }
+
+        if (eventPosY < 0) {
+            eventPosY = 0;
         }
 
         return {

--- a/src/api/menu/menu.js
+++ b/src/api/menu/menu.js
@@ -30,6 +30,9 @@ class Menu extends EventEmitter {
         this.options = options;
 
         this.component = new Vue({
+            provide: {
+                options
+            },
             components: {
                 MenuComponent
             },

--- a/src/ui/inspector/styles/FontStyleEditor.vue
+++ b/src/ui/inspector/styles/FontStyleEditor.vue
@@ -1,31 +1,31 @@
 <template>
 <div class="c-toolbar">
-    <toolbar-select-menu
-        class="menus-to-left menus-no-icon"
-        :options="fontSizeMenuOptions"
-        @change="setFontSize"
-    />
-    <div class="c-toolbar__separator"></div>
-    <toolbar-select-menu
-        class="menus-to-left menus-no-icon"
-        :options="fontMenuOptions"
-        @change="setFont"
-    />
+    <div class="c-menu-button c-ctrl-wrapper c-ctrl-wrapper--menus-left">
+        <button
+            class="c-icon-button c-button--menu icon-font-size"
+            @click.prevent.stop="showFontSizeMenu"
+        >
+            <span class="c-button__label">{{ fontStyle.fontSize }}</span>
+        </button>
+    </div>
+    <div class="c-menu-button c-ctrl-wrapper c-ctrl-wrapper--menus-left">
+        <button
+            class="c-icon-button c-button--menu icon-font"
+            @click.prevent.stop="showFontMenu"
+        >
+            <span class="c-button__label">{{ fontStyle.font }}</span>
+        </button>
+    </div>
 </div>
 </template>
 
 <script>
-import ToolbarSelectMenu from '@/ui/toolbar/components/toolbar-select-menu.vue';
-
 import {
     FONT_SIZES,
     FONTS
 } from '@/ui/inspector/styles/constants';
 
 export default {
-    components: {
-        ToolbarSelectMenu
-    },
     inject: ['openmct'],
     props: {
         fontStyle: {
@@ -34,31 +34,39 @@ export default {
         }
     },
     computed: {
-        fontMenuOptions() {
-            return {
-                control: 'select-menu',
-                icon: "icon-font",
-                title: "Set font style",
-                value: this.fontStyle.font,
-                options: FONTS
-            };
+        fontMenu() {
+            return FONTS.map(font => {
+                return {
+                    cssClass: font.cssClass || '',
+                    name: font.name,
+                    description: font.name,
+                    callBack: () => this.setFont(font.value)
+                };
+            });
         },
-        fontSizeMenuOptions() {
-            return {
-                control: 'select-menu',
-                icon: "icon-font-size",
-                title: "Set font size",
-                value: this.fontStyle.fontSize,
-                options: FONT_SIZES
-            };
+        fontSizeMenu() {
+            return FONT_SIZES.map(fontSize => {
+                return {
+                    cssClass: fontSize.cssClass || '',
+                    name: fontSize.name,
+                    description: fontSize.name,
+                    callBack: () => this.setFontSize(fontSize.value)
+                };
+            });
         }
     },
     methods: {
         setFont(font) {
-            this.$emit('set-font-property', { font: font });
+            this.$emit('set-font-property', { font });
         },
         setFontSize(fontSize) {
-            this.$emit('set-font-property', { fontSize: fontSize });
+            this.$emit('set-font-property', { fontSize });
+        },
+        showFontMenu() {
+            this.openmct.menus.showMenu(event.x, event.y, this.fontMenu);
+        },
+        showFontSizeMenu() {
+            this.openmct.menus.showMenu(event.x, event.y, this.fontSizeMenu);
         }
     }
 };

--- a/src/ui/inspector/styles/FontStyleEditor.vue
+++ b/src/ui/inspector/styles/FontStyleEditor.vue
@@ -1,6 +1,8 @@
 <template>
 <div class="c-toolbar">
-    <div class="c-menu-button c-ctrl-wrapper c-ctrl-wrapper--menus-left">
+    <div ref="fontSizeMenu"
+         class="c-menu-button c-ctrl-wrapper c-ctrl-wrapper--menus-left"
+    >
         <button
             class="c-icon-button c-button--menu icon-font-size"
             @click.prevent.stop="showFontSizeMenu"
@@ -8,7 +10,9 @@
             <span class="c-button__label">{{ fontStyle.fontSize }}</span>
         </button>
     </div>
-    <div class="c-menu-button c-ctrl-wrapper c-ctrl-wrapper--menus-left">
+    <div ref="fontMenu"
+         class="c-menu-button c-ctrl-wrapper c-ctrl-wrapper--menus-left"
+    >
         <button
             class="c-icon-button c-button--menu icon-font"
             @click.prevent.stop="showFontMenu"
@@ -63,10 +67,18 @@ export default {
             this.$emit('set-font-property', { fontSize });
         },
         showFontMenu() {
-            this.openmct.menus.showMenu(event.x, event.y, this.fontMenu);
+            const elementBoundingClientRect = this.$refs.fontMenu.getBoundingClientRect();
+            const x = elementBoundingClientRect.x;
+            const y = elementBoundingClientRect.bottom;
+
+            this.openmct.menus.showMenu(x, y, this.fontMenu);
         },
         showFontSizeMenu() {
-            this.openmct.menus.showMenu(event.x, event.y, this.fontSizeMenu);
+            const elementBoundingClientRect = this.$refs.fontSizeMenu.getBoundingClientRect();
+            const x = elementBoundingClientRect.x;
+            const y = elementBoundingClientRect.bottom;
+
+            this.openmct.menus.showMenu(x, y, this.fontSizeMenu);
         }
     }
 };

--- a/src/ui/inspector/styles/FontStyleEditor.vue
+++ b/src/ui/inspector/styles/FontStyleEditor.vue
@@ -7,7 +7,7 @@
             class="c-icon-button c-button--menu icon-font-size"
             @click.prevent.stop="showFontSizeMenu"
         >
-            <span class="c-button__label">{{ fontStyle.fontSize }}</span>
+            <span class="c-button__label">{{ fontSizeLabel }}</span>
         </button>
     </div>
     <div ref="fontMenu"
@@ -17,7 +17,7 @@
             class="c-icon-button c-button--menu icon-font"
             @click.prevent.stop="showFontMenu"
         >
-            <span class="c-button__label">{{ fontStyle.font }}</span>
+            <span class="c-button__label">{{ fontTypeLable }}</span>
         </button>
     </div>
 </div>
@@ -34,10 +34,29 @@ export default {
     props: {
         fontStyle: {
             type: Object,
-            required: true
+            required: true,
+            default: () => {
+                return {};
+            }
         }
     },
     computed: {
+        fontTypeLable() {
+            const fontType = FONTS.find(f => f.value === this.fontStyle.font);
+            if (!fontType) {
+                return '??';
+            }
+
+            return fontType.name || fontType.value || FONTS[0].name;
+        },
+        fontSizeLabel() {
+            const fontSize = FONT_SIZES.find(f => f.value === this.fontStyle.fontSize);
+            if (!fontSize) {
+                return '??';
+            }
+
+            return fontSize.name || fontSize.value || FONT_SIZES[0].name;
+        },
         fontMenu() {
             return FONTS.map(font => {
                 return {

--- a/src/ui/inspector/styles/constants.js
+++ b/src/ui/inspector/styles/constants.js
@@ -1,6 +1,6 @@
 export const FONT_SIZES = [
     {
-        name: 'Default Size',
+        name: 'Default',
         value: 'default'
     },
     {

--- a/src/ui/layout/CreateButton.vue
+++ b/src/ui/layout/CreateButton.vue
@@ -65,7 +65,7 @@ export default {
                 menuClass: 'c-create-menu'
             };
 
-            this.openmct.menus.showMenu(x, y, this.sortedItems, menuOptions);
+            this.openmct.menus.showSuperMenu(x, y, this.sortedItems, menuOptions);
         },
         create(key) {
             // Hack for support.  TODO: rewrite create action.

--- a/src/ui/layout/CreateButton.vue
+++ b/src/ui/layout/CreateButton.vue
@@ -61,7 +61,6 @@ export default {
             const y = elementBoundingClientRect.y + elementBoundingClientRect.height;
 
             const menuOptions = {
-                isShowDescription: true,
                 menuClass: 'c-create-menu'
             };
 

--- a/src/ui/layout/create-button.scss
+++ b/src/ui/layout/create-button.scss
@@ -15,7 +15,7 @@
 
 .c-create-menu {
     max-height: 80vh;
-    max-width: 500px;
+    width: 500px;
     min-height: 250px;
     z-index: 70;
 

--- a/src/ui/mixins/context-menu-gesture.js
+++ b/src/ui/mixins/context-menu-gesture.js
@@ -40,7 +40,11 @@ export default {
             let actions = actionsCollection.getVisibleActions();
             let sortedActions = this.openmct.actions._groupAndSortActions(actions);
 
-            this.openmct.menus.showMenu(event.clientX, event.clientY, sortedActions, this.onContextMenuDestroyed);
+            const menuOptions = {
+                onDestroy: this.onContextMenuDestroyed
+            };
+
+            this.openmct.menus.showMenu(event.clientX, event.clientY, sortedActions, menuOptions);
             this.contextClickActive = true;
             this.$emit('context-click-active', true);
         },


### PR DESCRIPTION
### Resolves: 
resolves: #3607

### TODOs:
- [x] fix size of super menu (menu with description) @charlesh88 
- [x] May need to add `text-transform: capitalize;` on font-style menus @charlesh88 
![Screen Shot 2021-01-08 at 3 24 10 PM](https://user-images.githubusercontent.com/1292612/104074700-9da25200-51c5-11eb-907d-bc23f2e9af15.png)

- [x] Create menu
- [x] Time conductor menus (ConductorMode.vue, ConductorTimeSystem.vue, ConductorHistory.vue)
- [x]  Inspector Font style menus (FontStyleEditor.vue)

### Notes: 
Identified following menus:

1. Tree right click context menu (already done)
1. Notebook Snapshot menu (already done)
1. View Change menu (already done)
1. Display layout alphanumeric context click menu (already done)
1. Display layout Object frame three-dot-menu (already done)
1. Flex layout Object frame three-dot-menu (already done)
1. LAD table row (already done)
1. Telemetry table row (already done)
1. BrowseBar three-dot-menu (already done)
1. Preview header three-dot-menu (already done) 

### Author Checklist:
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y