### PR TITLE
Spectral plots fixes

### DIFF
--- a/example/generator/GeneratorMetadataProvider.js
+++ b/example/generator/GeneratorMetadataProvider.js
@@ -140,7 +140,8 @@ define([
                     unit: "Hz",
                     formatString: '%0.2f',
                     hints: {
-                        domain: 2
+                        domain: 2,
+                        spectralAttribute: true
                     }
                 },
                 {
@@ -149,7 +150,8 @@ define([
                     unit: "deg",
                     formatString: '%0.2f',
                     hints: {
-                        range: 2
+                        range: 2,
+                        spectralAttribute: true
                     }
                 }
             ]

--- a/example/generator/GeneratorProvider.js
+++ b/example/generator/GeneratorProvider.js
@@ -86,7 +86,6 @@ define([
         var workerRequest = this.makeWorkerRequest(domainObject, request);
         workerRequest.start = request.start;
         workerRequest.end = request.end;
-        workerRequest.spectra = request.spectra;
 
         return this.workerInterface.request(workerRequest);
     };

--- a/example/generator/SpectralGeneratorProvider.js
+++ b/example/generator/SpectralGeneratorProvider.js
@@ -88,12 +88,14 @@ define([
         var workerRequest = this.makeWorkerRequest(domainObject, request);
         workerRequest.start = request.start;
         workerRequest.end = request.end;
+        workerRequest.spectra = true;
 
         return this.workerInterface.request(workerRequest);
     };
 
     SpectralGeneratorProvider.prototype.subscribe = function (domainObject, callback) {
         var workerRequest = this.makeWorkerRequest(domainObject, {});
+        workerRequest.spectra = true;
 
         return this.workerInterface.subscribe(workerRequest, callback);
     };

--- a/example/generator/generatorWorker.js
+++ b/example/generator/generatorWorker.js
@@ -59,12 +59,15 @@
             while (nextStep < now) {
                 self.postMessage({
                     id: message.id,
-                    data: {
+                    data: message.spectra ? {
+                        wavelength: [wavelength(nextStep)],
+                        cos: [cos(nextStep, data.period, data.amplitude, data.offset, data.phase, data.randomness)]
+                    } : {
                         name: data.name,
                         utc: nextStep,
                         yesterday: nextStep - 60 * 60 * 24 * 1000,
                         sin: sin(nextStep, data.period, data.amplitude, data.offset, data.phase, data.randomness),
-                        wavelength: sin(nextStep, data.period, data.amplitude, data.offset, data.phase, data.randomness),
+                        wavelength: wavelength(nextStep),
                         cos: cos(nextStep, data.period, data.amplitude, data.offset, data.phase, data.randomness)
                     }
                 });
@@ -112,14 +115,21 @@
                 utc: nextStep,
                 yesterday: nextStep - 60 * 60 * 24 * 1000,
                 sin: sin(nextStep, period, amplitude, offset, phase, randomness),
-                wavelength: sin(nextStep, period, amplitude, offset, phase, randomness),
+                wavelength: wavelength(nextStep),
                 cos: cos(nextStep, period, amplitude, offset, phase, randomness)
             });
         }
 
         self.postMessage({
             id: message.id,
-            data: data
+            data: request.spectra ? {
+                wavelength: data.map((item) => {
+                    return item.wavelength;
+                }),
+                cos: data.map((item) => {
+                    return item.cos;
+                })
+            } : data
         });
     }
 
@@ -131,6 +141,13 @@
     function sin(timestamp, period, amplitude, offset, phase, randomness) {
         return amplitude
             * Math.sin(phase + (timestamp / period / 1000 * Math.PI * 2)) + (amplitude * Math.random() * randomness) + offset;
+    }
+
+    function wavelength(timestamp) {
+        // eslint-disable-next-line no-bitwise
+        const value = String(timestamp).substr(5, 10);
+
+        return value;
     }
 
     function sendError(error, message) {

--- a/src/plugins/plot/spectralAggregatePlot/SpectralAggregatePlotViewProvider.js
+++ b/src/plugins/plot/spectralAggregatePlot/SpectralAggregatePlotViewProvider.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import SpectralView from './SpectralAggregateView.vue';
+import SpectralAggregateView from './SpectralAggregateView.vue';
 import Vue from 'vue';
 
 export default function SpectralAggregatePlotViewProvider(openmct) {
@@ -33,11 +33,11 @@ export default function SpectralAggregatePlotViewProvider(openmct) {
         name: 'Spectral Aggregate Plot',
         cssClass: 'icon-telemetry',
         canView(domainObject, objectPath) {
-            return domainObject && domainObject.type === 'telemetry.plot.spectral.aggregate';
+            return domainObject && domainObject.type === 'telemetry.plot.spectral-aggregate';
         },
 
         canEdit(domainObject, objectPath) {
-            return domainObject && domainObject.type === 'telemetry.plot.spectral.aggregate';
+            return domainObject && domainObject.type === 'telemetry.plot.spectral-aggregate';
         },
 
         view: function (domainObject, objectPath) {
@@ -49,7 +49,7 @@ export default function SpectralAggregatePlotViewProvider(openmct) {
                     component = new Vue({
                         el: element,
                         components: {
-                            SpectralView
+                            SpectralAggregateView
                         },
                         provide: {
                             openmct,


### PR DESCRIPTION
Fixes bugs with SpectralAggregateViewProvider checking the wrong object type and including the wrong view.
Fix Spectral generator to: 
1. Include spectralAttribute: true in cos and wavelength metadatas.
2. Emit wavelengths in the data
2. Return data in the format:
```
data: {
wavelength: [],
cos: []
}
```

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
