### PR TITLE
3745 - [Imagery] Remove roll and pitch as required keys for orientation

### DIFF
--- a/src/plugins/imagery/components/Compass/pluginSpec.js
+++ b/src/plugins/imagery/components/Compass/pluginSpec.js
@@ -32,8 +32,6 @@ describe("The Compass component", () => {
     beforeEach(() => {
         let imageDatum = {
             heading: 100,
-            roll: 90,
-            pitch: 90,
             cameraTilt: 100,
             cameraPan: 90,
             sunAngle: 30

--- a/src/plugins/imagery/pluginSpec.js
+++ b/src/plugins/imagery/pluginSpec.js
@@ -128,20 +128,6 @@ describe("The Imagery View Layout", () => {
                                 "valueKey": "value"
                             }
                         },
-                        "roll": {
-                            "comparisonFunction": comparisonFunction,
-                            "historical": {
-                                "telemetryObjectId": "roll",
-                                "valueKey": "value"
-                            }
-                        },
-                        "pitch": {
-                            "comparisonFunction": comparisonFunction,
-                            "historical": {
-                                "telemetryObjectId": "pitch",
-                                "valueKey": "value"
-                            }
-                        },
                         "cameraPan": {
                             "comparisonFunction": comparisonFunction,
                             "historical": {


### PR DESCRIPTION
Resolves: #3745 