### PR TITLE
String in our yaml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,8 +14,8 @@ coverage:
   range: "66...100"
 
 ignore:
-  - */*Spec.js
-  - e2e
+  - "**/*Spec.js"
+  - "e2e"
 
 parsers:
   gcov:


### PR DESCRIPTION
Fixes #4549 

need to specify these lines as strings https://docs.codecov.com/docs/ignoring-paths

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
