### PR TITLE
Preserve the previousFocusedImage for subscription updates, bound change

### DIFF
--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -417,6 +417,8 @@ export default {
                 imageIndex = newSize > 0 ? newSize - 1 : undefined;
             }
 
+            // handle subscription update
+            this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
             this.setFocusedImage(imageIndex, false);
             this.scrollToRight();
         },
@@ -508,12 +510,6 @@ export default {
                 this.timeContext.off("timeSystem", this.trackDuration);
                 this.timeContext.off("clock", this.trackDuration);
                 this.timeContext.off("timeContext", this.setTimeContext);
-            }
-        },
-        boundsChange(bounds, isTick) {
-            if (!isTick) {
-                this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
-                this.requestHistory();
             }
         },
         expand() {
@@ -691,20 +687,23 @@ export default {
             }
 
             if (this.previousFocusedImage) {
+                console.log('previousImageUrl', this.previousFocusedImage.url)
                 // determine if the previous image exists in the new bounds of imageHistory
                 const matchIndex = this.matchIndexOfPreviousImage(
                     this.previousFocusedImage,
                     this.imageHistory
                 );
                 focusedIndex = matchIndex > -1 ? matchIndex : this.imageHistory.length - 1;
-
-                delete this.previousFocusedImage;
+                console.log('new focused image', focusedIndex, this.imageHistory[focusedIndex].url)
             }
 
             if (thumbnailClick) {
                 //We use the props till the user changes what they want to see
                 this.initFocusedImageIndex = undefined;
             }
+
+            this.focusedImageIndex = focusedIndex;
+            delete this.previousFocusedImage;
 
             if (this.isPaused && !thumbnailClick && this.initFocusedImageIndex === undefined) {
                 this.nextImageIndex = focusedIndex;
@@ -715,8 +714,6 @@ export default {
 
                 return;
             }
-
-            this.focusedImageIndex = focusedIndex;
 
             if (thumbnailClick && !this.isPaused) {
                 this.paused(true);

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -122,14 +122,46 @@ export default {
             return this.timeFormatter.parse(datum);
         },
         boundsChange(bounds, isTick) {
-            if (!isTick) {
-                this.requestHistory();
+            if (isTick) {
+                return;
             }
+
+            // the focusedImageIndex is calculated twice; once before and after request history arrives
+            const focusedImage = this.imageHistory[this.focusedImageIndex];
+            const previousFocusedImage = focusedImage ? JSON.parse(JSON.stringify(focusedImage)) : undefined;
+            this.updateFocusedImageIndex(previousFocusedImage, this.imageHistory);
+
+            return this.requestHistory();
+        },
+        matchIndexOfPreviousImage(previous, imageHistory) {
+            // match logic uses a composite of url and time to account
+            // for example imagery not having fully unique urls
+            return imageHistory.findIndex((x) => (
+                x.url === previous.url
+                && x.time === previous.time
+                && x.utc === previous.utc
+            ));
+        },
+        updateFocusedImageIndex(previous, imageHistory) {
+            if (!previous) {
+                return;
+            }
+
+            const matchIndex = this.matchIndexOfPreviousImage(
+                previous,
+                imageHistory
+            );
+            this.focusedImageIndex = matchIndex > -1 ? matchIndex : this.imageHistory.length - 1;
+
         },
         async requestHistory() {
             let bounds = this.timeContext.bounds();
             this.requestCount++;
             const requestId = this.requestCount;
+
+            // maintain previous focused image value to discern new index
+            const focusedImage = this.imageHistory[this.focusedImageIndex];
+            const previousFocusedImage = focusedImage ? JSON.parse(JSON.stringify(focusedImage)) : undefined;
             this.imageHistory = [];
 
             let data = await this.openmct.telemetry
@@ -143,7 +175,8 @@ export default {
                         imagery.push(image);
                     }
                 });
-                //this is to optimize anything that reacts to imageHistory length
+                this.updateFocusedImageIndex(previousFocusedImage, imagery);
+
                 this.imageHistory = imagery;
             }
         },


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
