### PR TITLE
[CI] Update github actions automation to work across forks

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -15,8 +15,8 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: nasa,
-              repo: openmct,
+              owner: "nasa",
+              repo: "openmct",
               body: 'Started e2e Run. Follow along: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })
       - uses: actions/checkout@v2
@@ -37,8 +37,8 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: nasa,
-              repo: openmct,
+              owner: "nasa",
+              repo: "openmct",
               body: 'Success ✅ ! Build artifacts are here: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })
       - name: Test failure
@@ -48,7 +48,7 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: nasa,
-              repo: openmct,
+              owner: "nasa",
+              repo: "openmct",
               body: 'Failure ❌ ! Build artifacts are here: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -15,8 +15,8 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: nasa,
+              repo: openmct,
               body: 'Started e2e Run. Follow along: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })
       - uses: actions/checkout@v2
@@ -37,8 +37,8 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: nasa,
+              repo: openmct,
               body: 'Success ✅ ! Build artifacts are here: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })
       - name: Test failure
@@ -48,7 +48,7 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: nasa,
+              repo: openmct,
               body: 'Failure ❌ ! Build artifacts are here: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #4541 

### Describe your changes:
github action triggers are currently not working across forks because of some homerolled script assumptions around owner and repo. I've hardcoded them to nasa/openmct.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
