### PR TITLE
Fix #4299

### DIFF
--- a/src/plugins/displayLayout/components/display-layout.scss
+++ b/src/plugins/displayLayout/components/display-layout.scss
@@ -47,8 +47,8 @@
 
 .is-editing {
     .l-shell__main-container {
-        &[s-selected],
-        &[s-selected-parent] {
+        [s-selected],
+        [s-selected-parent] {
             // Display grid and allow edit marquee to display in main layout holder when editing
             > .l-layout {
                 background: $editUIGridColorBg;


### PR DESCRIPTION
Fixes #4299. Modded CSS selector to target child of `__main-container` element.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? Will users need to change how they are calling the API, or how they've extended core plugins such as Tables or Plots?

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes? N/A
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
