### PR TITLE
webpack stats changed to 'errors-warnings'

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -127,5 +127,5 @@ module.exports = {
             }
         ]
     },
-    stats: 'detailed'
+    stats: 'errors-warnings'
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
