### PR TITLE
Run Codecov in informational mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,18 +1,13 @@
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
 
-coverage:
-  precision: 2
-  round: down
-  range: "70...100"
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+status:
+  project:
+    default:
+      informational: true
+  patch:
+    default:
+      informational: true
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
After further reading, this will configure codecov to run in informational mode.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
