### PR TITLE
Fix the clock and update some tests

### DIFF
--- a/e2e/tests/visual/default.spec.js
+++ b/e2e/tests/visual/default.spec.js
@@ -22,14 +22,14 @@
 
 /*
 Collection of Visual Tests set to run in a default context. The tests within this suite
-are only meant to run against openmct's app.js started by `npm run start` within the 
+are only meant to run against openmct's app.js started by `npm run start` within the
 `./e2e/playwright-visual.config.js` file.
 
-These should only use functional expect statements to verify assumptions about the state 
+These should only use functional expect statements to verify assumptions about the state
 in a test and not for functional verification of correctness. Visual tests are not supposed
 to "fail" on assertions. Instead, they should be used to detect changes between builds or branches.
 
-Note: Larger testsuite sizes are OK due to the setup time associated with these tests. 
+Note: Larger testsuite sizes are OK due to the setup time associated with these tests.
 */
 
 const { test, expect } = require('@playwright/test');
@@ -170,4 +170,25 @@ test('Visual - Sine Wave Generator Form', async ({ page }) => {
     // Validate red x mark
     await page.waitForTimeout(VISUAL_GRACE_PERIOD);
     await percySnapshot(page, 'removed amplitude property value');
+});
+
+test.only('Visual - Timestrip', async ({ page }) => {
+    //Go to baseURL
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    //Click the Create button
+    await page.click('button:has-text("Create")');
+
+    // Click li:has-text("Example Imagery")
+    await page.locator('li:has-text("Example Imagery")').click();
+
+    // Fill input[type="number"]
+    await page.locator('input[type="number"]').fill('500');
+
+    // Click text=OK
+    await page.locator('text=OK').click();
+    
+    // Validate red x mark
+    await page.waitForTimeout(VISUAL_GRACE_PERIOD);
+    await percySnapshot(page, 'Default Timestrip created');
 });

--- a/e2e/tests/visual/default.visual.spec.js
+++ b/e2e/tests/visual/default.visual.spec.js
@@ -1,0 +1,126 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*
+Collection of Visual Tests set to run in a default context. The tests within this suite
+are only meant to run against openmct's app.js started by `npm run start` within the
+`./e2e/playwright-visual.config.js` file.
+
+These should only use functional expect statements to verify assumptions about the state
+in a test and not for functional verification of correctness. Visual tests are not supposed
+to "fail" on assertions. Instead, they should be used to detect changes between builds or branches.
+
+Note: Larger testsuite sizes are OK due to the setup time associated with these tests.
+*/
+
+const { test, expect } = require('@playwright/test');
+const percySnapshot = require('@percy/playwright');
+const path = require('path');
+const sinon = require('sinon');
+
+const VISUAL_GRACE_PERIOD = 5 * 1000; //Lets the application "simmer" before the snapshot is taken
+
+// // Snippet from https://github.com/microsoft/playwright/issues/6347#issuecomment-965887758
+// //Will replace with cy.clock() equivalent
+test.beforeEach(async ({ context }) => {
+    await context.addInitScript({
+        // eslint-disable-next-line no-undef
+        path: path.join(__dirname, '../../..', './node_modules/sinon/pkg/sinon.js')
+    });
+    await context.addInitScript(() => {
+        window.__clock = sinon.useFakeTimers({
+            now: 1483228800000,
+            shouldAdvanceTime: true
+        }); //Set browser clock to UNIX Epoch
+    });
+});
+
+test('Visual - Display layout items view', async ({ page }) => {
+    //Go to baseURL
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    await page.evaluate(() => window.__clock.tick(1000));
+
+    //Click the Create button
+    await page.click('button:has-text("Create")');
+
+    // Click text=Display Layout
+    await page.click('text=Display Layout');
+
+    // Click text=OK
+    await page.click('text=OK');
+
+    // Take a snapshot of the newly created Display Layout object
+    await page.waitForTimeout(VISUAL_GRACE_PERIOD);
+    await percySnapshot(page, 'Default Display Layout');
+
+    // Click text=Snapshot Save and Finish Editing Save and Continue Editing >> button >> nth=1
+    await page.locator('text=Snapshot Save and Finish Editing Save and Continue Editing >> button').nth(1).click();
+
+    // Click text=Save and Finish Editing
+    await page.locator('text=Save and Finish Editing').click();
+
+    //Click the Create button
+    await page.click('button:has-text("Create")');
+
+    // Click text=Sine Wave Generator
+    await page.click('text=Sine Wave Generator');
+
+    // Click text=Save In Open MCT No items >> input[type="search"]
+    await page.locator('text=Save In Open MCT No items >> input[type="search"]').click();
+
+    // Fill text=Save In Open MCT No items >> input[type="search"]
+    await page.locator('text=Save In Open MCT No items >> input[type="search"]').fill('Unnamed Display Layout');
+
+    // Click text=OK Cancel
+    await page.locator('text=OK Cancel').click();
+
+    // Click text=OK
+    await page.click('text=OK');
+
+    // Take a snapshot of the newly created Display Layout object
+    await page.waitForTimeout(VISUAL_GRACE_PERIOD);
+    await percySnapshot(page, 'Default Sine Wave Generator');
+
+});
+
+test.skip('Visual - Timestrip', async ({ page }) => {
+    //Go to baseURL
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    //Click the Create button
+    await page.click('button:has-text("Create")');
+
+    // Click li:has-text("Example Imagery")
+    await page.locator('li:has-text("Example Imagery")').click();
+
+    // Fill input[type="number"]
+    //await page.locator('input[type="number"]').fill('500');
+
+    // Click text=OK
+    await page.locator('text=OK').click();
+
+    await page.pause();
+    // 
+    await page.waitForTimeout(VISUAL_GRACE_PERIOD);
+    await percySnapshot(page, 'Default Timestrip created');
+});

--- a/e2e/tests/visual/modifiedClock.visual.spec.js
+++ b/e2e/tests/visual/modifiedClock.visual.spec.js
@@ -40,7 +40,7 @@ const sinon = require('sinon');
 const VISUAL_GRACE_PERIOD = 5 * 1000; //Lets the application "simmer" before the snapshot is taken
 
 // Snippet from https://github.com/microsoft/playwright/issues/6347#issuecomment-965887758
-// Will replace with cy.clock() equivalent
+//Will replace with cy.clock() equivalent
 test.beforeEach(async ({ context }) => {
     await context.addInitScript({
         // eslint-disable-next-line no-undef
@@ -183,12 +183,13 @@ test.only('Visual - Timestrip', async ({ page }) => {
     await page.locator('li:has-text("Example Imagery")').click();
 
     // Fill input[type="number"]
-    await page.locator('input[type="number"]').fill('500');
+    //await page.locator('input[type="number"]').fill('500');
 
     // Click text=OK
     await page.locator('text=OK').click();
-    
-    // Validate red x mark
+
+    await page.pause();
+    // 
     await page.waitForTimeout(VISUAL_GRACE_PERIOD);
     await percySnapshot(page, 'Default Timestrip created');
 });


### PR DESCRIPTION
Closes

### Describe your changes:
This fixes some clock based tests and allows us to manipulate the clock more precisely. This is necessary for things like timestrip which rely on window.clock != 0

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
