### PR TITLE
[Build] npm run clean uses absolute path instead of relative for node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "zepto": "^1.2.0"
   },
   "scripts": {
-    "clean": "rm -rf ./dist /node_modules; rm package-lock.json",
-    "clean-test-lint": "npm run clean; npm install ; npm run test; npm run lint",
+    "clean": "rm -rf ./dist ./node_modules; rm package-lock.json",
+    "clean-test-lint": "npm run clean; npm install; npm run test; npm run lint",
     "start": "node app.js",
     "lint": "eslint platform example src --ext .js,.vue openmct.js",
     "lint:fix": "eslint platform example src --ext .js,.vue openmct.js --fix",


### PR DESCRIPTION
Closes #4800 
### Describe your changes:
npm run clean is designed to clean the dist and node_modules folder. With the current implementation, it uses a relative path for ./dist but an absolute path /node_modules . Effectively, this means that node_modules are not cleaned on personal devices.

This PR corrects that mistake

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
