### PR TITLE
[Build] Enforce engine at build time

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,6 @@ loglevel=warn
 # webpack 4 being the latest version it supports, so this legacy-peer-deps
 # allows us to install it anyway.
 legacy-peer-deps=true
+
+#Prevent folks from ignoring an important error when building from source
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "imports-loader": "0.8.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine-core": "4.0.0",
-    "jsdoc": "^3.3.2",
+    "jsdoc": "3.5.5",
     "karma": "6.3.15",
     "karma-chrome-launcher": "3.1.0",
     "karma-cli": "2.0.0",


### PR DESCRIPTION
Closes https://github.com/nasa/openmct/issues/4845

### Describe your changes:
Adds a flag in npmrc to enforce engine rules

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
