### PR TITLE
babel-eslint is deprecated and replaced with babel-eslint-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "allure-playwright": "^2.0.0-beta.14",
     "angular": ">=1.8.0",
     "angular-route": "1.4.14",
-    "babel-eslint": "10.0.3",
+    "@babel/eslint-parser": "7.16.5",
     "comma-separated-values": "^3.6.4",
     "concurrently": "^3.6.1",
     "copy-webpack-plugin": "^4.5.2",


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
