### PR TITLE
Prevent extra loading of plots data

### DIFF
--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -323,6 +323,8 @@ export default {
                 return;
             }
 
+            this.offsetWidth = this.$parent.$refs.plotWrapper.offsetWidth;
+
             this.startLoading();
             const options = {
                 size: this.$parent.$refs.plotWrapper.offsetWidth,


### PR DESCRIPTION
Fixes #4121 

Set the offsetWidth of the plot on initial load so that the handleWindowResize method doesn't re-load data.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
