### PR TITLE
Dependabot cannot run two different npm scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"  
-    open-pull-requests-limit: 2
-    labels:
-      - "type:maintenance"
-      - "dependencies"
-    allow:
-      - dependency-name: "eslint*"
-      - dependency-name: "karma*"
-      - dependency-name: "jasmine*"
-  
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"  
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 4
     labels:
       - "type:maintenance"
       - "dependencies"
       - "pr:e2e"
     allow:
+      - dependency-name: "eslint*"
+      - dependency-name: "karma*"
+      - dependency-name: "jasmine*"
       - dependency-name: "playwright*"
       - dependency-name: "percy*"
 


### PR DESCRIPTION
Github Checks are broken because dependabot cannot be configured to run two checks against the same package library. This PR combines the two checks into a single reference

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
