### PR TITLE
Remove e2e caching until we can fix it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,19 +79,10 @@ jobs:
       NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:
       - checkout
-      - restore_cache:
-          key: deps-{{ .Branch }}--<< parameters.node-version >>--{{ checksum "package.json" }}
       - node/install:
           install-npm: false
           node-version: << parameters.node-version >>
       - run: npm install
-      - save_cache:
-          key: deps-{{ .Branch }}--<< parameters.node-version >>--{{ checksum "package.json" }}
-          paths:
-            - ~/.npm
-            - ~/.cache
-            - node_modules
-            - ~/Library/Caches/ms-playwright
       - run: npm run test:e2e:<<parameters.suite>>
       - store_test_results:
           path: test-results/results.xml


### PR DESCRIPTION
I have no idea why this caching isn't working. I'm assuming that the binaries cannot be installed and when we attempt to 'restore cache', we wipe the dir which contains the browsers.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
