### PR TITLE
Observe changes to sub-objects in flexible layouts.

### DIFF
--- a/src/plugins/flexibleLayout/components/frame.vue
+++ b/src/plugins/flexibleLayout/components/frame.vue
@@ -97,7 +97,14 @@ export default {
     },
     mounted() {
         if (this.frame.domainObjectIdentifier) {
-            this.openmct.objects.get(this.frame.domainObjectIdentifier).then((object) => {
+            let domainObjectPromise;
+            if (this.openmct.objects.supportsMutation(this.frame.domainObjectIdentifier)) {
+                domainObjectPromise = this.openmct.objects.getMutable(this.frame.domainObjectIdentifier);
+            } else {
+                domainObjectPromise = this.openmct.objects.get(this.frame.domainObjectIdentifier);
+            }
+
+            domainObjectPromise.then((object) => {
                 this.setDomainObject(object);
             });
         }
@@ -105,6 +112,10 @@ export default {
         this.dragGhost = document.getElementById('js-fl-drag-ghost');
     },
     beforeDestroy() {
+        if (this.domainObject.isMutable) {
+            this.openmct.objects.destroyMutable(this.domainObject);
+        }
+
         if (this.unsubscribeSelection) {
             this.unsubscribeSelection();
         }

--- a/src/plugins/notebook/components/Notebook.vue
+++ b/src/plugins/notebook/components/Notebook.vue
@@ -632,7 +632,8 @@ export default {
         updateDefaultNotebook(updatedNotebookStorageObject) {
             if (!this.isDefaultNotebook()) {
                 const persistedNotebookStorageObject = getDefaultNotebook();
-                if (persistedNotebookStorageObject.identifier !== undefined) {
+                if (persistedNotebookStorageObject
+                    && persistedNotebookStorageObject.identifier !== undefined) {
                     this.removeDefaultClass(persistedNotebookStorageObject.identifier);
                 }
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes: https://github.com/nasa/openmct/issues/4773

### Describe your changes:
* Modifies the "Frame" component of Flexible layouts to fetch a MutableDomainObject if possible, instead of a regular domain object. This will allow the sub object view to react to asynchronous mutation events.
* Fixes a bug that would cause a JavaScript error if no default notebook was set at all.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes? N/A - Forgoing unit test due to small changeset.
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
