### PR TITLE
Add Performance Mark to View Large action

### DIFF
--- a/src/plugins/viewLargeAction/viewLargeAction.js
+++ b/src/plugins/viewLargeAction/viewLargeAction.js
@@ -38,6 +38,7 @@ export default class ViewLargeAction {
     }
 
     invoke(objectPath, view) {
+        performance.mark('viewlarge.start');
         const childElement = view?.parentElement?.firstChild;
         if (!childElement) {
             const message = "ViewLargeAction: missing element";


### PR DESCRIPTION
Closes #4401

### Describe your changes:
Example of performance.mark for measure UserTiming(). It then becomes available in devtools as:

<img width="255" alt="Screen Shot 2022-04-01 at 3 26 08 PM" src="https://user-images.githubusercontent.com/12446869/161350004-84ce93bf-85e0-4147-bd2d-ca5bbe6f5c97.png">


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
