### PR TITLE
remove can edit from hyperlink

### DIFF
--- a/src/plugins/hyperlink/HyperlinkProvider.js
+++ b/src/plugins/hyperlink/HyperlinkProvider.js
@@ -33,10 +33,6 @@ export default function HyperlinkProvider(openmct) {
             return domainObject.type === 'hyperlink';
         },
 
-        canEdit(domainObject) {
-            return domainObject.type === 'hyperlink';
-        },
-
         view: function (domainObject) {
             let component;
 


### PR DESCRIPTION
Issue: https://github.com/nasa/openmct/issues/4056

The change from this PR will remove the edit mode from hyperlink to meet the expected behavior.
For tests please refer to https://github.com/nasa/openmct/pull/4062

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

