### PR TITLE
mct4269 - disallowing overlay plots for bar charts

### DIFF
--- a/src/plugins/charts/BarGraphCompositionPolicy.js
+++ b/src/plugins/charts/BarGraphCompositionPolicy.js
@@ -42,7 +42,7 @@ export default function BarGraphCompositionPolicy(openmct) {
     return {
         allow: function (parent, child) {
             if ((parent.type === BAR_GRAPH_KEY)
-                && ((child.type !== 'telemetry.plot.overlay') && (hasBarGraphTelemetry(child) === false))
+                && (hasBarGraphTelemetry(child) === false)
             ) {
                 return false;
             }


### PR DESCRIPTION
Resolves #4269 

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? Will users need to change how they are calling the API, or how they've extended core plugins such as Tables or Plots?

### Author Checklist

* [X] Changes address original issue?
* [X] Unit tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue?
