### PR TITLE
4328 - Maintain reference to a focusedImage if the bounds change

### DIFF
--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -296,6 +296,11 @@ export default {
             return disabled;
         },
         focusedImage() {
+            console.assert(this.imageHistory.length > this.focusedImageIndex, {
+                imageHistoryLength: this.imageHistory.length,
+                focusedImageIndex: this.focusedImageIndex
+            });
+
             return this.imageHistory[this.focusedImageIndex];
         },
         parsedSelectedTime() {
@@ -412,11 +417,20 @@ export default {
         imageHistorySize(newSize, oldSize) {
             let imageIndex;
             if (this.indexForFocusedImage !== undefined) {
+                console.log('setting to initFocusedImageIndex', this.initFocusedImageIndex)
                 imageIndex = this.initFocusedImageIndex;
             } else {
-                imageIndex = newSize - 1;
+                imageIndex = newSize > 0 ? newSize -1 : undefined;
             }
-
+            console.table({
+                newSize,
+                oldSize,
+                imageIndex,
+                imageHistoryLength: this.imageHistory.length,
+                indexForFocusedImage: this.indexForFocusedImage,
+                initFocusedImageIndex: this.initFocusedImageIndex
+                });
+            console.assert(imageIndex > -1, "The imageIndex value of %s fails", imageIndex);
             this.setFocusedImage(imageIndex, false);
             this.scrollToRight();
         },
@@ -502,6 +516,7 @@ export default {
             this.timeContext.on('timeSystem', this.trackDuration);
             this.timeContext.on('clock', this.trackDuration);
             this.timeContext.on("timeContext", this.setTimeContext);
+            // this.timeContext.on('bounds', this.handleNewBounds);
         },
         stopFollowingTimeContext() {
             if (this.timeContext) {
@@ -510,6 +525,32 @@ export default {
                 this.timeContext.off("timeContext", this.setTimeContext);
             }
         },
+        // handleNewBounds(bounds) {
+        //     // console.trace();
+        //     console.group('handleBounds');
+        //     console.log('handleBounds: image history length', this.imageHistory.length, Array.isArray(this.imageHistory))
+        //     console.log('handleBounds: focusedImage', this.focusedImage, this.focusedImageIndex);
+
+        //     // if the focused image is no longer in bounds;
+        //     // if (this.focusedImage && (bounds.start > this.focusedImage.time || bounds.end < this.focusedImage.time) 
+            
+        //     // // || (!this.focusedImage && this.focusedImageIndex > -1)
+            
+        //     // ) {
+        //     //     console.log('handleBounds: not in bounds');
+        //     //     this.isPaused = false;
+        //     // } else {
+        //     //     console.log('handleBounds: is in bounds');
+        //     // }
+        //     console.groupEnd();
+        //     // setTimeout(() => {
+
+        //     //     console.log('imagery history length after timeout', this.imageHistory.length, typeof this.imageHistory, this.imageHistory[this.imageHistory.length - 1], Array.isArray(this.imageHistory));
+        //     // // this.setFocusedImage(this.imageHistory.length - 2, false);
+        //     // }, 2000)
+        //     // console.log('ImageryVue end')
+
+        // },
         expand() {
             const actionCollection = this.openmct.actions.getActionsCollection(this.objectPath, this.currentView);
             const visibleActions = actionCollection.getVisibleActions();
@@ -671,12 +712,15 @@ export default {
             });
         },
         setFocusedImage(index, thumbnailClick = false) {
+            console.assert(index > -1, {index})
+            console.log('setFocusedImageIndex', 'from', this.focusedImageIndex, "to", index)
             if (thumbnailClick) {
                 //We use the props till the user changes what they want to see
                 this.initFocusedImageIndex = undefined;
             }
 
             if (this.isPaused && !thumbnailClick && this.initFocusedImageIndex === undefined) {
+                console.log('setFocusedImage is paused and not thumnail click', index);
                 this.nextImageIndex = index;
                 //this could happen if bounds changes
                 if (this.focusedImageIndex > this.imageHistory.length - 1) {

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -296,10 +296,10 @@ export default {
             return disabled;
         },
         focusedImage() {
-            console.assert(this.imageHistory.length > this.focusedImageIndex, {
-                imageHistoryLength: this.imageHistory.length,
-                focusedImageIndex: this.focusedImageIndex
-            });
+            // console.assert(this.imageHistory.length > this.focusedImageIndex, {
+            //     imageHistoryLength: this.imageHistory.length,
+            //     focusedImageIndex: this.focusedImageIndex
+            // });
 
             return this.imageHistory[this.focusedImageIndex];
         },
@@ -422,15 +422,15 @@ export default {
             } else {
                 imageIndex = newSize > 0 ? newSize -1 : undefined;
             }
-            console.table({
-                newSize,
-                oldSize,
-                imageIndex,
-                imageHistoryLength: this.imageHistory.length,
-                indexForFocusedImage: this.indexForFocusedImage,
-                initFocusedImageIndex: this.initFocusedImageIndex
-                });
-            console.assert(imageIndex > -1, "The imageIndex value of %s fails", imageIndex);
+            // console.table({
+            //     newSize,
+            //     oldSize,
+            //     imageIndex,
+            //     imageHistoryLength: this.imageHistory.length,
+            //     indexForFocusedImage: this.indexForFocusedImage,
+            //     initFocusedImageIndex: this.initFocusedImageIndex
+            //     });
+            // console.assert(imageIndex > -1, "The imageIndex value of %s fails", imageIndex);
             this.setFocusedImage(imageIndex, false);
             this.scrollToRight();
         },
@@ -523,6 +523,12 @@ export default {
                 this.timeContext.off("timeSystem", this.trackDuration);
                 this.timeContext.off("clock", this.trackDuration);
                 this.timeContext.off("timeContext", this.setTimeContext);
+            }
+        },
+        boundsChange(bounds, isTick) {
+            if (!isTick) {
+                this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
+                this.requestHistory().then(() => { console.log('done in imageryview', this.imageHistory)});
             }
         },
         // handleNewBounds(bounds) {
@@ -712,7 +718,12 @@ export default {
             });
         },
         setFocusedImage(index, thumbnailClick = false) {
-            console.assert(index > -1, {index})
+            if (!index) {
+                return;
+            }
+
+            console.log('previous?', this.previousFocusedImage);
+            // console.assert(index > -1, {index})
             console.log('setFocusedImageIndex', 'from', this.focusedImageIndex, "to", index)
             if (thumbnailClick) {
                 //We use the props till the user changes what they want to see

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -677,7 +677,8 @@ export default {
             });
         },
         matchIndexOfPreviousImage(previous, imageHistory) {
-            // match logic uses a composite of url and time to account for example imagery not having fully unique urls
+            // match logic uses a composite of url and time to account
+            // for example imagery not having fully unique urls
             return imageHistory.findIndex((x) => (
                 x.url === previous.url
                 && x.time === previous.time
@@ -691,21 +692,14 @@ export default {
 
             if (this.previousFocusedImage) {
                 // determine if the previous image exists in the new bounds of imageHistory
-                const matchIndex = this.matchIndexOfPreviousImage(this.previousFocusedImage, this.imageHistory);
-
-                if (matchIndex > -1) {
-                    focusedIndex = matchIndex;
-                } else {
-                    // when the previous image is no longer present, set focused image to last item and unpause
-                    focusedIndex = this.imageHistory.length - 1;
-                    // this.paused(false);
-                }
+                const matchIndex = this.matchIndexOfPreviousImage(
+                    this.previousFocusedImage,
+                    this.imageHistory
+                );
+                focusedIndex = matchIndex > -1 ? matchIndex : this.imageHistory.length - 1;
 
                 delete this.previousFocusedImage;
             }
-
-            console.log('setFocusedImageIndex', 'from', this.focusedImageIndex, "to", focusedIndex);
-            this.focusedImageIndex = focusedIndex;
 
             if (thumbnailClick) {
                 //We use the props till the user changes what they want to see
@@ -722,6 +716,7 @@ export default {
                 return;
             }
 
+            this.focusedImageIndex = focusedIndex;
 
             if (thumbnailClick && !this.isPaused) {
                 this.paused(true);

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -296,11 +296,6 @@ export default {
             return disabled;
         },
         focusedImage() {
-            // console.assert(this.imageHistory.length > this.focusedImageIndex, {
-            //     imageHistoryLength: this.imageHistory.length,
-            //     focusedImageIndex: this.focusedImageIndex
-            // });
-
             return this.imageHistory[this.focusedImageIndex];
         },
         parsedSelectedTime() {
@@ -417,20 +412,11 @@ export default {
         imageHistorySize(newSize, oldSize) {
             let imageIndex;
             if (this.indexForFocusedImage !== undefined) {
-                console.log('setting to initFocusedImageIndex', this.initFocusedImageIndex)
                 imageIndex = this.initFocusedImageIndex;
             } else {
-                imageIndex = newSize > 0 ? newSize -1 : undefined;
+                imageIndex = newSize > 0 ? newSize - 1 : undefined;
             }
-            // console.table({
-            //     newSize,
-            //     oldSize,
-            //     imageIndex,
-            //     imageHistoryLength: this.imageHistory.length,
-            //     indexForFocusedImage: this.indexForFocusedImage,
-            //     initFocusedImageIndex: this.initFocusedImageIndex
-            //     });
-            // console.assert(imageIndex > -1, "The imageIndex value of %s fails", imageIndex);
+
             this.setFocusedImage(imageIndex, false);
             this.scrollToRight();
         },
@@ -516,7 +502,6 @@ export default {
             this.timeContext.on('timeSystem', this.trackDuration);
             this.timeContext.on('clock', this.trackDuration);
             this.timeContext.on("timeContext", this.setTimeContext);
-            // this.timeContext.on('bounds', this.handleNewBounds);
         },
         stopFollowingTimeContext() {
             if (this.timeContext) {
@@ -719,7 +704,7 @@ export default {
                 delete this.previousFocusedImage;
             }
 
-            console.log('setFocusedImageIndex', 'from', this.focusedImageIndex, "to", focusedIndex)
+            console.log('setFocusedImageIndex', 'from', this.focusedImageIndex, "to", focusedIndex);
             this.focusedImageIndex = focusedIndex;
 
             if (thumbnailClick) {
@@ -728,7 +713,6 @@ export default {
             }
 
             if (this.isPaused && !thumbnailClick && this.initFocusedImageIndex === undefined) {
-                console.log('setFocusedImage is paused and not thumnail click', index);
                 this.nextImageIndex = focusedIndex;
                 //this could happen if bounds changes
                 if (this.focusedImageIndex > this.imageHistory.length - 1) {

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -144,8 +144,10 @@ export default {
                     }
                 });
                 //this is to optimize anything that reacts to imageHistory length
+                console.log(imagery, 'set to imageHistory');
                 this.imageHistory = imagery;
             }
+            console.log('end of requestHistory');
         },
         timeSystemChange() {
             this.timeSystem = this.timeContext.timeSystem();

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -144,10 +144,8 @@ export default {
                     }
                 });
                 //this is to optimize anything that reacts to imageHistory length
-                console.log(imagery, 'set to imageHistory');
                 this.imageHistory = imagery;
             }
-            console.log('end of requestHistory');
         },
         timeSystemChange() {
             this.timeSystem = this.timeContext.timeSystem();


### PR DESCRIPTION
Closes #4328 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue?


Solution maintains the previous image object and compares it against the updated imageHistory array. If the item is found, the index is updated and reference to the original focused image is maintained. If the previous image no longer exists in the updated bounds, the focused image will be set to the last item in the `imageHistory`.  