### PR TITLE
[CI] Add npm audit to the nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,15 @@ orbs:
   node: circleci/node@4.5.1
   browser-tools: circleci/browser-tools@1.1.3
 jobs:
+  npm-audit:
+    executor: linux
+    steps:
+      - checkout
+      - node/install:
+          install-npm: true
+          node-version: lts/fermium
+      - run: npm install
+      - run: npm audit --audit-level=low
   test:
     parameters:
       node-version:
@@ -92,6 +101,7 @@ workflows:
           name: node14-firefox-nightly
           node-version: lts/fermium
           browser: FirefoxHeadless
+      - npm-audit
     triggers:
       - schedule:
           cron: "0 0 * * *"


### PR DESCRIPTION
This will attempt to close https://github.com/nasa/openmct/issues/2449 by running npm audit and failing if we are failing at the lowest threshold. This is preferable to failing on PR because the ruleset for npm audit changes independent of packaging changes.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
