### PR TITLE
Pinch to zoom and wheel zoom work the same way

### DIFF
--- a/src/plugins/plot/src/plot/MCTPlotController.js
+++ b/src/plugins/plot/src/plot/MCTPlotController.js
@@ -413,6 +413,21 @@ define([
             return;
         }
 
+        const isPinchToZoom = event.ctrlKey === true;
+        let isZoomIn = event.wheelDelta < 0;
+        let isZoomOut = event.wheelDelta >= 0;
+
+        //Flip the zoom direction if this is pinch to zoom
+        if (isPinchToZoom) {
+            if (isZoomIn === true) {
+                isZoomOut = true;
+                isZoomIn = false;
+            } else if (isZoomOut === true) {
+                isZoomIn = true;
+                isZoomOut = false;
+            }
+        }
+
         let xDisplayRange = this.$scope.xAxis.get('displayRange');
         let yDisplayRange = this.$scope.yAxis.get('displayRange');
 
@@ -445,7 +460,7 @@ define([
             };
         }
 
-        if (event.wheelDelta < 0) {
+        if (isZoomIn) {
 
             this.$scope.xAxis.set('displayRange', {
                 min: xDisplayRange.min + ((xAxisDist * ZOOM_AMT) * xAxisMinDist),
@@ -456,7 +471,7 @@ define([
                 min: yDisplayRange.min + ((yAxisDist * ZOOM_AMT) * yAxisMinDist),
                 max: yDisplayRange.max - ((yAxisDist * ZOOM_AMT) * yAxisMaxDist)
             });
-        } else if (event.wheelDelta >= 0) {
+        } else if (isZoomOut) {
 
             this.$scope.xAxis.set('displayRange', {
                 min: xDisplayRange.min - ((xAxisDist * ZOOM_AMT) * xAxisMinDist),


### PR DESCRIPTION
Use wheel event + ctrl key to identify a pinch gesture and invert the zoom direction.
Resolves: #3631

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y