### PR TITLE
Ignore tests in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,10 @@ coverage:
   round: down
   range: "66...100"
 
+ignore:
+  - */*Spec.js
+  - e2e
+
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
Fixes https://github.com/nasa/openmct/issues/4549

At the moment, codecov is reporting on missing coverage in Spec.js files, themselves. This should ignore the test files from line coverage patch notes like https://github.com/nasa/openmct/pull/4522/checks?check_run_id=4436987606

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
