### PR TITLE
[Build] Update broken transitive percy package and override core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
+    "@percy/cli": "1.0.4",
     "@percy/playwright": "1.0.2",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
-    "@percy/cli": "1.0.0-beta.76",
+    "@percy/cli": "1.0.1",
     "@percy/playwright": "1.0.1",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
     "@percy/cli": "1.0.0-beta.75",
-    "@percy/playwright": "1.0.0-beta.75",
+    "@percy/playwright": "1.0.1",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",
     "@types/jasmine": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
-    "@percy/cli": "1.0.1",
-    "@percy/playwright": "1.0.1",
+    "@percy/cli": "1.0.0-beta.75",
+    "@percy/playwright": "1.0.0-beta.75",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",
     "@types/jasmine": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
-    "@percy/cli": "1.0.2",
-    "@percy/playwright": "1.0.1",
+    "@percy/cli": "1.0.4",
+    "@percy/playwright": "1.0.2",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",
     "@types/jasmine": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
-    "@percy/cli": "1.0.0-beta.75",
+    "@percy/cli": "1.0.0-beta.76",
     "@percy/playwright": "1.0.1",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",
@@ -18,7 +18,6 @@
     "babel-plugin-istanbul": "6.1.1",
     "comma-separated-values": "3.6.4",
     "copy-webpack-plugin": "10.2.0",
-    "core-js": "3.21.1",
     "cross-env": "7.0.3",
     "css-loader": "4.0.0",
     "d3-axis": "1.0.x",
@@ -111,6 +110,10 @@
   },
   "engines": {
     "node": ">=14.19.1"
+  },
+  "overrides": {
+    "core-js": "3.21.1",
+    "@percy/sdk-utils": "1.0.0-beta.76"
   },
   "browserslist": [
     "Firefox ESR",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
-    "@percy/cli": "1.0.4",
     "@percy/playwright": "1.0.2",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.16.3",
     "@braintree/sanitize-url": "6.0.0",
-    "@percy/cli": "1.0.0-beta.76",
+    "@percy/cli": "1.0.2",
     "@percy/playwright": "1.0.1",
     "@playwright/test": "1.19.2",
     "@types/eventemitter3": "^1.0.0",
@@ -112,8 +112,7 @@
     "node": ">=14.19.1"
   },
   "overrides": {
-    "core-js": "3.21.1",
-    "@percy/sdk-utils": "1.0.0-beta.76"
+    "core-js": "3.21.1"
   },
   "browserslist": [
     "Firefox ESR",


### PR DESCRIPTION
Closes: https://github.com/nasa/openmct/issues/5029 and https://github.com/nasa/openmct/issues/5034

### Describe your changes:
Pins percy to a working version by overriding the depenency resolution
We did this a few months ago for core-js https://github.com/nasa/openmct/pull/4795/files#r794604908

Here is some more info https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
