### PR TITLE
[#3789] Destroy mutable objects only if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "1.6.3-SNAPSHOT",
+  "version": "1.7.1-SNAPSHOT",
   "description": "The Open MCT core platform",
   "dependencies": {},
   "devDependencies": {

--- a/src/api/objects/MutableDomainObject.js
+++ b/src/api/objects/MutableDomainObject.js
@@ -112,12 +112,11 @@ class MutableDomainObject {
         return () => this._instanceEventEmitter.off(event, callback);
     }
     $destroy() {
-        this._observers.forEach(observer => observer());
-        //TODO: the following deletes will not work since they're not configurable properties.
-        // Also, this._globalEventEmitter doesn't seem to change after the above observer listeners are 'removed'
-        // Also, probably need to pop items off this._observers here or the items will remain on the array.
-        delete this._globalEventEmitter;
-        delete this._observers;
+        while (this._observers.length > 0) {
+            const observer = this._observers.pop();
+            observer();
+        }
+
         this._instanceEventEmitter.emit('$_destroy');
     }
 

--- a/src/api/objects/MutableDomainObject.js
+++ b/src/api/objects/MutableDomainObject.js
@@ -113,6 +113,9 @@ class MutableDomainObject {
     }
     $destroy() {
         this._observers.forEach(observer => observer());
+        //TODO: the following deletes will not work since they're not configurable properties.
+        // Also, this._globalEventEmitter doesn't seem to change after the above observer listeners are 'removed'
+        // Also, probably need to pop items off this._observers here or the items will remain on the array.
         delete this._globalEventEmitter;
         delete this._observers;
         this._instanceEventEmitter.emit('$_destroy');

--- a/src/plugins/filters/components/FiltersView.vue
+++ b/src/plugins/filters/components/FiltersView.vue
@@ -90,20 +90,12 @@ export default {
         this.composition.load();
         this.unobserve = this.openmct.objects.observe(this.providedObject, 'configuration.filters', this.updatePersistedFilters);
         this.unobserveGlobalFilters = this.openmct.objects.observe(this.providedObject, 'configuration.globalFilters', this.updateGlobalFilters);
-        if (this.providedObject.isMutable !== true) {
-            this.unobserveAllMutation = this.openmct.objects.observe(this.providedObject, '*', (mutatedObject) => {
-                this.providedObject = mutatedObject;
-            });
-        }
     },
     beforeDestroy() {
         this.composition.off('add', this.addChildren);
         this.composition.off('remove', this.removeChildren);
         this.unobserve();
         this.unobserveGlobalFilters();
-        if (this.unobserveAllMutation) {
-            this.unobserveAllMutation();
-        }
     },
     methods: {
         addChildren(domainObject) {

--- a/src/plugins/plot/src/configuration/PlotSeries.js
+++ b/src/plugins/plot/src/configuration/PlotSeries.js
@@ -413,6 +413,10 @@ define([
          * @public
          */
         updateFiltersAndRefresh: function (updatedFilters) {
+            if (updatedFilters === undefined) {
+                return;
+            }
+
             let deepCopiedFilters = JSON.parse(JSON.stringify(updatedFilters));
 
             if (this.filters && !_.isEqual(this.filters, deepCopiedFilters)) {

--- a/src/plugins/plot/vue/single/configuration/PlotSeries.js
+++ b/src/plugins/plot/vue/single/configuration/PlotSeries.js
@@ -403,6 +403,10 @@ export default class PlotSeries extends Model {
      * @public
      */
     updateFiltersAndRefresh(updatedFilters) {
+        if (updatedFilters === undefined) {
+            return;
+        }
+
         let deepCopiedFilters = JSON.parse(JSON.stringify(updatedFilters));
 
         if (this.filters && !_.isEqual(this.filters, deepCopiedFilters)) {

--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -222,11 +222,15 @@ define([
         getColumnMapForObject(objectKeyString) {
             let columns = this.configuration.getColumns();
 
-            return columns[objectKeyString].reduce((map, column) => {
-                map[column.getKey()] = column;
+            if (columns[objectKeyString]) {
+                return columns[objectKeyString].reduce((map, column) => {
+                    map[column.getKey()] = column;
 
-                return map;
-            }, {});
+                    return map;
+                }, {});
+            }
+
+            return {};
         }
 
         addColumnsForObject(telemetryObject) {

--- a/src/plugins/telemetryTable/TelemetryTableConfiguration.js
+++ b/src/plugins/telemetryTable/TelemetryTableConfiguration.js
@@ -37,10 +37,6 @@ define([
             this.objectMutated = this.objectMutated.bind(this);
             //Make copy of configuration, otherwise change detection is impossible if shared instance is being modified.
             this.oldConfiguration = JSON.parse(JSON.stringify(this.getConfiguration()));
-
-            if (domainObject.isMutable !== true) {
-                this.unlistenFromMutation = openmct.objects.observe(domainObject, '*', this.objectMutated);
-            }
         }
 
         getConfiguration() {
@@ -164,12 +160,6 @@ define([
             let configuration = this.getConfiguration();
             configuration.columnOrder = columnOrder;
             this.updateConfiguration(configuration);
-        }
-
-        destroy() {
-            if (this.unlistenFromMutation) {
-                this.unlistenFromMutation();
-            }
         }
     }
 

--- a/src/plugins/telemetryTable/TelemetryTableConfiguration.js
+++ b/src/plugins/telemetryTable/TelemetryTableConfiguration.js
@@ -38,7 +38,9 @@ define([
             //Make copy of configuration, otherwise change detection is impossible if shared instance is being modified.
             this.oldConfiguration = JSON.parse(JSON.stringify(this.getConfiguration()));
 
-            this.unlistenFromMutation = openmct.objects.observe(domainObject, '*', this.objectMutated);
+            if (domainObject.isMutable !== true) {
+                this.unlistenFromMutation = openmct.objects.observe(domainObject, '*', this.objectMutated);
+            }
         }
 
         getConfiguration() {
@@ -165,7 +167,9 @@ define([
         }
 
         destroy() {
-            this.unlistenFromMutation();
+            if (this.unlistenFromMutation) {
+                this.unlistenFromMutation();
+            }
         }
     }
 

--- a/src/plugins/telemetryTable/TelemetryTableConfiguration.js
+++ b/src/plugins/telemetryTable/TelemetryTableConfiguration.js
@@ -161,6 +161,8 @@ define([
             configuration.columnOrder = columnOrder;
             this.updateConfiguration(configuration);
         }
+
+        destroy() {}
     }
 
     return TelemetryTableConfiguration;

--- a/src/selection/Selection.js
+++ b/src/selection/Selection.js
@@ -237,11 +237,13 @@ define(
 
             const capture = this.capture.bind(this, selectable);
             const selectCapture = this.selectCapture.bind(this, selectable);
+            let removeMutable = false;
 
             element.addEventListener('click', capture, true);
             element.addEventListener('click', selectCapture);
 
-            if (context.item) {
+            if (context.item && context.item.isMutable !== true) {
+                removeMutable = true;
                 context.item = this.openmct.objects._toMutable(context.item);
             }
 
@@ -257,7 +259,7 @@ define(
                 element.removeEventListener('click', capture, true);
                 element.removeEventListener('click', selectCapture);
 
-                if (context.item !== undefined && context.item.isMutable) {
+                if (context.item !== undefined && context.item.isMutable && removeMutable === true) {
                     this.openmct.objects.destroyMutable(context.item);
                 }
             }).bind(this);


### PR DESCRIPTION
The Selection API was removing mutable listeners when the inspector view was dismissed even if it didn't create the mutable. This was resulting in the mutables not staying in sync.
The Selection API now only destroys mutables if it creates one. While this works, it is likely a localized fix and the MutableDomainObject.$destroy API probably needs to be looked at again. (See comments in the file)

Resolves #3789 


### Author Checklist

1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y


