### PR TITLE
[Navigation Tree] Whole tree item clickable

### DIFF
--- a/src/ui/components/ObjectLabel.vue
+++ b/src/ui/components/ObjectLabel.vue
@@ -42,6 +42,10 @@ export default {
         navigateToPath: {
             type: String,
             default: undefined
+        },
+        propagate: {
+            type: Boolean,
+            default: true
         }
     },
     data() {
@@ -80,6 +84,10 @@ export default {
     },
     methods: {
         navigateOrPreview(event) {
+            if (!this.propagate) {
+                event.stopPropagation();
+            }
+
             if (this.openmct.editor.isEditing()) {
                 event.preventDefault();
                 this.preview();

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -31,7 +31,6 @@
             :object-path="node.objectPath"
             :navigate-to-path="navigationPath"
             :style="{ paddingLeft: leftOffset }"
-            :propagate="false"
             @context-click-active="setContextClickActive"
         />
         <view-control
@@ -148,6 +147,7 @@ export default {
         },
         handleContextMenu(event) {
             this.$refs.objectLabel.showContextMenu(event);
+            event.stopPropagation();
         },
         isNavigated() {
             return this.navigationPath === this.openmct.router.currentLocation.path;

--- a/src/ui/layout/tree-item.vue
+++ b/src/ui/layout/tree-item.vue
@@ -6,6 +6,8 @@
         'position': virtualScroll ? 'absolute' : 'relative'
     }"
     class="c-tree__item-h"
+    @click="handleClick"
+    @contextmenu="handleContextMenu"
 >
     <div
         class="c-tree__item"
@@ -20,13 +22,16 @@
             class="c-tree__item__view-control"
             :control-class="'c-nav__up'"
             :enabled="showUp"
+            :propagate="false"
             @input="resetTreeHere"
         />
         <object-label
+            ref="objectLabel"
             :domain-object="node.object"
             :object-path="node.objectPath"
             :navigate-to-path="navigationPath"
             :style="{ paddingLeft: leftOffset }"
+            :propagate="false"
             @context-click-active="setContextClickActive"
         />
         <view-control
@@ -34,6 +39,7 @@
             class="c-tree__item__view-control"
             :control-class="'c-nav__down'"
             :enabled="hasComposition && showDown"
+            :propagate="false"
         />
     </div>
 </div>
@@ -137,6 +143,12 @@ export default {
         this.openmct.router.off('change:path', this.highlightIfNavigated);
     },
     methods: {
+        handleClick(event) {
+            this.$refs.objectLabel.$el.click();
+        },
+        handleContextMenu(event) {
+            this.$refs.objectLabel.showContextMenu(event);
+        },
         isNavigated() {
             return this.navigationPath === this.openmct.router.currentLocation.path;
         },


### PR DESCRIPTION
Capturing events on the tree item itself (not just object label) and passing those on to object label so the whole tree item is responsive to clicks and context clicks.

closes #3627 

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y