### PR TITLE
Dynamic sizing for compass rose based on image size

### DIFF
--- a/src/plugins/imagery/components/Compass/Compass.vue
+++ b/src/plugins/imagery/components/Compass/Compass.vue
@@ -79,17 +79,18 @@ export default {
     },
     computed: {
         sizedImageDimensions() {
-            let dim = {};
+            let sizedImageDimensions = {};
             if ((this.containerWidth / this.containerHeight) > this.naturalAspectRatio) {
                 // container is wider than image
-                dim.width = this.containerHeight * this.naturalAspectRatio;
-                dim.height = this.containerHeight;
+                sizedImageDimensions.width = this.containerHeight * this.naturalAspectRatio;
+                sizedImageDimensions.height = this.containerHeight;
             } else {
                 // container is taller than image
-                dim.width = this.containerWidth;
-                dim.height = this.containerWidth * this.naturalAspectRatio;
+                sizedImageDimensions.width = this.containerWidth;
+                sizedImageDimensions.height = this.containerWidth * this.naturalAspectRatio;
             }
-            return dim;
+
+            return sizedImageDimensions;
         },
         hasCameraFieldOfView() {
             return this.cameraPan !== undefined && this.cameraAngleOfView > 0;

--- a/src/plugins/imagery/components/Compass/Compass.vue
+++ b/src/plugins/imagery/components/Compass/Compass.vue
@@ -23,7 +23,7 @@
 <template>
 <div
     class="c-compass"
-    :style="compassDimensionsStyle"
+    :style="`width: ${ sizedImageDimensions.width }px; height: ${ sizedImageDimensions.height }px`"
 >
     <CompassHUD
         v-if="hasCameraFieldOfView"
@@ -34,6 +34,7 @@
     <CompassRose
         v-if="hasCameraFieldOfView"
         :heading="heading"
+        :sized-image-width="sizedImageDimensions.width"
         :sun-heading="sunHeading"
         :camera-angle-of-view="cameraAngleOfView"
         :camera-pan="cameraPan"
@@ -77,6 +78,19 @@ export default {
         }
     },
     computed: {
+        sizedImageDimensions() {
+            let dim = {};
+            if ((this.containerWidth / this.containerHeight) > this.naturalAspectRatio) {
+                // container is wider than image
+                dim.width = this.containerHeight * this.naturalAspectRatio;
+                dim.height = this.containerHeight;
+            } else {
+                // container is taller than image
+                dim.width = this.containerWidth;
+                dim.height = this.containerWidth * this.naturalAspectRatio;
+            }
+            return dim;
+        },
         hasCameraFieldOfView() {
             return this.cameraPan !== undefined && this.cameraAngleOfView > 0;
         },
@@ -94,25 +108,6 @@ export default {
         },
         cameraAngleOfView() {
             return CAMERA_ANGLE_OF_VIEW;
-        },
-        compassDimensionsStyle() {
-            const containerAspectRatio = this.containerWidth / this.containerHeight;
-
-            let width;
-            let height;
-
-            if (containerAspectRatio < this.naturalAspectRatio) {
-                width = '100%';
-                height = `${ this.containerWidth / this.naturalAspectRatio }px`;
-            } else {
-                width = `${ this.containerHeight * this.naturalAspectRatio }px`;
-                height = '100%';
-            }
-
-            return {
-                width: width,
-                height: height
-            };
         }
     },
     methods: {

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -21,130 +21,133 @@
  *****************************************************************************/
 
 <template>
-<div
-    class="c-direction-rose"
-    @click="toggleLockCompass"
->
+<div class="w-direction-rose"
+     :class="compassRoseSizing">
     <div
-        class="c-nsew"
-        :style="compassRoseStyle"
+        class="c-direction-rose"
+        @click="toggleLockCompass"
     >
-        <svg
-            class="c-nsew__minor-ticks"
-            viewBox="0 0 100 100"
+        <div
+            class="c-nsew"
+            :style="compassRoseStyle"
         >
-            <rect
-                class="c-nsew__tick c-tick-ne"
-                x="49"
-                y="0"
-                width="2"
-                height="5"
-            />
-            <rect
-                class="c-nsew__tick c-tick-se"
-                x="95"
-                y="49"
-                width="5"
-                height="2"
-            />
-            <rect
-                class="c-nsew__tick c-tick-sw"
-                x="49"
-                y="95"
-                width="2"
-                height="5"
-            />
-            <rect
-                class="c-nsew__tick c-tick-nw"
-                x="0"
-                y="49"
-                width="5"
-                height="2"
-            />
+            <svg
+                class="c-nsew__minor-ticks"
+                viewBox="0 0 100 100"
+            >
+                <rect
+                    class="c-nsew__tick c-tick-ne"
+                    x="49"
+                    y="0"
+                    width="2"
+                    height="5"
+                />
+                <rect
+                    class="c-nsew__tick c-tick-se"
+                    x="95"
+                    y="49"
+                    width="5"
+                    height="2"
+                />
+                <rect
+                    class="c-nsew__tick c-tick-sw"
+                    x="49"
+                    y="95"
+                    width="2"
+                    height="5"
+                />
+                <rect
+                    class="c-nsew__tick c-tick-nw"
+                    x="0"
+                    y="49"
+                    width="5"
+                    height="2"
+                />
 
-        </svg>
+            </svg>
 
-        <svg
-            class="c-nsew__ticks"
-            viewBox="0 0 100 100"
-        >
-            <polygon
-                class="c-nsew__tick c-tick-n"
-                points="50,0 57,5 43,5"
-            />
-            <rect
-                class="c-nsew__tick c-tick-e"
-                x="95"
-                y="49"
-                width="5"
-                height="2"
-            />
-            <rect
-                class="c-nsew__tick c-tick-w"
-                x="0"
-                y="49"
-                width="5"
-                height="2"
-            />
-            <rect
-                class="c-nsew__tick c-tick-s"
-                x="49"
-                y="95"
-                width="2"
-                height="5"
-            />
+            <svg
+                class="c-nsew__ticks"
+                viewBox="0 0 100 100"
+            >
+                <polygon
+                    class="c-nsew__tick c-tick-n"
+                    points="50,0 60,10 40,10"
+                />
+                <rect
+                    class="c-nsew__tick c-tick-e"
+                    x="95"
+                    y="49"
+                    width="5"
+                    height="2"
+                />
+                <rect
+                    class="c-nsew__tick c-tick-w"
+                    x="0"
+                    y="49"
+                    width="5"
+                    height="2"
+                />
+                <rect
+                    class="c-nsew__tick c-tick-s"
+                    x="49"
+                    y="95"
+                    width="2"
+                    height="5"
+                />
 
-            <text
-                class="c-nsew__label c-label-n"
-                text-anchor="middle"
-                :transform="northTextTransform"
-            >N</text>
-            <text
-                class="c-nsew__label c-label-e"
-                text-anchor="middle"
-                :transform="eastTextTransform"
-            >E</text>
-            <text
-                class="c-nsew__label c-label-w"
-                text-anchor="middle"
-                :transform="southTextTransform"
-            >W</text>
-            <text
-                class="c-nsew__label c-label-s"
-                text-anchor="middle"
-                :transform="westTextTransform"
-            >S</text>
-        </svg>
-    </div>
-
-    <div
-        v-if="hasHeading"
-        class="c-spacecraft-body"
-        :style="headingStyle"
-    >
-    </div>
-
-    <div
-        v-if="hasSunHeading"
-        class="c-sun"
-        :style="sunHeadingStyle"
-    ></div>
-
-    <div
-        class="c-cam-field"
-        :style="cameraPanStyle"
-    >
-        <div class="cam-field-half cam-field-half-l">
-            <div
-                class="cam-field-area"
-                :style="cameraFOVStyleLeftHalf"
-            ></div>
+                <text
+                    class="c-nsew__label c-label-n"
+                    text-anchor="middle"
+                    :transform="northTextTransform"
+                >N</text>
+                <text
+                    class="c-nsew__label c-label-e"
+                    text-anchor="middle"
+                    :transform="eastTextTransform"
+                >E</text>
+                <text
+                    class="c-nsew__label c-label-w"
+                    text-anchor="middle"
+                    :transform="southTextTransform"
+                >W</text>
+                <text
+                    class="c-nsew__label c-label-s"
+                    text-anchor="middle"
+                    :transform="westTextTransform"
+                >S</text>
+            </svg>
         </div>
-        <div class="cam-field-half cam-field-half-r">
-            <div
-                class="cam-field-area"
-                :style="cameraFOVStyleRightHalf"
-            ></div>
+
+        <div
+            v-if="hasHeading"
+            class="c-spacecraft-body"
+            :style="headingStyle"
+        >
+        </div>
+
+        <div
+            v-if="hasSunHeading"
+            class="c-sun"
+            :style="sunHeadingStyle"
+        ></div>
+
+        <div
+            class="c-cam-field"
+            :style="cameraPanStyle"
+        >
+            <div class="cam-field-half cam-field-half-l">
+                <div
+                    class="cam-field-area"
+                    :style="cameraFOVStyleLeftHalf"
+                ></div>
+            </div>
+            <div class="cam-field-half cam-field-half-r">
+                <div
+                    class="cam-field-area"
+                    :style="cameraFOVStyleRightHalf"
+                ></div>
+            </div>
         </div>
     </div>
 </div>
@@ -155,6 +158,10 @@ import { rotate } from './utils';
 
 export default {
     props: {
+        sizedImageWidth: {
+            type: Number,
+            required: true
+        },
         heading: {
             type: Number,
             required: true
@@ -177,11 +184,22 @@ export default {
         }
     },
     computed: {
-        north() {
-            return this.lockCompass ? rotate(-this.cameraPan) : 0;
+        compassRoseSizing() {
+            if (this.sizedImageWidth < 300) {
+                return '--rose-small --rose-min';
+            }
+            if (this.sizedImageWidth < 500) {
+                return '--rose-small';
+            }
+            if (this.sizedImageWidth > 1000) {
+                return '--rose-max';
+            }
         },
         compassRoseStyle() {
             return { transform: `rotate(${ this.north }deg)` };
+        },
+        north() {
+            return this.lockCompass ? rotate(-this.cameraPan) : 0;
         },
         northTextTransform() {
             return this.cardinalPointsTextTransform.north;
@@ -204,10 +222,10 @@ export default {
             const rotation = `rotate(${ -this.north })`;
 
             return {
-                north: `translate(50,15) ${ rotation }`,
-                east: `translate(87,50) ${ rotation }`,
-                south: `translate(13,50) ${ rotation }`,
-                west: `translate(50,87) ${ rotation }`
+                north: `translate(50,23) ${ rotation }`,
+                east: `translate(82,50) ${ rotation }`,
+                south: `translate(18,50) ${ rotation }`,
+                west: `translate(50,82) ${ rotation }`
             };
         },
         hasHeading() {

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -21,8 +21,9 @@
  *****************************************************************************/
 
 <template>
-<div class="w-direction-rose"
-     :class="compassRoseSizing"
+<div
+    class="w-direction-rose"
+    :class="compassRoseSizingClasses"
 >
     <div
         class="c-direction-rose"
@@ -185,21 +186,17 @@ export default {
         }
     },
     computed: {
-        compassRoseSizing() {
-            let compassRoseSizing = '';
+        compassRoseSizingClasses() {
+            let compassRoseSizingClasses = '';
             if (this.sizedImageWidth < 300) {
-                compassRoseSizing = '--rose-small --rose-min';
+                compassRoseSizingClasses = '--rose-small --rose-min';
+            } else if (this.sizedImageWidth < 500) {
+                compassRoseSizingClasses = '--rose-small';
+            } else if (this.sizedImageWidth > 1000) {
+                compassRoseSizingClasses = '--rose-max';
             }
 
-            if (this.sizedImageWidth < 500) {
-                compassRoseSizing = '--rose-small';
-            }
-
-            if (this.sizedImageWidth > 1000) {
-                compassRoseSizing = '--rose-max';
-            }
-
-            return compassRoseSizing;
+            return compassRoseSizingClasses;
         },
         compassRoseStyle() {
             return { transform: `rotate(${ this.north }deg)` };

--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -22,7 +22,8 @@
 
 <template>
 <div class="w-direction-rose"
-     :class="compassRoseSizing">
+     :class="compassRoseSizing"
+>
     <div
         class="c-direction-rose"
         @click="toggleLockCompass"
@@ -185,15 +186,20 @@ export default {
     },
     computed: {
         compassRoseSizing() {
+            let compassRoseSizing = '';
             if (this.sizedImageWidth < 300) {
-                return '--rose-small --rose-min';
+                compassRoseSizing = '--rose-small --rose-min';
             }
+
             if (this.sizedImageWidth < 500) {
-                return '--rose-small';
+                compassRoseSizing = '--rose-small';
             }
+
             if (this.sizedImageWidth > 1000) {
-                return '--rose-max';
+                compassRoseSizing = '--rose-max';
             }
+
+            return compassRoseSizing;
         },
         compassRoseStyle() {
             return { transform: `rotate(${ this.north }deg)` };

--- a/src/plugins/imagery/components/Compass/compass.scss
+++ b/src/plugins/imagery/components/Compass/compass.scss
@@ -20,195 +20,252 @@ $elemBg: rgba(black, 0.7);
 
 /***************************** COMPASS HUD */
 .c-hud {
-  // To be placed within a imagery view, in the bounding box of the image
-  $m: 1px;
-  $padTB: 2px;
-  $padLR: $padTB;
-  color: $interfaceKeyColor;
-  font-size: 0.8em;
-  position: absolute;
-  top: $m; right: $m; left: $m;
-  height: 18px;
-
-  svg, div {
+    // To be placed within a imagery view, in the bounding box of the image
+    $m: 1px;
+    $padTB: 2px;
+    $padLR: $padTB;
+    color: $interfaceKeyColor;
+    font-size: 0.8em;
     position: absolute;
-  }
+    top: $m;
+    right: $m;
+    left: $m;
+    height: 18px;
 
-  &__display {
-      height: 30px;
-      pointer-events: all;
-      position: absolute;
-      top: 0;
-      right: 0;
-      left: 0;
-  }
+    svg, div {
+        position: absolute;
+    }
 
-  &__range {
-    border: 1px solid $interfaceKeyColor;
-    border-top-color: transparent;
-    position: absolute;
-    top: 50%; right: $padLR; bottom: $padTB; left: $padLR;
-  }
+    &__display {
+        height: 30px;
+        pointer-events: all;
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+    }
 
-  [class*="__dir"] {
-    // NSEW
-    display: inline-block;
-    font-weight: bold;
-    text-shadow: 0 1px 2px black;
-    top: 50%;
-    transform: translate(-50%,-50%);
-    z-index: 2;
-  }
+    &__range {
+        border: 1px solid $interfaceKeyColor;
+        border-top-color: transparent;
+        position: absolute;
+        top: 50%;
+        right: $padLR;
+        bottom: $padTB;
+        left: $padLR;
+    }
 
-  [class*="__dir--sub"] {
-    font-weight: normal;
-    opacity: 0.5;
-  }
+    [class*="__dir"] {
+        // NSEW
+        display: inline-block;
+        font-weight: bold;
+        text-shadow: 0 1px 2px black;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 2;
+    }
 
-  &__sun {
-    $s: 10px;
-    @include sun('circle farthest-side at bottom');
-    bottom: $padTB + 2px;
-    height: $s; width: $s*2;
-    opacity: 0.8;
-    transform: translateX(-50%);
-    z-index: 1;
-  }
+    [class*="__dir--sub"] {
+        font-weight: normal;
+        opacity: 0.5;
+    }
+
+    &__sun {
+        $s: 10px;
+        @include sun('circle farthest-side at bottom');
+        bottom: $padTB + 2px;
+        height: $s;
+        width: $s*2;
+        opacity: 0.8;
+        transform: translateX(-50%);
+        z-index: 1;
+    }
 
 }
 
 /***************************** COMPASS DIRECTIONS */
 .c-nsew {
-  $color: $interfaceKeyColor;
-  $inset: 7%;
-  $tickHeightPerc: 15%;
-  text-shadow: black 0 0 10px;
-  top: $inset; right: $inset; bottom: $inset; left: $inset;
-  z-index: 3;
+    $color: $interfaceKeyColor;
+    $inset: 5%;
+    $tickHeightPerc: 15%;
+    text-shadow: black 0 0 10px;
+    top: $inset;
+    right: $inset;
+    bottom: $inset;
+    left: $inset;
+    z-index: 3;
 
-  &__tick,
-  &__label {
-    fill: $color;
-  }
+    &__tick,
+    &__label {
+        fill: $color;
+    }
 
-  &__minor-ticks {
-    opacity: 0.5;
-    transform-origin: center;
-    transform: rotate(45deg);
-  }
+    &__minor-ticks {
+        opacity: 0.5;
+        transform-origin: center;
+        transform: rotate(45deg);
+    }
 
-  &__label {
-    dominant-baseline: central;
-    font-size: 0.8em;
-    font-weight: bold;
-  }
+    &__label {
+        dominant-baseline: central;
+        font-size: 1.25em;
+        font-weight: bold;
+    }
 
-  .c-label-n {
-    font-size: 1.1em;
-  }
+    .c-label-n {
+        font-size: 2em;
+    }
 }
 
 /***************************** CAMERA FIELD ANGLE */
 .c-cam-field {
-  $color: white;
-  opacity: 0.2;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 2;
-
-  .cam-field-half {
+    $color: white;
+    opacity: 0.3;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+    z-index: 2;
 
-    .cam-field-area {
-      background: $color;
-      top: -30%;
-      right: 0;
-      bottom: -30%;
-      left: 0;
-    }
+    .cam-field-half {
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
 
-    // clip-paths overlap a bit to avoid a gap between halves
-    &-l {
-      clip-path: polygon(0 0, 50.5% 0, 50.5% 100%, 0 100%);
-      .cam-field-area {
-        transform-origin: left center;
-      }
-    }
+        .cam-field-area {
+            background: $color;
+            top: -30%;
+            right: 0;
+            bottom: -30%;
+            left: 0;
+        }
 
-    &-r {
-      clip-path: polygon(49.5% 0, 100% 0, 100% 100%, 49.5% 100%);
-      .cam-field-area {
-        transform-origin: right center;
-      }
+        // clip-paths overlap a bit to avoid a gap between halves
+        &-l {
+            clip-path: polygon(0 0, 50.5% 0, 50.5% 100%, 0 100%);
+
+            .cam-field-area {
+                transform-origin: left center;
+            }
+        }
+
+        &-r {
+            clip-path: polygon(49.5% 0, 100% 0, 100% 100%, 49.5% 100%);
+
+            .cam-field-area {
+                transform-origin: right center;
+            }
+        }
     }
-  }
 }
 
 /***************************** SPACECRAFT BODY */
 .c-spacecraft-body {
-  $color: $interfaceKeyColor;
-  $s: 30%;
-  background: $color;
-  border-radius: 3px;
-  height: $s; width: $s;
-  left: 50%; top: 50%;
-  opacity: 0.4;
-  transform-origin: center top;
-
-  &:before {
-    // Direction arrow
-    $color: rgba(black, 0.5);
-    $arwPointerY: 60%;
-    $arwBodyOffset: 25%;
+    $color: $interfaceKeyColor;
+    $s: 30%;
     background: $color;
-    content: '';
-    display: block;
-    position: absolute;
-    top: 10%; right: 20%; bottom: 50%; left: 20%;
-    clip-path: polygon(50% 0, 100% $arwPointerY, 100%-$arwBodyOffset $arwPointerY, 100%-$arwBodyOffset 100%, $arwBodyOffset 100%, $arwBodyOffset $arwPointerY, 0 $arwPointerY);
-  }
+    border-radius: 3px;
+    height: $s;
+    width: $s;
+    left: 50%;
+    top: 50%;
+    opacity: 0.4;
+    transform-origin: center top;
+    transform: translateX(-50%); // center by default, overridden by CompassRose.vue / headingStyle()
+
+    &:before {
+        // Direction arrow
+        $color: rgba(black, 0.5);
+        $arwPointerY: 60%;
+        $arwBodyOffset: 25%;
+        background: $color;
+        content: '';
+        display: block;
+        position: absolute;
+        top: 10%;
+        right: 20%;
+        bottom: 50%;
+        left: 20%;
+        clip-path: polygon(50% 0, 100% $arwPointerY, 100%-$arwBodyOffset $arwPointerY, 100%-$arwBodyOffset 100%, $arwBodyOffset 100%, $arwBodyOffset $arwPointerY, 0 $arwPointerY);
+    }
 }
 
 /***************************** DIRECTION ROSE */
-.c-direction-rose {
-  $d: 100px;
-  $c2: rgba(white, 0.1);
-  background: $elemBg;
-  background-image: radial-gradient(circle closest-side, transparent, transparent 80%, $c2);
-  width: $d;
-  height: $d;
-  transform-origin: 0 0;
-  position: absolute;
-  bottom: 10px; left: 10px;
-  clip-path: circle(50% at 50% 50%);
-  border-radius: 100%;
-
-  svg, div {
+.w-direction-rose {
+    $s: 10%;
+    $m: 2%;
     position: absolute;
-  }
+    bottom: $m;
+    left: $m;
+    width: $s;
+    padding-top: $s;
 
-  // Sun
-  .c-sun {
+    &.--rose-min {
+        $s: 30px;
+        width: $s;
+        padding-top: $s;
+    }
+
+    &.--rose-small {
+        .c-nsew__minor-ticks,
+        .c-tick-w,
+        .c-tick-s,
+        .c-tick-e,
+        .c-label-w,
+        .c-label-s,
+        .c-label-e {
+            display: none;
+        }
+
+        .c-label-n {
+            font-size: 2.5em;
+        }
+    }
+
+    &.--rose-max {
+        $s: 100px;
+        width: $s;
+        padding-top: $s;
+    }
+}
+
+.c-direction-rose {
+    $c2: rgba(white, 0.1);
+    background: $elemBg;
+    background-image: radial-gradient(circle closest-side, transparent, transparent 80%, $c2);
+    transform-origin: 0 0;
+    position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+    clip-path: circle(50% at 50% 50%);
+    border-radius: 100%;
 
-    &:before {
-      $s: 35%;
-      @include sun();
-      content: '';
-      display: block;
-      position: absolute;
-      opacity: 0.7;
-      top: 0; left: 50%;
-      height:$s; width: $s;
-      transform: translate(-50%, -60%);
+    svg, div {
+        position: absolute;
     }
-  }
+
+    // Sun
+    .c-sun {
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+
+        &:before {
+            $s: 35%;
+            @include sun();
+            content: '';
+            display: block;
+            position: absolute;
+            opacity: 0.7;
+            top: 0;
+            left: 50%;
+            height: $s;
+            width: $s;
+            transform: translate(-50%, -60%);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3742. See issue for testing notes.

### Changes
- Compass rose now sizes and positions proportionally to the containing image, with min and max sizes;
- Refactored computed `compassDimensionsStyle` as `sizedImageDimensions` for reusability;
- Tweaked sizing of compass ordinals text and North arrow for better legibility;
- Minor tweaks to element positioning and opacity for better legibility;
- Per discussion, automated testing not added at this time due to other issues with Imagery failing automated tests;
- Smoke tested locally and on hulk/dev

### Author Checklist
1. Changes address original issue? Y
1. Unit tests included and/or updated with changes? N
1. Command line build passes? Y
1. Changes have been smoke-tested? Y
