### PR TITLE
Improvements to Compass Rose and HUD

### DIFF
--- a/src/plugins/imagery/components/Compass/Compass.vue
+++ b/src/plugins/imagery/components/Compass/Compass.vue
@@ -26,18 +26,17 @@
     :style="compassDimensionsStyle"
 >
     <CompassHUD
-        v-if="shouldDisplayCompassHUD"
+        v-if="hasCameraFieldOfView"
         :heading="heading"
-        :roll="roll"
         :sun-heading="sunHeading"
-        :camera-field-of-view="cameraFieldOfView"
+        :camera-angle-of-view="cameraAngleOfView"
         :camera-pan="cameraPan"
     />
     <CompassRose
-        v-if="shouldDisplayCompassRose"
+        v-if="hasCameraFieldOfView"
         :heading="heading"
         :sun-heading="sunHeading"
-        :camera-field-of-view="cameraFieldOfView"
+        :camera-angle-of-view="cameraAngleOfView"
         :camera-pan="cameraPan"
     />
 </div>
@@ -47,7 +46,7 @@
 import CompassHUD from './CompassHUD.vue';
 import CompassRose from './CompassRose.vue';
 
-const CAM_FIELD_OF_VIEW = 70;
+const CAMERA_ANGLE_OF_VIEW = 70;
 
 export default {
     components: {
@@ -73,35 +72,29 @@ export default {
         }
     },
     computed: {
-        shouldDisplayCompassRose() {
-            return this.heading !== undefined;
+        hasCameraFieldOfView() {
+            return this.heading !== undefined && this.cameraPan !== undefined;
         },
-        shouldDisplayCompassHUD() {
-            return this.heading !== undefined;
-        },
-        // degrees from north heading
+        // compass direction from north in degrees
         heading() {
             return this.image.heading;
-        },
-        roll() {
-            return this.image.roll;
         },
         pitch() {
             return this.image.pitch;
         },
-        // degrees from north heading
+        // compass direction from north in degrees
         sunHeading() {
             return this.image.sunOrientation;
         },
-        // degrees from spacecraft heading
+        // relative direction from heading in degrees
         cameraPan() {
             return this.image.cameraPan;
         },
         cameraTilt() {
             return this.image.cameraTilt;
         },
-        cameraFieldOfView() {
-            return CAM_FIELD_OF_VIEW;
+        cameraAngleOfView() {
+            return CAMERA_ANGLE_OF_VIEW;
         },
         compassDimensionsStyle() {
             const containerAspectRatio = this.containerWidth / this.containerHeight;

--- a/src/plugins/imagery/components/Compass/Compass.vue
+++ b/src/plugins/imagery/components/Compass/Compass.vue
@@ -38,7 +38,7 @@
         :sun-heading="sunHeading"
         :camera-angle-of-view="cameraAngleOfView"
         :camera-pan="cameraPan"
-        :lock-bezel="lockBezel"
+        :lock-bezel="options.lock"
         @toggle-lock-bezel="toggleLockBezel"
     />
 </div>
@@ -71,12 +71,11 @@ export default {
         image: {
             type: Object,
             required: true
+        },
+        options: {
+            type: Object,
+            required: true
         }
-    },
-    data() {
-        return {
-            lockBezel: true
-        };
     },
     computed: {
         hasCameraFieldOfView() {
@@ -123,8 +122,10 @@ export default {
             };
         }
     },
-    toggleLockBezel() {
-        this.lockBezel = !this.lockBezel;
+    methods: {
+        toggleLockBezel() {
+            this.$emit('toggle-lock-compass');
+        }
     }
 };
 </script>

--- a/src/plugins/imagery/components/Compass/Compass.vue
+++ b/src/plugins/imagery/components/Compass/Compass.vue
@@ -38,6 +38,8 @@
         :sun-heading="sunHeading"
         :camera-angle-of-view="cameraAngleOfView"
         :camera-pan="cameraPan"
+        :lock-bezel="lockBezel"
+        @toggle-lock-bezel="toggleLockBezel"
     />
 </div>
 </template>
@@ -70,6 +72,11 @@ export default {
             type: Object,
             required: true
         }
+    },
+    data() {
+        return {
+            lockBezel: true
+        };
     },
     computed: {
         hasCameraFieldOfView() {
@@ -115,6 +122,9 @@ export default {
                 height: height
             };
         }
+    },
+    toggleLockBezel() {
+        this.lockBezel = !this.lockBezel;
     }
 };
 </script>

--- a/src/plugins/imagery/components/Compass/Compass.vue
+++ b/src/plugins/imagery/components/Compass/Compass.vue
@@ -38,8 +38,8 @@
         :sun-heading="sunHeading"
         :camera-angle-of-view="cameraAngleOfView"
         :camera-pan="cameraPan"
-        :lock-bezel="options.lock"
-        @toggle-lock-bezel="toggleLockBezel"
+        :lock-compass="lockCompass"
+        @toggle-lock-compass="toggleLockCompass"
     />
 </div>
 </template>
@@ -72,8 +72,8 @@ export default {
             type: Object,
             required: true
         },
-        options: {
-            type: Object,
+        lockCompass: {
+            type: Boolean,
             required: true
         }
     },
@@ -123,7 +123,7 @@ export default {
         }
     },
     methods: {
-        toggleLockBezel() {
+        toggleLockCompass() {
             this.$emit('toggle-lock-compass');
         }
     }

--- a/src/plugins/imagery/components/Compass/CompassHUD.vue
+++ b/src/plugins/imagery/components/Compass/CompassHUD.vue
@@ -118,20 +118,6 @@ export default {
         }
     },
     computed: {
-        /* only useful if combined with tilt to find horizon
-        skewCompassHUDStyle() {
-            if (this.roll === undefined || this.roll === 0) {
-                return;
-            }
-
-            const origin = this.roll > 0 ? 'left bottom' : 'right top';
-
-            return {
-                'transform-origin': origin,
-                transform: `skew(0, ${ this.roll }deg`
-            };
-        },
-        */
         visibleCompassPoints() {
             return COMPASS_POINTS
                 .filter(point => inRange(point.degrees, this.visibleRange))

--- a/src/plugins/imagery/components/Compass/CompassHUD.vue
+++ b/src/plugins/imagery/components/Compass/CompassHUD.vue
@@ -23,7 +23,6 @@
 <template>
 <div
     class="c-compass__hud c-hud"
-    :style="skewCompassHUDStyle"
 >
     <div
         v-for="point in visibleCompassPoints"
@@ -109,7 +108,7 @@ export default {
             type: Number,
             default: undefined
         },
-        cameraFieldOfView: {
+        cameraAngleOfView: {
             type: Number,
             default: undefined
         },
@@ -157,8 +156,8 @@ export default {
         },
         visibleRange() {
             return [
-                rotate(this.heading, this.cameraPan, -this.cameraFieldOfView / 2),
-                rotate(this.heading, this.cameraPan, this.cameraFieldOfView / 2)
+                rotate(this.heading, this.cameraPan, -this.cameraAngleOfView / 2),
+                rotate(this.heading, this.cameraPan, this.cameraAngleOfView / 2)
             ];
         }
     }

--- a/src/plugins/imagery/components/Compass/CompassHUD.vue
+++ b/src/plugins/imagery/components/Compass/CompassHUD.vue
@@ -45,7 +45,7 @@
 
 <script>
 import {
-    normalizeDegrees,
+    rotate,
     inRange,
     percentOfRange
 } from './utils';
@@ -99,10 +99,12 @@ export default {
             type: Number,
             required: true
         },
+        /* only useful if combined with tilt to find horizon
         roll: {
             type: Number,
             default: undefined
         },
+        */
         sunHeading: {
             type: Number,
             default: undefined
@@ -113,10 +115,11 @@ export default {
         },
         cameraPan: {
             type: Number,
-            default: undefined
+            required: true
         }
     },
     computed: {
+        /* only useful if combined with tilt to find horizon
         skewCompassHUDStyle() {
             if (this.roll === undefined || this.roll === 0) {
                 return;
@@ -129,6 +132,7 @@ export default {
                 transform: `skew(0, ${ this.roll }deg`
             };
         },
+        */
         visibleCompassPoints() {
             return COMPASS_POINTS
                 .filter(point => inRange(point.degrees, this.visibleRange))
@@ -142,28 +146,19 @@ export default {
                 });
         },
         isSunInRange() {
-            return inRange(this.normalizedSunHeading, this.visibleRange);
+            return inRange(this.sunHeading, this.visibleRange);
         },
         sunPositionStyle() {
-            const percentage = percentOfRange(this.normalizedSunHeading, this.visibleRange);
+            const percentage = percentOfRange(this.sunHeading, this.visibleRange);
 
             return {
                 left: `${ percentage * 100 }%`
             };
         },
-        normalizedSunHeading() {
-            return normalizeDegrees(this.sunHeading);
-        },
-        normalizedHeading() {
-            return normalizeDegrees(this.heading);
-        },
         visibleRange() {
-            const min = normalizeDegrees(this.normalizedHeading + this.cameraPan - this.cameraFieldOfView / 2);
-            const max = normalizeDegrees(this.normalizedHeading + this.cameraPan + this.cameraFieldOfView / 2);
-
             return [
-                min,
-                max
+                rotate(this.heading, this.cameraPan, -this.cameraFieldOfView / 2),
+                rotate(this.heading, this.cameraPan, this.cameraFieldOfView / 2)
             ];
         }
     }

--- a/src/plugins/imagery/components/Compass/CompassHUD.vue
+++ b/src/plugins/imagery/components/Compass/CompassHUD.vue
@@ -98,12 +98,6 @@ export default {
             type: Number,
             required: true
         },
-        /* only useful if combined with tilt to find horizon
-        roll: {
-            type: Number,
-            default: undefined
-        },
-        */
         sunHeading: {
             type: Number,
             default: undefined

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -169,15 +169,12 @@ export default {
         cameraPan: {
             type: Number,
             required: true
+        },
+        lockBezel: {
+            type: Boolean,
+            required: true
         }
     },
-
-    data() {
-        return {
-            lockBezel: true
-        };
-    },
-
     computed: {
         cameraHeading() {
             return rotate(this.heading, this.cameraPan);
@@ -259,7 +256,7 @@ export default {
     },
     methods: {
         toggleBezelLock() {
-            this.lockBezel = !this.lockBezel;
+            this.$emit('toggle-lock-bezel');
         }
     }
 };

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -23,7 +23,7 @@
 <template>
 <div
     class="c-direction-rose"
-    @click="toggleBezelLock"
+    @click="toggleLockBezel"
 >
     <div
         class="c-nsew"
@@ -162,7 +162,7 @@ export default {
             type: Number,
             default: undefined
         },
-        cameraFieldOfView: {
+        cameraAngleOfView: {
             type: Number,
             default: undefined
         },
@@ -237,25 +237,25 @@ export default {
             };
         },
         showCameraFOV() {
-            return this.cameraPan !== undefined && this.cameraFieldOfView > 0;
+            return this.cameraPan !== undefined && this.cameraAngleOfView > 0;
         },
         // left half of camera field of view
         // rotated counter-clockwise from camera field of view heading
         cameraFOVStyleLeftHalf() {
             return {
-                transform: `translateX(50%) rotate(${ -this.cameraFieldOfView / 2 }deg)`
+                transform: `translateX(50%) rotate(${ -this.cameraAngleOfView / 2 }deg)`
             };
         },
         // right half of camera field of view
         // rotated clockwise from camera field of view heading
         cameraFOVStyleRightHalf() {
             return {
-                transform: `translateX(-50%) rotate(${ this.cameraFieldOfView / 2 }deg)`
+                transform: `translateX(-50%) rotate(${ this.cameraAngleOfView / 2 }deg)`
             };
         }
     },
     methods: {
-        toggleBezelLock() {
+        toggleLockBezel() {
             this.$emit('toggle-lock-bezel');
         }
     }

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -23,7 +23,7 @@
 <template>
 <div
     class="c-direction-rose"
-    @click="toggleLockBezel"
+    @click="toggleLockCompass"
 >
     <div
         class="c-nsew"
@@ -170,7 +170,7 @@ export default {
             type: Number,
             required: true
         },
-        lockBezel: {
+        lockCompass: {
             type: Boolean,
             required: true
         }
@@ -180,7 +180,7 @@ export default {
             return rotate(this.heading, this.cameraPan);
         },
         compassHeading() {
-            return this.lockBezel ? this.cameraHeading : 0;
+            return this.lockCompass ? this.cameraHeading : 0;
         },
         north() {
             return rotate(this.compassHeading, -this.cameraHeading);
@@ -255,8 +255,8 @@ export default {
         }
     },
     methods: {
-        toggleLockBezel() {
-            this.$emit('toggle-lock-bezel');
+        toggleLockCompass() {
+            this.$emit('toggle-lock-compass');
         }
     }
 };

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -131,7 +131,7 @@
     <div
         v-if="showCameraFOV"
         class="c-cam-field"
-        :style="cameraFOVHeadingStyle"
+        :style="cameraHeadingStyle"
     >
         <div class="cam-field-half cam-field-half-l">
             <div
@@ -150,7 +150,7 @@
 </template>
 
 <script>
-import { normalizeDegrees } from './utils';
+import { rotate } from './utils';
 
 export default {
     props: {
@@ -168,7 +168,7 @@ export default {
         },
         cameraPan: {
             type: Number,
-            default: undefined
+            required: true
         }
     },
 
@@ -179,11 +179,14 @@ export default {
     },
 
     computed: {
+        cameraHeading() {
+            return rotate(this.heading, this.cameraPan);
+        },
         compassHeading() {
-            return this.lockBezel ? normalizeDegrees(this.heading) : 0;
+            return this.lockBezel ? this.cameraHeading : 0;
         },
         north() {
-            return normalizeDegrees(this.compassHeading - this.heading);
+            return rotate(this.compassHeading, -this.cameraHeading);
         },
         rotateFrameStyle() {
             return { transform: `rotate(${ this.north }deg)` };
@@ -216,20 +219,21 @@ export default {
             };
         },
         headingStyle() {
+            const rotation = rotate(this.north, this.heading);
+
             return {
-                transform: `translateX(-50%) rotate(${ this.compassHeading }deg)`
+                transform: `translateX(-50%) rotate(${ rotation }deg)`
             };
         },
-        cameraFOVHeading() {
-            return this.compassHeading + this.cameraPan;
-        },
-        cameraFOVHeadingStyle() {
+        cameraHeadingStyle() {
+            const rotation = rotate(this.north, this.cameraHeading);
+
             return {
-                transform: `rotate(${ this.cameraFOVHeading }deg)`
+                transform: `rotate(${ rotation }deg)`
             };
         },
         sunHeadingStyle() {
-            const rotation = normalizeDegrees(this.north + this.sunHeading);
+            const rotation = rotate(this.north, this.sunHeading);
 
             return {
                 transform: `rotate(${ rotation }deg)`

--- a/src/plugins/imagery/components/Compass/utils.js
+++ b/src/plugins/imagery/components/Compass/utils.js
@@ -1,4 +1,10 @@
-export function normalizeDegrees(degrees) {
+export function rotate(direction, ...rotations) {
+    const rotation = rotations.reduce((a, b) => a + b, 0);
+
+    return normalizeCompassDirection(direction + rotation);
+}
+
+export function normalizeCompassDirection(degrees) {
     const base = degrees % 360;
 
     return base >= 0 ? base : 360 + base;
@@ -24,21 +30,4 @@ export function percentOfRange(degrees, [min, max]) {
     }
 
     return (distance - minRange) / (maxRange - minRange);
-}
-
-export function normalizeSemiCircleDegrees(rawDegrees) {
-    // in case tony hawk is providing us degrees
-    let degrees = rawDegrees % 360;
-
-    // westward degrees are between 0 and -180 exclusively
-    if (degrees > 180) {
-        degrees = degrees - 360;
-    }
-
-    // eastward degrees are between 0 and 180 inclusively
-    if (degrees <= -180) {
-        degrees = 360 - degrees;
-    }
-
-    return degrees;
 }

--- a/src/plugins/imagery/components/ImageryViewLayout.vue
+++ b/src/plugins/imagery/components/ImageryViewLayout.vue
@@ -74,6 +74,8 @@
                 :container-height="imageContainerHeight"
                 :natural-aspect-ratio="focusedImageNaturalAspectRatio"
                 :image="focusedImage"
+                :options="compass"
+                @toggle-lock-compass="toggleLockCompass"
             />
         </div>
         <div class="c-local-controls c-local-controls--show-on-hover c-imagery__prev-next-buttons">
@@ -196,7 +198,11 @@ export default {
             latestRelatedTelemetry: {},
             focusedImageNaturalAspectRatio: undefined,
             imageContainerWidth: undefined,
-            imageContainerHeight: undefined
+            imageContainerHeight: undefined,
+            compass: {
+                display: true, // for manual disabling if obtrusive
+                lock: true // lock compass rose to camera view
+            }
         };
     },
     computed: {
@@ -763,6 +769,9 @@ export default {
             if (this.$refs.focusedImage.clientHeight !== this.imageContainerHeight) {
                 this.imageContainerHeight = this.$refs.focusedImage.clientHeight;
             }
+        },
+        toggleLockCompass() {
+            this.compass.lock = !this.compass.lock;
         }
     }
 };

--- a/src/plugins/imagery/components/ImageryViewLayout.vue
+++ b/src/plugins/imagery/components/ImageryViewLayout.vue
@@ -74,7 +74,7 @@
                 :container-height="imageContainerHeight"
                 :natural-aspect-ratio="focusedImageNaturalAspectRatio"
                 :image="focusedImage"
-                :options="compass"
+                :lock-compass="lockCompass"
                 @toggle-lock-compass="toggleLockCompass"
             />
         </div>
@@ -199,10 +199,7 @@ export default {
             focusedImageNaturalAspectRatio: undefined,
             imageContainerWidth: undefined,
             imageContainerHeight: undefined,
-            compass: {
-                display: true, // for manual disabling if obtrusive
-                lock: true // lock compass rose to camera view
-            }
+            lockCompass: true
         };
     },
     computed: {
@@ -771,7 +768,7 @@ export default {
             }
         },
         toggleLockCompass() {
-            this.compass.lock = !this.compass.lock;
+            this.lockCompass = !this.lockCompass;
         }
     }
 };


### PR DESCRIPTION
* Flatten HUD (not intended for horizon line)
* Lock bezel should lock to camera FOV, not rover heading
* Lock bezel should persist for imagery view lifetimed