### PR TITLE
[Build] Update minimum node12 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "url": "https://github.com/nasa/openmct.git"
   },
   "engines": {
-    "node": ">=12.0.1 <15.0.0"
+    "node": ">=12.20.1 <15.0.0"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes: #4778 

### Describe your changes:
This catches a node 12.18 and 12.19 bug which was fixed in node 12.20+. This will cause an WARN to be thrown if the node 12 version is note >12.20.1. (12.22.9 is the latest as of this writing)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
