### PR TITLE
4555 - Preserve the previousFocusedImage for local and fixed time

### DIFF
--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -420,8 +420,11 @@ export default {
                 imageIndex = newSize > 0 ? newSize - 1 : undefined;
             }
 
-            // preserve previous image if a subscription updates history size 
-            this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
+            // preserve previous image if a subscription updates history size
+            if (this.isPaused) {
+                this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
+            }
+
             this.setFocusedImage(imageIndex, false);
             this.scrollToRight();
         },

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -420,6 +420,8 @@ export default {
                 imageIndex = newSize > 0 ? newSize - 1 : undefined;
             }
 
+            // preserve previous image if a subscription updates history size 
+            this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
             this.setFocusedImage(imageIndex, false);
             this.scrollToRight();
         },
@@ -508,12 +510,6 @@ export default {
             if (this.timeContext) {
                 this.timeContext.off("timeSystem", this.trackDuration);
                 this.timeContext.off("clock", this.trackDuration);
-            }
-        },
-        boundsChange(bounds, isTick) {
-            if (!isTick) {
-                this.previousFocusedImage = this.focusedImage ? JSON.parse(JSON.stringify(this.focusedImage)) : undefined;
-                this.requestHistory();
             }
         },
         expand() {
@@ -676,14 +672,6 @@ export default {
                 this.$refs.thumbsWrapper.scrollLeft = scrollWidth;
             });
         },
-        matchIndexOfPreviousImage(previous, imageHistory) {
-            // match logic uses a composite of url and time to account
-            // for example imagery not having fully unique urls
-            return imageHistory.findIndex((x) => (
-                x.url === previous.url
-                && x.time === previous.time
-            ));
-        },
         setFocusedImage(index, thumbnailClick = false) {
             let focusedIndex = index;
             if (!(Number.isInteger(index) && index > -1)) {
@@ -697,8 +685,6 @@ export default {
                     this.imageHistory
                 );
                 focusedIndex = matchIndex > -1 ? matchIndex : this.imageHistory.length - 1;
-
-                delete this.previousFocusedImage;
             }
 
             if (thumbnailClick) {
@@ -706,7 +692,10 @@ export default {
                 this.focusedImageTimestamp = undefined;
             }
 
-            if (this.isPaused && !thumbnailClick && this.focusedImageTimestamp === undefined) {
+            this.focusedImageIndex = focusedIndex;
+            delete this.previousFocusedImage;
+
+            if (this.isPaused && !thumbnailClick && this.initFocusedImageIndex === undefined) {
                 this.nextImageIndex = focusedIndex;
                 //this could happen if bounds changes
                 if (this.focusedImageIndex > this.imageHistory.length - 1) {
@@ -715,8 +704,6 @@ export default {
 
                 return;
             }
-
-            this.focusedImageIndex = focusedIndex;
 
             if (thumbnailClick && !this.isPaused) {
                 this.paused(true);

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -129,10 +129,9 @@ export default {
             const previousFocusedImage = focusedImage ? JSON.parse(JSON.stringify(focusedImage)) : undefined;
             this.updateFocusedImageIndex(previousFocusedImage, this.imageHistory);
 
-            // forcibly recalculate the imageContainer size to prevent an aspect ratio distortion
+            // forcibly reset the imageContainer size to prevent an aspect ratio distortion
             delete this.imageContainerWidth;
             delete this.imageContainerHeight;
-            this.resizeImageContainer();
 
             return this.requestHistory();
         },

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -120,14 +120,45 @@ export default {
             return this.timeFormatter.parse(datum);
         },
         boundsChange(bounds, isTick) {
-            if (!isTick) {
-                this.requestHistory();
+            if (isTick) {
+                return;
             }
+
+            // the focusedImageIndex is calculated twice; once before and after request history arrives
+            const focusedImage = this.imageHistory[this.focusedImageIndex];
+            const previousFocusedImage = focusedImage ? JSON.parse(JSON.stringify(focusedImage)) : undefined;
+            this.updateFocusedImageIndex(previousFocusedImage, this.imageHistory);
+
+            return this.requestHistory();
+        },
+        matchIndexOfPreviousImage(previous, imageHistory) {
+            // match logic uses a composite of url and time to account
+            // for example imagery not having fully unique urls
+            return imageHistory.findIndex((x) => (
+                x.url === previous.url
+                && x.time === previous.time
+            ));
+        },
+        updateFocusedImageIndex(previous, imageHistory) {
+            if (!previous) {
+                return;
+            }
+
+            const matchIndex = this.matchIndexOfPreviousImage(
+                previous,
+                imageHistory
+            );
+            this.focusedImageIndex = matchIndex > -1 ? matchIndex : this.imageHistory.length - 1;
+
         },
         async requestHistory() {
             let bounds = this.timeContext.bounds();
             this.requestCount++;
             const requestId = this.requestCount;
+
+            // maintain previous focused image value to discern new index
+            const focusedImage = this.imageHistory[this.focusedImageIndex];
+            const previousFocusedImage = focusedImage ? JSON.parse(JSON.stringify(focusedImage)) : undefined;
             this.imageHistory = [];
 
             let data = await this.openmct.telemetry
@@ -141,7 +172,8 @@ export default {
                         imagery.push(image);
                     }
                 });
-                //this is to optimize anything that reacts to imageHistory length
+                this.updateFocusedImageIndex(previousFocusedImage, imagery);
+
                 this.imageHistory = imagery;
             }
         },

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -129,6 +129,11 @@ export default {
             const previousFocusedImage = focusedImage ? JSON.parse(JSON.stringify(focusedImage)) : undefined;
             this.updateFocusedImageIndex(previousFocusedImage, this.imageHistory);
 
+            // forcibly recalculate the imageContainer size to prevent an aspect ratio distortion
+            delete this.imageContainerWidth;
+            delete this.imageContainerHeight;
+            this.resizeImageContainer();
+
             return this.requestHistory();
         },
         matchIndexOfPreviousImage(previous, imageHistory) {


### PR DESCRIPTION
Replaces #4582 targeting `release/1.8.3` instead of master.

Closes #4555

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
