### PR TITLE
[CI] Dependabot and PR Cop have conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,4 @@ updates:
     labels:
       - "type:maintenance"
       - "dependencies"
+      - "prcop:disable"


### PR DESCRIPTION
### Describe your changes:
This updates the PR to include a "safe word" for pr cop to ignore PRs opened by the dependabot user. The Dependabot PRs will not follow our issue template requirements because they strictly modify dependencies (which fall out of our traditional testing notes requirements)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
