### PR TITLE
Always check and/or install latest e2e browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ jobs:
             - ~/.npm
             - ~/.cache
             - node_modules
-            - ~/Library/Caches/ms-playwright
       - when:
           condition:
             equal: [ "", <<parameters.browser>> ] #Only run linting when browsers are not running to save time
@@ -91,7 +90,7 @@ jobs:
             - ~/.npm
             - ~/.cache
             - node_modules
-            - ~/Library/Caches/ms-playwright
+      - run: npx playwright install
       - run: npm run test:e2e:<<parameters.suite>>
       - store_test_results:
           path: test-results/results.xml


### PR DESCRIPTION
Per Playwright team:


> playwright - library, installs browsers by default. with @playwright/test we walked away from it because people did not want all browsers by default, so you need to npx playwright install . You can npx playwright install chromium for bots that only run Chromium tests, etc.


### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
