### PR TITLE
[Notebook] Fix incorrectly deleting page from sidebar

### DIFF
--- a/src/plugins/notebook/components/PageCollection.vue
+++ b/src/plugins/notebook/components/PageCollection.vue
@@ -69,7 +69,7 @@ export default {
     methods: {
         deletePage(id) {
             const selectedSection = this.sections.find(s => s.isSelected);
-            const page = this.pages.find(p => p.id !== id);
+            const page = this.pages.find(p => p.id === id);
             deleteNotebookEntries(this.openmct, this.domainObject, selectedSection, page);
 
             const selectedPage = this.pages.find(p => p.isSelected);


### PR DESCRIPTION
Looks like an array find was being treated as a filter, was resulting in the first page's entry of a section being deleted no mater what page was removed.

### Author Checklist
Check | Passed
-- | --
Changes address original issue? | Y
Unit tests included and/or updated with changes? | N/A
Command line build passes? | Y
Changes have been smoke-tested? | Y
Testing instructions included? | Y

closes #3753
