### PR TITLE
Add source maps to map plan properties to expected properties

### DIFF
--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -21,6 +21,7 @@
  *****************************************************************************/
 
 export function getValidatedPlan(domainObject) {
+    let sourceMap = domainObject.sourceMap;
     let body = domainObject.selectFile.body;
     let json = {};
     if (typeof body === 'string') {
@@ -33,5 +34,33 @@ export function getValidatedPlan(domainObject) {
         json = body;
     }
 
-    return json;
+    if (sourceMap !== undefined && sourceMap.activities !== undefined && sourceMap.groupId !== undefined) {
+        let mappedJson = {};
+        json[sourceMap.activities].forEach((activity) => {
+            if (activity[sourceMap.groupId]) {
+                const groupIdKey = activity[sourceMap.groupId];
+                let groupActivity = {
+                    ...activity
+                };
+
+                if (sourceMap.start) {
+                    groupActivity.start = activity[sourceMap.start];
+                }
+
+                if (sourceMap.end) {
+                    groupActivity.end = activity[sourceMap.end];
+                }
+
+                if (!mappedJson[groupIdKey]) {
+                    mappedJson[groupIdKey] = [];
+                }
+
+                mappedJson[groupIdKey].push(groupActivity);
+            }
+        });
+
+        return mappedJson;
+    } else {
+        return json;
+    }
 }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #4882

### Describe your changes:
The VIPER planning tool team has changed the structure of the JSON they post to couchDB. In order to not change the current model for plans in Open MCT, we're introducing a sourceMap option where JSON properties can be mapped to expected json properties. For example:
`object.sourceMap = {
                        start: 'start_time',
                        end: 'end_time',
                        activities: 'items',
                        groupId: 'group_name'
                    };`

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
