### PR TITLE
[Notebook] Persist timeframe and sort configuration

### DIFF
--- a/src/plugins/notebook/components/Notebook.vue
+++ b/src/plugins/notebook/components/Notebook.vue
@@ -175,7 +175,7 @@ export default {
             focusEntryId: null,
             search: '',
             searchResults: [],
-            showTime: 0,
+            showTime: this.domainObject.configuration.showTime || 0,
             showNav: false,
             sidebarCoversEntries: false
         };
@@ -239,6 +239,12 @@ export default {
     watch: {
         search() {
             this.getSearchResults();
+        },
+        defaultSort() {
+            mutateObject(this.openmct, this.domainObject, 'configuration.defaultSort', this.defaultSort);
+        },
+        showTime() {
+            mutateObject(this.openmct, this.domainObject, 'configuration.showTime', this.showTime);
         }
     },
     beforeMount() {


### PR DESCRIPTION
### All Submissions:

Saving config for timeframe and sort for notebook entries.

closes: #4319

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?
