### PR TITLE
[Tree] More granular size tracking

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -226,18 +226,21 @@ export default {
     },
     created() {
         this.getSearchResults = _.debounce(this.getSearchResults, 400);
-        this.handleWindowResize = _.debounce(this.handleWindowResize, 500);
+        this.handleTreeResize = _.debounce(this.handleTreeResize, 300);
         this.scrollEndEvent = _.debounce(this.scrollEndEvent, 100);
     },
     destroyed() {
-        window.removeEventListener('resize', this.handleWindowResize);
+        if (this.treeResizeObserver) {
+            this.treeResizeObserver.disconnect();
+        }
     },
     methods: {
         async initialize() {
             this.isLoading = true;
             this.openmct.$injector.get('searchService');
             this.getSavedOpenItems();
-            window.addEventListener('resize', this.handleWindowResize);
+            this.treeResizeObserver = new ResizeObserver(this.handleTreeResize);
+            this.treeResizeObserver.observe(this.$el);
 
             await this.calculateHeights();
 
@@ -710,7 +713,7 @@ export default {
         setSavedOpenItems() {
             localStorage.setItem(LOCAL_STORAGE_KEY__TREE_EXPANDED, JSON.stringify(this.openTreeItems));
         },
-        handleWindowResize() {
+        handleTreeResize() {
             this.calculateHeights();
         }
     }


### PR DESCRIPTION
Changed from window resize event to ResizeObserver on tree element to handle tree size calculations. This should fix the issue where the snapshots banner wasn't triggering the tree to calculate heights.

closes #3929

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
