### PR TITLE
Update job names to be more explicit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,12 @@ workflows:
           browser: ChromeHeadless
           always-pass: false
       - test:
-          name: node12-firefoxESR
+          name: node12-firefoxESR-build-only
           node-version: lts/erbium
           browser: FirefoxESR
           always-pass: true
       - test:
-          name: node14-chrome
+          name: node14-chrome-build-only
           node-version: lts/fermium
           browser: ChromeHeadless
           always-pass: true


### PR DESCRIPTION
It's still not clear which jobs pass/fail on tests. This change will update the name of the job which is run to be more explicit that it only pass/fails on the build step

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
