### PR TITLE
Fix duration to milliseconds converter

### DIFF
--- a/src/plugins/timelist/Timelist.vue
+++ b/src/plugins/timelist/Timelist.vue
@@ -229,7 +229,7 @@ export default {
                 } else if (durationIndex === 1) {
                     return duration * 60 * 1000;
                 } else if (durationIndex === 2) {
-                    return duration * 60 * 24 * 1000;
+                    return duration * 60 * 60 * 1000;
                 }
             }
         },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Addresses 4765 

### Describe your changes:
Fix typo in duration to milliseconds conversion (60 not 24)

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
