### PR TITLE
Request data when switching between real time and fixed.

### DIFF
--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -456,8 +456,10 @@ export default {
         },
         updateRealTime(clock) {
             this.isRealTime = clock !== undefined;
-            //re-request data if we switch from/to realtime
-            this.updateDisplayBounds(this.timeContext.bounds());
+            //re-request data if we switch to realtime
+            if (this.isRealTime) {
+                this.updateDisplayBounds(this.timeContext.bounds());
+            }
         },
 
         /**

--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -456,6 +456,8 @@ export default {
         },
         updateRealTime(clock) {
             this.isRealTime = clock !== undefined;
+            //re-request data if we switch from/to realtime
+            this.updateDisplayBounds(this.timeContext.bounds());
         },
 
         /**

--- a/src/plugins/timeConductor/ConductorInputsFixed.vue
+++ b/src/plugins/timeConductor/ConductorInputsFixed.vue
@@ -131,11 +131,17 @@ export default {
             this.setViewFromBounds(bounds);
         },
         clearAllValidation() {
-            if (!this.$refs.startDate || !this.$refs.endDate) {
-                return;
+            let dateRefs = [];
+
+            if (this.$refs.startDate) {
+                dateRefs.push(this.$refs.startDate);
             }
 
-            [this.$refs.startDate, this.$refs.endDate].forEach(this.clearValidationForInput);
+            if (this.$refs.endDate) {
+                dateRefs.push(this.$refs.endDate);
+            }
+
+            dateRefs.forEach(this.clearValidationForInput);
         },
         clearValidationForInput(input) {
             input.setCustomValidity('');

--- a/src/plugins/timeConductor/ConductorInputsFixed.vue
+++ b/src/plugins/timeConductor/ConductorInputsFixed.vue
@@ -131,6 +131,10 @@ export default {
             this.setViewFromBounds(bounds);
         },
         clearAllValidation() {
+            if (!this.$refs.startDate || !this.$refs.endDate) {
+                return;
+            }
+
             [this.$refs.startDate, this.$refs.endDate].forEach(this.clearValidationForInput);
         },
         clearValidationForInput(input) {

--- a/src/plugins/timeConductor/ConductorInputsRealtime.vue
+++ b/src/plugins/timeConductor/ConductorInputsRealtime.vue
@@ -155,6 +155,10 @@ export default {
             this.setViewFromBounds(bounds);
         },
         clearAllValidation() {
+            if (!this.$refs.startOffset || !this.$refs.endOffset) {
+                return;
+            }
+
             [this.$refs.startOffset, this.$refs.endOffset].forEach(this.clearValidationForInput);
         },
         clearValidationForInput(input) {

--- a/src/plugins/timeConductor/ConductorInputsRealtime.vue
+++ b/src/plugins/timeConductor/ConductorInputsRealtime.vue
@@ -155,11 +155,17 @@ export default {
             this.setViewFromBounds(bounds);
         },
         clearAllValidation() {
-            if (!this.$refs.startOffset || !this.$refs.endOffset) {
-                return;
+            let dateRefs = [];
+
+            if (this.$refs.startOffset) {
+                dateRefs.push(this.$refs.startOffset);
             }
 
-            [this.$refs.startOffset, this.$refs.endOffset].forEach(this.clearValidationForInput);
+            if (this.$refs.endOffset) {
+                dateRefs.push(this.$refs.endOffset);
+            }
+
+            dateRefs.forEach(this.clearValidationForInput);
         },
         clearValidationForInput(input) {
             input.setCustomValidity('');


### PR DESCRIPTION
Closes #4777 

Update display bounds when switching between time conductor modes. Which in turn re-requests data.
Also add some null checks.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
