### PR TITLE
[ci] Firefox needs to be defined as FirefoxHeadless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
       - test:
           name: node14-firefox-nightly
           node-version: lts/fermium
-          browser: Firefox
+          browser: FirefoxHeadless
     triggers:
       - schedule:
           cron: "0 0 * * *"


### PR DESCRIPTION
Quick Fix for the nightlies

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
