### PR TITLE
Trasactions tests are ids equal fix 1.8.2

### DIFF
--- a/src/api/objects/TransactionSpec.js
+++ b/src/api/objects/TransactionSpec.js
@@ -15,7 +15,15 @@ describe("Transaction Class", () => {
 
                 return object;
             },
-            refresh: (object) => Promise.resolve(object)
+            refresh: (object) => Promise.resolve(object),
+            areIdsEqual: (...identifiers) => {
+                return identifiers.map(utils.parseKeyString)
+                    .every(identifier => {
+                        return identifier === identifiers[0]
+                            || (identifier.namespace === identifiers[0].namespace
+                                && identifier.key === identifiers[0].key);
+                    });
+            }
         };
 
         transaction = new Transaction(objectAPI);

--- a/src/plugins/importFromJSONAction/ImportFromJSONActionSpec.js
+++ b/src/plugins/importFromJSONAction/ImportFromJSONActionSpec.js
@@ -122,6 +122,7 @@ describe("The import JSON action", function () {
         ];
 
         spyOn(openmct.forms, 'showForm').and.returnValue(Promise.resolve({}));
+        spyOn(importFromJSONAction, 'onSave').and.returnValue(Promise.resolve({}));
         importFromJSONAction.invoke(objectPath);
 
         expect(openmct.forms.showForm).toHaveBeenCalled();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
