### PR TITLE
Update the regex detection on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,11 @@ updates:
       - "dependencies"
       - "pr:e2e"
     allow:
-      - dependency-name: "eslint*"
-      - dependency-name: "karma*"
-      - dependency-name: "jasmine*"
-      - dependency-name: "playwright*"
-      - dependency-name: "percy*"
+      - dependency-name: "*eslint*"
+      - dependency-name: "*karma*"
+      - dependency-name: "*jasmine*"
+      - dependency-name: "*playwright*"
+      - dependency-name: "*percy*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This should properly pick up anything with dependencies that don't begin with the package titles

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
