### PR TITLE
catching any errors from a user canceling from dialog

### DIFF
--- a/src/plugins/duplicate/DuplicateAction.js
+++ b/src/plugins/duplicate/DuplicateAction.js
@@ -37,7 +37,15 @@ export default class DuplicateAction {
         let duplicationTask = new DuplicateTask(this.openmct);
         let originalObject = objectPath[0];
         let parent = objectPath[1];
-        let userInput = await this.getUserInput(originalObject, parent);
+        let userInput;
+
+        try {
+            userInput = await this.getUserInput(originalObject, parent);
+        } catch (error) {
+            // user most likely canceled
+            return;
+        }
+
         let newParent = userInput.location;
         let inNavigationPath = this.inNavigationPath(originalObject);
 


### PR DESCRIPTION
This fixes the issue of canceling a duplicate action from the dialog throwing an error in console by catching it.

closes #3944

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
