### PR TITLE
Missing Percy Token

### DIFF
--- a/.github/workflows/e2e-visual.yml
+++ b/.github/workflows/e2e-visual.yml
@@ -20,3 +20,5 @@ jobs:
       - run: npm install
       - name: Run the e2e visual tests
         run: npm run test:e2e:visual
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}


### PR DESCRIPTION
Percy needs to reference the PERCY_TOKEN stored in github

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
