### PR TITLE
Bumped dependency versions to fix build issues in Node 16 and later

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
     "sinon": "13.0.1",
     "style-loader": "^1.0.1",
     "uuid": "^3.3.3",
-    "vue": "2.5.6",
+    "vue": "2.6.14",
     "vue-eslint-parser": "8.2.0",
     "vue-loader": "15.9.8",
-    "vue-template-compiler": "2.5.6",
-    "webpack": "5.67.0",
+    "vue-template-compiler": "2.6.14",
+    "webpack": "5.68.0",
     "webpack-cli": "4.9.2",
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.3",
@@ -105,7 +105,7 @@
     "url": "https://github.com/nasa/openmct.git"
   },
   "engines": {
-    "node": ">=12.20.1 <15.0.0"
+    "node": ">=12.22.0"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,7 +6,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
-const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const {VueLoaderPlugin} = require('vue-loader');
 const gitRevision = require('child_process')
     .execSync('git rev-parse HEAD')
     .toString().trim();


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/nasa/openmct/issues/3966

### Describe your changes:
* Bumps version numbers of webpack, vue, and vue-template compiler which fixes the issue we were seeing where Open MCT builds would hang after successful compilation on Node 16+
* Updates `engines` attribute in `package.json` to bump minimum supported Node version to 12.22.0 due to incompatibility with vue-eslint-parser library
* Removes maximum supported Node version

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes? N/A - changes to build tooling only
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
