### PR TITLE
[Temp] Remove e2e-ci until percy fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,11 +153,7 @@ workflows:
       - unit-test:
           name: node16-chrome
           node-version: lts/gallium
-          browser: ChromeHeadless             
-      - e2e-test:
-          name: e2e-ci
-          node-version: lts/gallium
-          suite: ci
+          browser: ChromeHeadless
   the-nightly: #These jobs do not run on PRs, but against master at night
     jobs:
       - unit-test:


### PR DESCRIPTION
### Describe your changes:
Temporarily disable e2e-ci checks on release/2.0.2 due to https://github.com/nasa/openmct/issues/5029

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
