### PR TITLE
[NonEditable Folder Plugin] Default Install, Browse Bar Update, StyleGuide Use

### DIFF
--- a/example/styleguide/bundle.js
+++ b/example/styleguide/bundle.js
@@ -138,7 +138,7 @@ define([
                     "id": "styleguide:home",
                     "priority": "preferred",
                     "model": {
-                        "type": "folder",
+                        "type": "noneditable.folder",
                         "name": "Style Guide Home",
                         "location": "ROOT",
                         "composition": [
@@ -155,7 +155,7 @@ define([
                     "id": "styleguide:ui-elements",
                     "priority": "preferred",
                     "model": {
-                        "type": "folder",
+                        "type": "noneditable.folder",
                         "name": "UI Elements",
                         "location": "styleguide:home",
                         "composition": [

--- a/index.html
+++ b/index.html
@@ -88,7 +88,6 @@
         openmct.install(openmct.plugins.ExampleImagery());
         openmct.install(openmct.plugins.Timeline());
         openmct.install(openmct.plugins.UTCTimeSystem());
-        openmct.install(openmct.plugins.NonEditableFolder());
         openmct.install(openmct.plugins.AutoflowView({
             type: "telemetry.panel"
         }));

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
         openmct.install(openmct.plugins.ExampleImagery());
         openmct.install(openmct.plugins.Timeline());
         openmct.install(openmct.plugins.UTCTimeSystem());
+        openmct.install(openmct.plugins.NonEditableFolder());
         openmct.install(openmct.plugins.AutoflowView({
             type: "telemetry.panel"
         }));

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -283,6 +283,7 @@ define([
         this.install(this.plugins.NewFolderAction());
         this.install(this.plugins.ViewDatumAction());
         this.install(this.plugins.ObjectInterceptors());
+        this.install(this.plugins.NonEditableFolder());
     }
 
     MCT.prototype = Object.create(EventEmitter.prototype);

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -19,7 +19,8 @@
                 ></span>
             </div>
             <span
-                class="l-browse-bar__object-name c-object-label__name c-input-inline"
+                class="l-browse-bar__object-name c-object-label__name"
+                :class="{ 'c-input-inline' : type.creatable}"
                 :contenteditable="type.creatable"
                 @blur="updateName"
                 @keydown.enter.prevent


### PR DESCRIPTION
Added NonEditableFolder plugin as a default install. Updated styleguide to use it (can be used for testing too). Updated browse bar to not show input box on hover for objects that aren't createable.

closes #2634 

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Maybe
Changes have been smoke-tested? | Yes
Testing instructions included? | Updated