### PR TITLE
[CI] Remove warning output for eslint on platform workflow

### DIFF
--- a/.github/workflows/pr-platform.yml
+++ b/.github/workflows/pr-platform.yml
@@ -31,4 +31,4 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - run: npm install
       - run: npm test
-      - run: npm run lint
+      - run: npm run lint -- --quiet


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #4909 

### Describe your changes:
This adds the quiet flag to the `npm run lint` when run as a part of the pr:platform workflow. This prevents output from the cli being generated and attached to the 'Files' in-line help.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
