### PR TITLE
Follow domain object changes for Independent time conductor

### DIFF
--- a/src/plugins/timeConductor/ConductorInputsFixed.vue
+++ b/src/plugins/timeConductor/ConductorInputsFixed.vue
@@ -95,6 +95,11 @@ export default {
             isUTCBased: timeSystem.isUTCBased
         };
     },
+    watch: {
+        keyString() {
+            this.setTimeContext();
+        }
+    },
     mounted() {
         this.handleNewBounds = _.throttle(this.handleNewBounds, 300);
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));

--- a/src/plugins/timeConductor/ConductorInputsRealtime.vue
+++ b/src/plugins/timeConductor/ConductorInputsRealtime.vue
@@ -115,6 +115,11 @@ export default {
             isUTCBased: timeSystem.isUTCBased
         };
     },
+    watch: {
+        keyString() {
+            this.setTimeContext();
+        }
+    },
     mounted() {
         this.handleNewBounds = _.throttle(this.handleNewBounds, 300);
         this.setTimeSystem(JSON.parse(JSON.stringify(this.openmct.time.timeSystem())));

--- a/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
+++ b/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
@@ -137,7 +137,11 @@ export default {
             if (this.timeOptions.mode) {
                 this.mode = this.timeOptions.mode;
             } else {
-                this.timeOptions.mode = this.mode = this.timeContext.clock() === undefined ? { key: 'fixed' } : { key: Object.create(this.timeContext.clock()).key};
+                if (this.timeContext.clock() === undefined) {
+                    this.timeOptions.mode = this.mode = { key: 'fixed' };
+                } else {
+                    this.timeOptions.mode = this.mode = { key: Object.create(this.timeContext.clock()).key};
+                }
             }
 
             if (this.independentTCEnabled) {

--- a/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
+++ b/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
@@ -105,42 +105,45 @@ export default {
     watch: {
         domainObject: {
             handler(domainObject) {
-                this.independentTCEnabled = domainObject.configuration.useIndependentTime === true;
-
-                if (!domainObject.configuration.timeOptions || !this.independentTCEnabled) {
+                const key = this.openmct.objects.makeKeyString(domainObject.identifier);
+                if (key !== this.keyString) {
+                    //domain object has changed
                     this.destroyIndependentTime();
 
-                    return;
-                }
+                    this.independentTCEnabled = domainObject.configuration.useIndependentTime === true;
+                    this.timeOptions = domainObject.configuration.timeOptions || {
+                        clockOffsets: this.openmct.time.clockOffsets(),
+                        fixedOffsets: this.openmct.time.bounds()
+                    };
 
-                if (this.timeOptions.start !== domainObject.configuration.timeOptions.start
-                    || this.timeOptions.end !== domainObject.configuration.timeOptions.end) {
-                    this.timeOptions = domainObject.configuration.timeOptions;
-                    this.destroyIndependentTime();
-                    this.registerIndependentTimeOffsets();
+                    this.initialize();
                 }
             },
             deep: true
         }
     },
     mounted() {
-        this.setTimeContext();
-
-        if (this.timeOptions.mode) {
-            this.mode = this.timeOptions.mode;
-        } else {
-            this.timeOptions.mode = this.mode = this.timeContext.clock() === undefined ? { key: 'fixed' } : { key: Object.create(this.timeContext.clock()).key};
-        }
-
-        if (this.independentTCEnabled) {
-            this.registerIndependentTimeOffsets();
-        }
+        this.initialize();
     },
     beforeDestroy() {
         this.stopFollowingTimeContext();
         this.destroyIndependentTime();
     },
     methods: {
+        initialize() {
+            this.keyString = this.openmct.objects.makeKeyString(this.domainObject.identifier);
+            this.setTimeContext();
+
+            if (this.timeOptions.mode) {
+                this.mode = this.timeOptions.mode;
+            } else {
+                this.timeOptions.mode = this.mode = this.timeContext.clock() === undefined ? { key: 'fixed' } : { key: Object.create(this.timeContext.clock()).key};
+            }
+
+            if (this.independentTCEnabled) {
+                this.registerIndependentTimeOffsets();
+            }
+        },
         toggleIndependentTC() {
             this.independentTCEnabled = !this.independentTCEnabled;
             if (this.independentTCEnabled) {
@@ -213,10 +216,9 @@ export default {
                 offsets = this.timeOptions.clockOffsets;
             }
 
-            const key = this.openmct.objects.makeKeyString(this.domainObject.identifier);
-            const timeContext = this.openmct.time.getIndependentContext(key);
+            const timeContext = this.openmct.time.getIndependentContext(this.keyString);
             if (!timeContext.hasOwnContext()) {
-                this.unregisterIndependentTime = this.openmct.time.addIndependentContext(key, offsets, this.isFixed ? undefined : this.mode.key);
+                this.unregisterIndependentTime = this.openmct.time.addIndependentContext(this.keyString, offsets, this.isFixed ? undefined : this.mode.key);
             } else {
                 if (this.isFixed) {
                     timeContext.stopClock();


### PR DESCRIPTION
Closes: #4722 #4772

### Describe your changes:
Use the domain object identifier to check if the domain object being referenced in independent time conductor has changed.
Change the time context for independent time conductor, fixed and real time inputs if the domain object changes.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
