### PR TITLE
insert performance marks for telemetry table processing

### DIFF
--- a/src/api/telemetry/TelemetryCollection.js
+++ b/src/api/telemetry/TelemetryCollection.js
@@ -172,6 +172,7 @@ export class TelemetryCollection extends EventEmitter {
      * @private
      */
     _processNewTelemetry(telemetryData) {
+        performance.mark('begin telemetry processing')
         if (telemetryData === undefined) {
             return;
         }

--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -669,6 +669,7 @@ export default {
             this.setHeight();
         },
         rowsAdded(rows) {
+            performance.mark('end telemetry processing');
             this.setHeight();
 
             let sizingRow;


### PR DESCRIPTION
@unlikelyzero performance marks inserted for our current telemetry table implementation using insertion sort