### PR TITLE
Check for ref when trying to get the style receiver.

### DIFF
--- a/src/ui/components/ObjectView.vue
+++ b/src/ui/components/ObjectView.vue
@@ -141,11 +141,15 @@ export default {
             this.openmct.objectViews.off('clearData', this.clearData);
         },
         getStyleReceiver() {
-            let styleReceiver = this.$refs.objectViewWrapper.querySelector('.js-style-receiver')
-                || this.$refs.objectViewWrapper.querySelector(':first-child');
+            let styleReceiver;
 
-            if (styleReceiver === null) {
-                styleReceiver = undefined;
+            if (this.$refs.objectViewWrapper !== undefined) {
+                styleReceiver = this.$refs.objectViewWrapper.querySelector('.js-style-receiver')
+                  || this.$refs.objectViewWrapper.querySelector(':first-child');
+
+                if (styleReceiver === null) {
+                    styleReceiver = undefined;
+                }
             }
 
             return styleReceiver;

--- a/src/ui/inspector/details/Properties.vue
+++ b/src/ui/inspector/details/Properties.vue
@@ -186,6 +186,10 @@ export default {
                     return {
                         name: field.name,
                         value: field.path.reduce((object, key) => {
+                            if (object === undefined) {
+                                return object;
+                            }
+
                             return object[key];
                         }, this.domainObject)
                     };


### PR DESCRIPTION
Resolves #4681 
Also ensure that the property being displayed in Properties is actually a part of the domainObject.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
