### PR TITLE
Adds a simple indicator to display FPS

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -86,7 +86,7 @@ module.exports = (config) => {
             reports: ['html', 'lcovonly', 'text-summary'],
             thresholds: {
                 global: {
-                    lines: 65
+                    lines: 66
                 }
             }
         },

--- a/src/plugins/performanceIndicator/README.md
+++ b/src/plugins/performanceIndicator/README.md
@@ -1,0 +1,9 @@
+# URL Indicator
+Adds an indicator which shows the number of frames that the browser is able to render per second. This is a useful proxy for the maximum number of updates that any telemetry display can perform per second. This may be useful during performance testing, but probably should not be enabled by default. 
+
+This indicator adds adds about 3% points to CPU usage in the Chrome task manager.
+
+## Installation
+```js
+openmct.install(openmct.plugins.PerformanceIndicator());
+```

--- a/src/plugins/performanceIndicator/plugin.js
+++ b/src/plugins/performanceIndicator/plugin.js
@@ -1,0 +1,62 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2020, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+export default function PerformanceIndicator() {
+    return function install(openmct) {
+        let frames = 0;
+        let lastCalculated = performance.now();
+        const indicator = openmct.indicators.simpleIndicator();
+
+        indicator.text('~ fps');
+        indicator.statusClass('s-status-info');
+        openmct.indicators.add(indicator);
+
+        let rafHandle = requestAnimationFrame(incremementFrames);
+
+        openmct.on('destroy', () => {
+            cancelAnimationFrame(rafHandle);
+        });
+
+        function incremementFrames() {
+            let now = performance.now();
+            if ((now - lastCalculated) < 1000) {
+                frames++;
+            } else {
+                updateFPS(frames);
+                lastCalculated = now;
+                frames = 1;
+            }
+
+            rafHandle = requestAnimationFrame(incremementFrames);
+        }
+
+        function updateFPS(fps) {
+            indicator.text(`${fps} fps`);
+            if (fps >= 40) {
+                indicator.statusClass('s-status-on');
+            } else if (fps < 40 && fps >= 20) {
+                indicator.statusClass('s-status-warning');
+            } else {
+                indicator.statusClass('s-status-error');
+            }
+        }
+    };
+}

--- a/src/plugins/performanceIndicator/pluginSpec.js
+++ b/src/plugins/performanceIndicator/pluginSpec.js
@@ -1,0 +1,87 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2020, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+import PerformancePlugin from './plugin.js';
+import {
+    createOpenMct,
+    resetApplicationState
+} from 'utils/testing';
+
+describe('the plugin', () => {
+    let openmct;
+    let element;
+    let child;
+
+    let performanceIndicator;
+    let countFramesPromise;
+
+    beforeEach((done) => {
+        openmct = createOpenMct(false);
+
+        element = document.createElement('div');
+        child = document.createElement('div');
+        element.appendChild(child);
+
+        openmct.install(new PerformancePlugin());
+
+        countFramesPromise = countFrames();
+
+        openmct.on('start', done);
+
+        performanceIndicator = openmct.indicators.indicatorObjects.find((indicator) => {
+            return indicator.text && indicator.text() === '~ fps';
+        });
+
+        openmct.startHeadless();
+    });
+
+    afterEach(() => {
+        return resetApplicationState(openmct);
+    });
+
+    it('installs the performance indicator', () => {
+        expect(performanceIndicator).toBeDefined();
+    });
+
+    it('correctly calculates fps', () => {
+        return countFramesPromise.then((frames) => {
+            expect(performanceIndicator.text()).toEqual(`${frames} fps`);
+        });
+    });
+
+    function countFrames() {
+        let startTime = performance.now();
+        let frames = 0;
+
+        return new Promise((resolve) => {
+            requestAnimationFrame(function incrementCount() {
+                let now = performance.now();
+
+                if ((now - startTime) < 1000) {
+                    frames++;
+                    requestAnimationFrame(incrementCount);
+                } else {
+                    resolve(frames);
+                }
+            });
+        });
+    }
+});

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -60,7 +60,8 @@ define([
     './defaultRootName/plugin',
     './timeline/plugin',
     './viewDatumAction/plugin',
-    './interceptors/plugin'
+    './interceptors/plugin',
+    './performanceIndicator/plugin'
 ], function (
     _,
     UTCTimeSystem,
@@ -101,7 +102,8 @@ define([
     DefaultRootName,
     Timeline,
     ViewDatumAction,
-    ObjectInterceptors
+    ObjectInterceptors,
+    PerformanceIndicator
 ) {
     const bundleMap = {
         LocalStorage: 'platform/persistence/local',
@@ -197,6 +199,7 @@ define([
     plugins.Timeline = Timeline.default;
     plugins.ViewDatumAction = ViewDatumAction.default;
     plugins.ObjectInterceptors = ObjectInterceptors.default;
+    plugins.PerformanceIndicator = PerformanceIndicator.default;
 
     return plugins;
 });


### PR DESCRIPTION
Adds a "performance indicator" which shows Frames Per Second(FPS). FPS is a useful proxy measurement for the number of view updates that Open MCT can perform based on current load. An fps value of 60 would indicate that Open MCT can in theory update a telemetry display 60 times per second.

This also serves as a proof of concept for global performance monitoring, which could be used to dynamically throttle displays to ensure that the application remains responsive under load.

Fixes #3623