### PR TITLE
[VIPEROMCT-41] Criteria evaluation when telemetry data arrives

### DIFF
--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -82,7 +82,9 @@ export default class Condition extends EventEmitter {
                 if (this.isAnyOrAllTelemetry(criterion)) {
                     criterion.updateResult(datum, this.conditionManager.telemetryObjects);
                 } else {
-                    criterion.updateResult(datum);
+                    if (criterion.usesTelemetry(datum.id)) {
+                        criterion.updateResult(datum);
+                    }
                 }
             });
 
@@ -102,7 +104,7 @@ export default class Condition extends EventEmitter {
 
     isTelemetryUsed(id) {
         return this.criteria.some(criterion => {
-            return this.isAnyOrAllTelemetry(criterion) || criterion.telemetryObjectIdAsString === id;
+            return this.isAnyOrAllTelemetry(criterion) || criterion.usesTelemetry(id);
         });
     }
 

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -58,6 +58,10 @@ export default class TelemetryCriterion extends EventEmitter {
         }
     }
 
+    usesTelemetry(id) {
+        return this.telemetryObjectIdAsString && (this.telemetryObjectIdAsString === id);
+    }
+
     subscribeForStaleData() {
         if (this.stalenessSubscription) {
             this.stalenessSubscription.clear();


### PR DESCRIPTION
When new telemetry data arrives only evaluate criteria that use that telemetry endpoint.
Resolves [VIPEROMCT-41]

### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y (See VIPEROMCT-41)
