### PR TITLE
[CI] Update dependabot regex to use ruby rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,9 @@ updates:
       - "type:maintenance"
       - "dependencies"
     allow:
-      - dependency-name: "^.*eslint.*$"
+      - dependency-name: "eslint*"
+      - dependency-name: "karma*"
+      - dependency-name: "jasmine*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Need to use ruby regex matching. Added more dependencies to monitor.

Fixes https://github.com/nasa/openmct/issues/4399

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
