### PR TITLE
use relative path for imports in object-link.js

### DIFF
--- a/src/ui/mixins/object-link.js
+++ b/src/ui/mixins/object-link.js
@@ -1,4 +1,4 @@
-import objectPathToUrl from '/src/tools/url';
+import objectPathToUrl from '../../tools/url';
 
 export default {
     inject: ['openmct'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
