### PR TITLE
Pass objectPath as property to LAD rows

### DIFF
--- a/src/plugins/LADTable/LADTableSetViewProvider.js
+++ b/src/plugins/LADTable/LADTableSetViewProvider.js
@@ -43,12 +43,16 @@ export default function LADTableSetViewProvider(openmct) {
                         components: {
                             LadTableSet: LadTableSet
                         },
+                        data() {
+                            return {
+                                domainObject
+                            };
+                        },
                         provide: {
                             openmct,
-                            domainObject,
                             objectPath
                         },
-                        template: '<lad-table-set></lad-table-set>'
+                        template: '<lad-table-set :domain-object="domainObject"></lad-table-set>'
                     });
                 },
                 destroy: function (element) {

--- a/src/plugins/LADTable/components/LADRow.vue
+++ b/src/plugins/LADTable/components/LADRow.vue
@@ -56,7 +56,7 @@ export default {
             type: Object,
             required: true
         },
-        objectPath: {
+        pathToTable: {
             type: Array,
             required: true
         },
@@ -66,20 +66,19 @@ export default {
         }
     },
     data() {
-        let currentObjectPath = this.objectPath.slice();
-        currentObjectPath.unshift(this.domainObject);
-
         return {
             timestamp: undefined,
             value: '---',
             valueClass: '',
-            currentObjectPath,
             unit: ''
         };
     },
     computed: {
         formattedTimestamp() {
             return this.timestamp !== undefined ? this.getFormattedTimestamp(this.timestamp) : '---';
+        },
+        objectPath() {
+            return [this.domainObject, ...this.pathToTable];
         }
     },
     mounted() {
@@ -182,7 +181,7 @@ export default {
             };
         },
         showContextMenu(event) {
-            let actionCollection = this.openmct.actions.get(this.currentObjectPath, this.getView());
+            let actionCollection = this.openmct.actions.get(this.objectPath, this.getView());
             let allActions = actionCollection.getActionsObject();
             let applicableActions = CONTEXT_MENU_ACTIONS.map(key => allActions[key]);
 

--- a/src/plugins/LADTable/components/LADTable.vue
+++ b/src/plugins/LADTable/components/LADTable.vue
@@ -33,10 +33,10 @@
         </thead>
         <tbody>
             <lad-row
-                v-for="item in items"
-                :key="item.key"
-                :domain-object="item.domainObject"
-                :object-path="objectPath"
+                v-for="ladRow in items"
+                :key="ladRow.key"
+                :domain-object="ladRow.domainObject"
+                :path-to-table="objectPath"
                 :has-units="hasUnits"
             />
         </tbody>

--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -43,9 +43,10 @@
                 </td>
             </tr>
             <lad-row
-                v-for="telemetryObject in ladTelemetryObjects[ladTable.key]"
-                :key="telemetryObject.key"
-                :domain-object="telemetryObject.domainObject"
+                v-for="ladRow in ladTelemetryObjects[ladTable.key]"
+                :key="ladRow.key"
+                :domain-object="ladRow.domainObject"
+                :path-to-table="ladTable.objectPath"
                 :has-units="hasUnits"
             />
         </template>
@@ -60,7 +61,13 @@ export default {
     components: {
         LadRow
     },
-    inject: ['openmct', 'domainObject'],
+    inject: ['openmct', 'objectPath'],
+    props: {
+        domainObject: {
+            type: Object,
+            required: true
+        }
+    },
     data() {
         return {
             ladTableObjects: [],
@@ -106,6 +113,7 @@ export default {
             let ladTable = {};
             ladTable.domainObject = domainObject;
             ladTable.key = this.openmct.objects.makeKeyString(domainObject.identifier);
+            ladTable.objectPath = [domainObject, ...this.objectPath];
 
             this.$set(this.ladTelemetryObjects, ladTable.key, []);
             this.ladTableObjects.push(ladTable);


### PR DESCRIPTION
Fixes #3869

[The objectPath is now being passed as a property](https://github.com/nasa/openmct/commit/92737b43aff7ce35c5ed6fba9b199280d27f66b3#diff-c81b5971bfc1744860f666d448e5be2aac414b8e60d5f3e6e75f5fdc8b8fdfd7R58), rather than being injected into LAD Rows. This caused an issue in LAD Table Sets which include LAD Rows directly.

Fixed it by passing the objectPath to the included LADRows as a prop, instead of injecting it.

Also did some general tidying in the interests of code clarity.

### Author Checklist
1. Changes address original issue? Y
2. Unit tests included and/or updated with changes? N/A - Small change, does not warrant new automated tests.
3. Command line build passes? Y
4. Changes have been smoke-tested? Y
5. Testing instructions included? Y