### PR TITLE
[CI] Disable html unit test reporting to increase CI Speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
       - restore_cache:
           key: deps-{{ .Branch }}--<< parameters.node-version >>--{{ checksum "package.json" }}
       - node/install:
+          install-npm: false
           node-version: << parameters.node-version >>
-      - node/install-packages:
-          override-ci-command: npm install
+      - run: npm install
       - when:
           condition:
             equal: [ "FirefoxESR", <<parameters.browser>> ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open MCT [![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0) [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/nasa/openmct.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nasa/openmct/context:javascript)
+# Open MCT [![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0) [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/nasa/openmct.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nasa/openmct/context:javascript) [![codecov](https://codecov.io/gh/nasa/openmct/branch/master/graph/badge.svg?token=7DQIipp3ej)](https://codecov.io/gh/nasa/openmct)
 
 Open MCT (Open Mission Control Technologies) is a next-generation mission control framework for visualization of data on desktop and mobile devices. It is developed at NASA's Ames Research Center, and is being used by NASA for data analysis of spacecraft missions, as well as planning and operation of experimental rover systems. As a generalizable and open source framework, Open MCT could be used as the basis for building applications for planning, operation, and analysis of any systems producing telemetry data.
 
@@ -84,6 +84,8 @@ naming convention is otherwise the same.)
 
 When `npm test` is run, test results will be written as HTML to
 `dist/reports/tests/`. Code coverage information is written to `dist/reports/coverage`.
+
+Code Coverage Reports are available from [codecov.io](https://app.codecov.io/gh/nasa/openmct/)
 
 # Glossary
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -93,7 +93,7 @@ module.exports = (config) => {
             dir: process.env.CIRCLE_ARTIFACTS
                 ? process.env.CIRCLE_ARTIFACTS + '/coverage'
                 : "dist/reports/coverage",
-            reports: ['html', 'lcovonly', 'text-summary'],
+            reports: ['lcovonly', 'text-summary'],
             thresholds: {
                 global: {
                     lines: 66

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@
 const devMode = process.env.NODE_ENV !== 'production';
 const browsers = [process.env.NODE_ENV === 'debug' ? 'ChromeDebugging' : 'ChromeHeadless'];
 const coverageEnabled = process.env.COVERAGE === 'true';
-const reporters = ['spec', 'html', 'junit'];
+const reporters = ['spec', 'junit'];
 
 if (coverageEnabled) {
     reporters.push('coverage-istanbul');
@@ -78,11 +78,11 @@ module.exports = (config) => {
         logLevel: config.LOG_INFO,
         autoWatch: true,
         // HTML test reporting.
-        htmlReporter: {
-            outputDir: "dist/reports/tests",
-            preserveDescribeNesting: true,
-            foldAll: false
-        },
+        // htmlReporter: {
+        //    outputDir: "dist/reports/tests",
+        //    preserveDescribeNesting: true,
+        //    foldAll: false
+        // },
         junitReporter: {
             outputDir: "dist/reports/tests",
             outputFile: "test-results.xml",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "karma-coverage": "2.0.3",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-firefox-launcher": "2.1.1",
-    "karma-html-reporter": "0.2.7",
     "karma-jasmine": "4.0.1",
     "karma-junit-reporter": "2.0.1",
     "karma-sourcemap-loader": "0.3.8",


### PR DESCRIPTION
Addresses parts of: https://github.com/nasa/openmct/issues/4389

Since we have codecov.io integrated, we don't need to generate and archive a html view of our codecov metrics. This should save us considerable time.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
