### PR TITLE
Imagery time source could be something other than key

### DIFF
--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -159,7 +159,7 @@ export default {
             let image = { ...datum };
             image.formattedTime = this.formatTime(datum);
             image.url = this.formatImageUrl(datum);
-            image.time = datum[this.timeKey];
+            image.time = this.parseTime(image.formattedTime);
             image.imageDownloadName = this.getImageDownloadName(datum);
 
             return image;


### PR DESCRIPTION
Resolves #2977 
Resolves #4235
Use timeFormatter.parse to get the timestamp of imagery since the sou…rce could be something other than key

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
