### PR TITLE
[Navigation Tree] Fixes initial load navigation request breaks if children haven't loaded in yet

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -493,7 +493,7 @@ export default {
             if (!this.isLatestNavigationRequest(requestId)) {
                 return false;
             }
-            console.log('ancestors passed in', ancestors);
+
             // show or don't show root
             if (!this.multipleRootChildren && ancestors[0].id === 'ROOT') {
                 ancestors.shift();

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -388,7 +388,10 @@ export default {
 
             for (let i = 0; i < path.length; i++) {
                 let builtAncestor = this.buildTreeItem(path[i], path.slice(0, i));
-                this.tempAncestors.push(builtAncestor);
+
+                if (this.multipleRootChildren || !this.multipleRootChildren && builtAncestor.id !== 'ROOT') {
+                    this.tempAncestors.push(builtAncestor);
+                }
             }
 
             // load children for last ancestor
@@ -402,17 +405,20 @@ export default {
                 return false;
             }
 
+            let useTemporaryAncestors = false;
+
             this.childrenSlideClass = 'up';
 
             // check for edge case of initial load nav request before first load finished
             // only shows on handle reset
             if (this.ancestors.length !== 0) {
                 this.tempAncestors = [...this.ancestors];
+                useTemporaryAncestors = true;
             }
 
             this.tempAncestors.splice(this.tempAncestors.indexOf(node) + 1);
 
-            let objectPath = this.ancestorsAsObjects();
+            let objectPath = this.ancestorsAsObjects(useTemporaryAncestors);
             objectPath.splice(objectPath.indexOf(node.object) + 1);
 
             let childrenItems = await this.getChildrenAsTreeItems(node, objectPath, requestId);
@@ -438,8 +444,8 @@ export default {
             return this.updateTree(this.tempAncestors, childrenItems, requestId);
 
         },
-        ancestorsAsObjects() {
-            let ancestorsCopy = [...this.ancestors];
+        ancestorsAsObjects(useTemporary = false) {
+            let ancestorsCopy = useTemporary ? [...this.tempAncestors] : [...this.ancestors];
 
             if (this.multipleRootChildren && ancestorsCopy[0].id === 'ROOT') {
                 // no root for object paths

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -389,6 +389,7 @@ export default {
             for (let i = 0; i < path.length; i++) {
                 let builtAncestor = this.buildTreeItem(path[i], path.slice(0, i));
 
+                // prevents the root from showing up temporarily during navigation requests if it shouldn't
                 if (builtAncestor.id !== 'ROOT' || builtAncestor.id === 'ROOT' && this.multipleRootChildren) {
                     this.tempAncestors.push(builtAncestor);
                 }

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -404,7 +404,12 @@ export default {
 
             this.childrenSlideClass = 'up';
 
-            this.tempAncestors = [...this.ancestors];
+            // check for edge case of initial load nav request before first load finished
+            // only shows on handle reset
+            if (this.ancestors.length !== 0) {
+                this.tempAncestors = [...this.ancestors];
+            }
+
             this.tempAncestors.splice(this.tempAncestors.indexOf(node) + 1);
 
             let objectPath = this.ancestorsAsObjects();
@@ -488,7 +493,7 @@ export default {
             if (!this.isLatestNavigationRequest(requestId)) {
                 return false;
             }
-
+            console.log('ancestors passed in', ancestors);
             // show or don't show root
             if (!this.multipleRootChildren && ancestors[0].id === 'ROOT') {
                 ancestors.shift();

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -389,7 +389,7 @@ export default {
             for (let i = 0; i < path.length; i++) {
                 let builtAncestor = this.buildTreeItem(path[i], path.slice(0, i));
 
-                if (this.multipleRootChildren || !this.multipleRootChildren && builtAncestor.id !== 'ROOT') {
+                if (builtAncestor.id !== 'ROOT' || builtAncestor.id === 'ROOT' && this.multipleRootChildren) {
                     this.tempAncestors.push(builtAncestor);
                 }
             }
@@ -413,6 +413,7 @@ export default {
             // only shows on handle reset
             if (this.ancestors.length !== 0) {
                 this.tempAncestors = [...this.ancestors];
+            } else {
                 useTemporaryAncestors = true;
             }
 


### PR DESCRIPTION
When a navigation request is made in the tree a temporary set of ancestors is populated (and show) so the old set of ancestors can be reused if another navigation request is made before the first has finished. When the page loads however, there are NO ancestors yet, only temporary ones built (and show in tree). If a nav up the tree request is made (only type available at this point) the ancestors never get set from the temporary ancestors. This fixes this scenario, by check if there are ANY ancestors to utilize, if not it's the edge case condition and the temporary ancestors are used instead.

closes #3629

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y
