### PR TITLE
Add objects to transaction before committing them during creation

### DIFF
--- a/platform/commonUI/edit/src/actions/SaveAsAction.js
+++ b/platform/commonUI/edit/src/actions/SaveAsAction.js
@@ -132,11 +132,14 @@ function (
             return fetchObject(object.getModel().location);
         }
 
-        function saveObject(parent) {
-            return self.openmct.editor.save().then(() => {
-                // Force mutation for search indexing
-                return parent;
-            });
+        function saveObject(object) {
+            //persist the object, which adds it to the transaction and then call editor.save
+            return object.getCapability("persistence").persist()
+                .then(() => {
+                    return self.openmct.editor.save().then(() => {
+                        return object;
+                    });
+                });
         }
 
         function addSavedObjectToParent(parent) {
@@ -147,17 +150,6 @@ function (
                         .then(function () {
                             return addedObject;
                         });
-                });
-        }
-
-        function undirty(object) {
-            return object.getCapability('persistence').refresh();
-        }
-
-        function undirtyOriginals(object) {
-            return object.getCapability("persistence").persist()
-                .then(function () {
-                    return object;
                 });
         }
 
@@ -187,10 +179,9 @@ function (
         return getParent(domainObject)
             .then(doWizardSave)
             .then(showBlockingDialog)
-            .then(getParent)
             .then(saveObject)
+            .then(getParent)
             .then(addSavedObjectToParent)
-            .then(undirtyOriginals)
             .then((addedObject) => {
                 return fetchObject(addedObject.getId());
             })


### PR DESCRIPTION
Resolves #4382 
May ALSO fix #4385 (I couldn't repro after the fix)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
