### PR TITLE
[e2e] Add projects to local config and comment out ipad

### DIFF
--- a/e2e/playwright-ci.config.js
+++ b/e2e/playwright-ci.config.js
@@ -41,14 +41,14 @@ const config = {
                     height: 1440
                 }
             }
-        },
-        {
+        }
+        /*{
             name: 'ipad',
             use: {
                 browserName: 'webkit',
                 ...devices['iPad (gen 7) landscape'] // Complete List https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/deviceDescriptorsSource.json
             }
-        }
+        }*/
     ],
     reporter: [
         ['list'],

--- a/e2e/playwright-local.config.js
+++ b/e2e/playwright-local.config.js
@@ -2,6 +2,8 @@
 // playwright.config.js
 // @ts-check
 
+const { devices } = require('@playwright/test');
+
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
     retries: 0,
@@ -23,6 +25,32 @@ const config = {
         trace: 'on',
         video: 'on'
     },
+    projects: [
+        {
+            name: 'chrome',
+            use: {
+                browserName: 'chromium',
+                ...devices['Desktop Chrome']
+            }
+        },
+        {
+            name: 'MMOC',
+            use: {
+                browserName: 'chromium',
+                viewport: {
+                    width: 2560,
+                    height: 1440
+                }
+            }
+        }
+        /*{
+            name: 'ipad',
+            use: {
+                browserName: 'webkit',
+                ...devices['iPad (gen 7) landscape'] // Complete List https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/deviceDescriptorsSource.json
+            }
+        }*/
+    ],
     reporter: [
         ['list'],
         ['allure-playwright']


### PR DESCRIPTION
Comments out ipad support until we can address it in build 7. File the ticket here https://github.com/nasa/openmct/issues/4728
Adds project profiles to local testing

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?
