### PR TITLE
Add braintree sanitize url lib and sanitize urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.8-SNAPSHOT",
   "description": "The Open MCT core platform",
   "devDependencies": {
+    "@braintree/sanitize-url": "^5.0.2",
     "angular": ">=1.8.0",
     "angular-route": "1.4.14",
     "babel-eslint": "10.0.3",

--- a/src/plugins/conditionWidget/components/ConditionWidget.vue
+++ b/src/plugins/conditionWidget/components/ConditionWidget.vue
@@ -23,7 +23,7 @@
 <template>
 <component :is="urlDefined ? 'a' : 'span'"
            class="c-condition-widget u-style-receiver js-style-receiver"
-           :href="urlDefined ? internalDomainObject.url : null"
+           :href="url"
 >
     <div class="c-condition-widget__label">
         {{ internalDomainObject.label }}
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+const sanitizeUrl = require("@braintree/sanitize-url").sanitizeUrl;
+
 export default {
     inject: ['openmct', 'domainObject'],
     data: function () {
@@ -40,8 +42,14 @@ export default {
         };
     },
     computed: {
-        urlDefined() {
-            return this.internalDomainObject.url && this.internalDomainObject.url.length > 0;
+        url() {
+            const urlDefined = this.internalDomainObject.url && this.internalDomainObject.url.length > 0;
+            let url = urlDefined ? this.internalDomainObject.url : null;
+            if (url) {
+                url = sanitizeUrl(url);
+            }
+
+            return url;
         }
     },
     mounted() {

--- a/src/plugins/hyperlink/HyperlinkLayout.vue
+++ b/src/plugins/hyperlink/HyperlinkLayout.vue
@@ -27,7 +27,7 @@
        'c-hyperlink--button' : isButton
    }"
    :target="domainObject.linkTarget"
-   :href="domainObject.url"
+   :href="url"
 >
     <span class="c-hyperlink__label">{{ domainObject.displayText }}</span>
 </a>
@@ -35,6 +35,7 @@
 </template>
 
 <script>
+const sanitizeUrl = require("@braintree/sanitize-url").sanitizeUrl;
 
 export default {
     inject: ['domainObject'],
@@ -45,6 +46,14 @@ export default {
             }
 
             return true;
+        },
+        url() {
+            let url = this.domainObject.url;
+            if (url) {
+                url = sanitizeUrl(url);
+            }
+
+            return url;
         }
     }
 };

--- a/src/plugins/summaryWidget/src/SummaryWidget.js
+++ b/src/plugins/summaryWidget/src/SummaryWidget.js
@@ -7,7 +7,8 @@ define([
     './eventHelpers',
     'objectUtils',
     'lodash',
-    'zepto'
+    'zepto',
+    '@braintree/sanitize-url'
 ], function (
     widgetTemplate,
     Rule,
@@ -17,7 +18,8 @@ define([
     eventHelpers,
     objectUtils,
     _,
-    $
+    $,
+    urlSanitizeLib
 ) {
 
     //default css configuration for new rules
@@ -114,6 +116,8 @@ define([
      */
     SummaryWidget.prototype.addHyperlink = function (url, openNewTab) {
         if (url) {
+            const sanitizeUrl = urlSanitizeLib.sanitizeUrl;
+            url = sanitizeUrl(url);
             this.widgetButton.attr('href', url);
         } else {
             this.widgetButton.removeAttr('href');

--- a/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
+++ b/src/plugins/summaryWidget/src/views/SummaryWidgetView.js
@@ -1,7 +1,9 @@
 define([
-    './summary-widget.html'
+    './summary-widget.html',
+    '@braintree/sanitize-url'
 ], function (
-    summaryWidgetTemplate
+    summaryWidgetTemplate,
+    urlSanitizeLib
 ) {
     const WIDGET_ICON_CLASS = 'c-sw__icon js-sw__icon';
 
@@ -35,8 +37,11 @@ define([
         this.icon = this.container.querySelector('#widgetIcon');
         this.label = this.container.querySelector('.js-sw__label');
 
-        if (this.domainObject.url) {
-            this.widget.setAttribute('href', this.domainObject.url);
+        let url = this.domainObject.url;
+        if (url) {
+            const sanitizeUrl = urlSanitizeLib.sanitizeUrl;
+            url = sanitizeUrl(url);
+            this.widget.setAttribute('href', url);
         } else {
             this.widget.removeAttribute('href');
         }

--- a/src/plugins/webPage/components/WebPage.vue
+++ b/src/plugins/webPage/components/WebPage.vue
@@ -1,16 +1,28 @@
 <template>
 <div class="l-iframe abs">
-    <iframe :src="currentDomainObject.url"></iframe>
+    <iframe :src="url"></iframe>
 </div>
 </template>
 
 <script>
+const sanitizeUrl = require("@braintree/sanitize-url").sanitizeUrl;
+
 export default {
     inject: ['openmct', 'domainObject'],
     data: function () {
         return {
             currentDomainObject: this.domainObject
         };
+    },
+    computed: {
+        url() {
+            let url = this.currentDomainObject.url;
+            if (url) {
+                url = sanitizeUrl(url);
+            }
+
+            return url;
+        }
     }
 };
 </script>


### PR DESCRIPTION
Fixes #4265 

Add braintree sanitize url lib and sanitize urls in the condition widget, summary widget, hyperlink, and web page objects.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? Will users need to change how they are calling the API, or how they've extended core plugins such as Tables or Plots?

### Author Checklist

* [X] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue?
