### PR TITLE
Use navigator platform to display separate for Linux OS - 4848

### DIFF
--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -180,7 +180,7 @@ test.describe('Example Imagery', () => {
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
 
-    test.only('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
+    test('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
         // userAgentData.platform is not available so match against entire userAgent string
         const userAgent = await page.evaluate('navigator.userAgent');
         expect(userAgent).toBeTruthy();
@@ -197,7 +197,7 @@ test.describe('Example Imagery', () => {
         expect(expectedAltText).toEqual(imageryHintsText);
     });
 
-    test.only('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
+    test('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
         // userAgentData.platform is not available so match against entire userAgent string
         const userAgent = await page.evaluate('navigator.userAgent');
         expect(userAgent).toBeTruthy();

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -31,7 +31,7 @@ const { test, expect } = require('@playwright/test');
 test.describe('Example Imagery', () => {
 
     test.beforeEach(async ({ page }) => {
-        page.on('console', msg => console.log(msg.text()))
+        page.on('console', msg => console.log(msg.text()));
         //Go to baseURL
         await page.goto('/', { waitUntil: 'networkidle' });
 
@@ -43,10 +43,13 @@ test.describe('Example Imagery', () => {
 
         // Click text=OK
         await Promise.all([
-            page.waitForNavigation(/*{ url: 'http://localhost:8080/#/browse/mine/dab945d4-5a84-480e-8180-222b4aa730fa?tc.mode=fixed&tc.startBound=1639696164435&tc.endBound=1639697964435&tc.timeSystem=utc&view=conditionSet.view' }*/),
-            page.click('text=OK')
+            page.waitForNavigation({waitUntil: 'networkidle'}),
+            page.click('text=OK'),
+            //Wait for Save Banner to appear
+            page.waitForSelector('.c-message-banner__message')
         ]);
-
+        //Wait until Save Banner is gone
+        await page.waitForSelector('.c-message-banner__message', { state: 'detached'});
         await expect(page.locator('.l-browse-bar__object-name')).toContainText('Unnamed Example Imagery');
     });
 
@@ -81,6 +84,7 @@ test.describe('Example Imagery', () => {
 
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
+
         // zoom in
         await page.mouse.wheel(0, deltaYStep * 2);
         await bgImageLocator.hover();
@@ -157,20 +161,26 @@ test.describe('Example Imagery', () => {
 
     test('Can use the reset button to reset the image', async ({ page }) => {
         const bgImageLocator = await page.locator(backgroundImageSelector);
+        // wait for zoom animation to finish
         await bgImageLocator.hover();
+
         const zoomInBtn = await page.locator('.t-btn-zoom-in');
         const zoomResetBtn = await page.locator('.t-btn-zoom-reset');
         const initialBoundingBox = await bgImageLocator.boundingBox();
 
         await zoomInBtn.click();
+        // wait for zoom animation to finish
+        await bgImageLocator.hover();
         await zoomInBtn.click();
         // wait for zoom animation to finish
         await bgImageLocator.hover();
+
         const zoomedInBoundingBox = await bgImageLocator.boundingBox();
         expect.soft(zoomedInBoundingBox.height).toBeGreaterThan(initialBoundingBox.height);
         expect.soft(zoomedInBoundingBox.width).toBeGreaterThan(initialBoundingBox.width);
 
         await zoomResetBtn.click();
+        // wait for zoom animation to finish
         await bgImageLocator.hover();
 
         const resetBoundingBox = await bgImageLocator.boundingBox();
@@ -181,7 +191,7 @@ test.describe('Example Imagery', () => {
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
     test('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
-        test.skip(process.platform !== 'linux');
+        test.skip(process.platform === 'linux');
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
         const zoomInBtn = await page.locator('.t-btn-zoom-in');
@@ -193,7 +203,7 @@ test.describe('Example Imagery', () => {
     });
 
     test('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
-        test.skip(process.platform === 'linux');
+        test.skip(process.platform !== 'linux');
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
         const zoomInBtn = await page.locator('.t-btn-zoom-in');
@@ -204,38 +214,38 @@ test.describe('Example Imagery', () => {
         expect(expectedAltText).toEqual(imageryHintsText);
     });
 
-    //test('Can use Mouse Wheel to zoom in and out of previous image');
-    //test('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
-    //test.skip('Can zoom into a previous image from thumbstrip in real-time or fixed-time');
-    //test.skip('Clicking on the left arrow should pause the imagery and go to previous image');
-    //test.skip('If the imagery view is in pause mode, it should not be updated when new images come in');
-    //test.skip('If the imagery view is not in pause mode, it should be updated when new images come in');
+    //test.fixme('Can use Mouse Wheel to zoom in and out of previous image');
+    //test.fixme('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
+    //test.fixme('Can zoom into a previous image from thumbstrip in real-time or fixed-time');
+    //test.fixme('Clicking on the left arrow should pause the imagery and go to previous image');
+    //test.fixme('If the imagery view is in pause mode, it should not be updated when new images come in');
+    //test.fixme('If the imagery view is not in pause mode, it should be updated when new images come in');
 });
 
 test.describe('Example Imagery in Display layout', () => {
-    test.skip('Can use Mouse Wheel to zoom in and out of previous image');
-    test.skip('Can use alt+drag to move around image once zoomed in');
-    test.skip('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
-    test.skip('Clicking on the left arrow should pause the imagery and go to previous image');
-    test.skip('If the imagery view is in pause mode, it should not be updated when new images come in');
-    test.skip('If the imagery view is not in pause mode, it should be updated when new images come in');
+    test.fixme('Can use Mouse Wheel to zoom in and out of previous image');
+    test.fixme('Can use alt+drag to move around image once zoomed in');
+    test.fixme('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
+    test.fixme('Clicking on the left arrow should pause the imagery and go to previous image');
+    test.fixme('If the imagery view is in pause mode, it should not be updated when new images come in');
+    test.fixme('If the imagery view is not in pause mode, it should be updated when new images come in');
 });
 
 test.describe('Example Imagery in Flexible layout', () => {
-    test.skip('Can use Mouse Wheel to zoom in and out of previous image');
-    test.skip('Can use alt+drag to move around image once zoomed in');
-    test.skip('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
-    test.skip('Clicking on the left arrow should pause the imagery and go to previous image');
-    test.skip('If the imagery view is in pause mode, it should not be updated when new images come in');
-    test.skip('If the imagery view is not in pause mode, it should be updated when new images come in');
+    test.fixme('Can use Mouse Wheel to zoom in and out of previous image');
+    test.fixme('Can use alt+drag to move around image once zoomed in');
+    test.fixme('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
+    test.fixme('Clicking on the left arrow should pause the imagery and go to previous image');
+    test.fixme('If the imagery view is in pause mode, it should not be updated when new images come in');
+    test.fixme('If the imagery view is not in pause mode, it should be updated when new images come in');
 });
 
 test.describe('Example Imagery in Tabs view', () => {
-    test.skip('Can use Mouse Wheel to zoom in and out of previous image');
-    test.skip('Can use alt+drag to move around image once zoomed in');
-    test.skip('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
-    test.skip('Can zoom into a previous image from thumbstrip in real-time or fixed-time');
-    test.skip('Clicking on the left arrow should pause the imagery and go to previous image');
-    test.skip('If the imagery view is in pause mode, it should not be updated when new images come in');
-    test.skip('If the imagery view is not in pause mode, it should be updated when new images come in');
+    test.fixme('Can use Mouse Wheel to zoom in and out of previous image');
+    test.fixme('Can use alt+drag to move around image once zoomed in');
+    test.fixme('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
+    test.fixme('Can zoom into a previous image from thumbstrip in real-time or fixed-time');
+    test.fixme('Clicking on the left arrow should pause the imagery and go to previous image');
+    test.fixme('If the imagery view is in pause mode, it should not be updated when new images come in');
+    test.fixme('If the imagery view is not in pause mode, it should be updated when new images come in');
 });

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -198,29 +198,6 @@ test.describe('Example Imagery', () => {
         expect.soft(resetBoundingBox.height).toEqual(initialBoundingBox.height);
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
-    // test('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
-    //     test.skip(process.platform === 'linux');
-    //     const bgImageLocator = await page.locator(backgroundImageSelector);
-    //     await bgImageLocator.hover();
-    //     const zoomInBtn = await page.locator('.t-btn-zoom-in');
-    //     await zoomInBtn.click();
-
-    //     const expectedAltText = 'Ctrl+Alt drag to pan';
-    //     const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
-    //     expect(expectedAltText).toEqual(imageryHintsText);
-    // });
-
-    // test('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
-    //     test.skip(process.platform !== 'linux');
-    //     const bgImageLocator = await page.locator(backgroundImageSelector);
-    //     await bgImageLocator.hover();
-    //     const zoomInBtn = await page.locator('.t-btn-zoom-in');
-    //     await zoomInBtn.click();
-
-    //     const expectedAltText = 'Alt drag to pan';
-    //     const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
-    //     expect(expectedAltText).toEqual(imageryHintsText);
-    // });
 
     //test.fixme('Can use Mouse Wheel to zoom in and out of previous image');
     //test.fixme('Can zoom into the latest image and the real-time/fixed-time imagery will pause');

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -180,6 +180,21 @@ test.describe('Example Imagery', () => {
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
 
+    test('Image Pan/Zoom alt text is displayed', async ({ page }) => {
+        const bgImageLocator = await page.locator(backgroundImageSelector);
+        await bgImageLocator.hover();
+        const zoomInBtn = await page.locator('.t-btn-zoom-in');
+        await zoomInBtn.click();
+        // userAgentData.platform is not available so match against entire userAgent string
+        const userAgent = await page.evaluate('navigator.userAgent');
+        expect(userAgent).toBeTruthy();
+
+        const regexLinux = /Linux/;
+        const expectedAltText = regexLinux.test(userAgent) ? 'Ctrl+Alt drag to pan' : 'Alt drag to pan';
+        const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
+        expect(expectedAltText).toEqual(imageryHintsText);
+    });
+
     //test('Can use Mouse Wheel to zoom in and out of previous image');
     //test('Can zoom into the latest image and the real-time/fixed-time imagery will pause');
     //test.skip('Can zoom into a previous image from thumbstrip in real-time or fixed-time');

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -96,8 +96,21 @@ test.describe('Example Imagery', () => {
         // center the mouse pointer
         await page.mouse.move(imageCenterX, imageCenterY);
 
+        let panOptions = '';
+
+        if (process.platform === 'linux') {
+            panOptions = 'Ctrl+Alt';
+        } else {
+            panOptions = 'Alt';
+        }
+
+        // Pan Imagery Hints
+        const expectedAltText = 'Ctrl+Alt drag to pan';
+        const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
+        expect(expectedAltText).toEqual(imageryHintsText);
+
         // pan right
-        await page.keyboard.down('Alt');
+        await page.keyboard.down(panOptions);
         await page.mouse.down();
         await page.mouse.move(imageCenterX - 200, imageCenterY, 10);
         await page.mouse.up();

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -24,6 +24,7 @@
 This test suite is dedicated to tests which verify the basic operations surrounding imagery,
 but only assume that example imagery is present.
 */
+/* globals process */
 
 const { test, expect } = require('@playwright/test');
 
@@ -179,14 +180,8 @@ test.describe('Example Imagery', () => {
         expect.soft(resetBoundingBox.height).toEqual(initialBoundingBox.height);
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
-
     test('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
-        // userAgentData.platform is not available so match against entire userAgent string
-        const userAgent = await page.evaluate('navigator.userAgent');
-        expect(userAgent).toBeTruthy();
-        const regexLinux = /Linux/;
-        test.skip(!regexLinux.test(userAgent));
-
+        test.skip(process.platform !== 'linux');
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
         const zoomInBtn = await page.locator('.t-btn-zoom-in');
@@ -198,12 +193,7 @@ test.describe('Example Imagery', () => {
     });
 
     test('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
-        // userAgentData.platform is not available so match against entire userAgent string
-        const userAgent = await page.evaluate('navigator.userAgent');
-        expect(userAgent).toBeTruthy();
-        const regexLinux = /Linux/;
-        test.skip(regexLinux.test(userAgent));
-
+        test.skip(process.platform === 'linux');
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
         const zoomInBtn = await page.locator('.t-btn-zoom-in');

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -180,17 +180,36 @@ test.describe('Example Imagery', () => {
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
 
-    test('Image Pan/Zoom alt text is displayed', async ({ page }) => {
+    test.only('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
+        // userAgentData.platform is not available so match against entire userAgent string
+        const userAgent = await page.evaluate('navigator.userAgent');
+        expect(userAgent).toBeTruthy();
+        const regexLinux = /Linux/;
+        test.skip(!regexLinux.test(userAgent));
+
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
         const zoomInBtn = await page.locator('.t-btn-zoom-in');
         await zoomInBtn.click();
+
+        const expectedAltText = 'Ctrl+Alt drag to pan';
+        const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
+        expect(expectedAltText).toEqual(imageryHintsText);
+    });
+
+    test.only('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
         // userAgentData.platform is not available so match against entire userAgent string
         const userAgent = await page.evaluate('navigator.userAgent');
         expect(userAgent).toBeTruthy();
-
         const regexLinux = /Linux/;
-        const expectedAltText = regexLinux.test(userAgent) ? 'Ctrl+Alt drag to pan' : 'Alt drag to pan';
+        test.skip(regexLinux.test(userAgent));
+
+        const bgImageLocator = await page.locator(backgroundImageSelector);
+        await bgImageLocator.hover();
+        const zoomInBtn = await page.locator('.t-btn-zoom-in');
+        await zoomInBtn.click();
+
+        const expectedAltText = 'Alt drag to pan';
         const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
         expect(expectedAltText).toEqual(imageryHintsText);
     });

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -79,7 +79,7 @@ test.describe('Example Imagery', () => {
 
     });
 
-    test.only('Can use alt+drag to move around image once zoomed in', async ({ page }) => {
+    test('Can use alt+drag to move around image once zoomed in', async ({ page }) => {
         const deltaYStep = 100; //equivalent to 1x zoom
         const panHotkey = process.platform === 'linux' ? ['Control', 'Alt'] : ['Alt'];
 

--- a/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/plugins/imagery/exampleImagery.e2e.spec.js
@@ -79,8 +79,9 @@ test.describe('Example Imagery', () => {
 
     });
 
-    test('Can use alt+drag to move around image once zoomed in', async ({ page }) => {
+    test.only('Can use alt+drag to move around image once zoomed in', async ({ page }) => {
         const deltaYStep = 100; //equivalent to 1x zoom
+        const panHotkey = process.platform === 'linux' ? ['Control', 'Alt'] : ['Alt'];
 
         const bgImageLocator = await page.locator(backgroundImageSelector);
         await bgImageLocator.hover();
@@ -96,53 +97,47 @@ test.describe('Example Imagery', () => {
         // center the mouse pointer
         await page.mouse.move(imageCenterX, imageCenterY);
 
-        let panOptions = '';
-
-        if (process.platform === 'linux') {
-            panOptions = 'Ctrl+Alt';
-        } else {
-            panOptions = 'Alt';
-        }
-
         // Pan Imagery Hints
-        const expectedAltText = 'Ctrl+Alt drag to pan';
+        const expectedAltText = process.platform === 'linux' ? 'Ctrl+Alt drag to pan' : 'Alt drag to pan';
         const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
         expect(expectedAltText).toEqual(imageryHintsText);
 
         // pan right
-        await page.keyboard.down(panOptions);
+        // await page.keyboard.down(panHotkey);
+        await Promise.all(panHotkey.map(x => page.keyboard.down(x)));
         await page.mouse.down();
         await page.mouse.move(imageCenterX - 200, imageCenterY, 10);
         await page.mouse.up();
-        await page.keyboard.up('Alt');
+        // await page.keyboard.up(panHotkey);
+        await Promise.all(panHotkey.map(x => page.keyboard.up(x)));
         const afterRightPanBoundingBox = await bgImageLocator.boundingBox();
         expect(zoomedBoundingBox.x).toBeGreaterThan(afterRightPanBoundingBox.x);
 
         // pan left
-        await page.keyboard.down('Alt');
+        await Promise.all(panHotkey.map(x => page.keyboard.down(x)));
         await page.mouse.down();
         await page.mouse.move(imageCenterX, imageCenterY, 10);
         await page.mouse.up();
-        await page.keyboard.up('Alt');
+        await Promise.all(panHotkey.map(x => page.keyboard.up(x)));
         const afterLeftPanBoundingBox = await bgImageLocator.boundingBox();
         expect(afterRightPanBoundingBox.x).toBeLessThan(afterLeftPanBoundingBox.x);
 
         // pan up
         await page.mouse.move(imageCenterX, imageCenterY);
-        await page.keyboard.down('Alt');
+        await Promise.all(panHotkey.map(x => page.keyboard.down(x)));
         await page.mouse.down();
         await page.mouse.move(imageCenterX, imageCenterY + 200, 10);
         await page.mouse.up();
-        await page.keyboard.up('Alt');
+        await Promise.all(panHotkey.map(x => page.keyboard.up(x)));
         const afterUpPanBoundingBox = await bgImageLocator.boundingBox();
         expect(afterUpPanBoundingBox.y).toBeGreaterThan(afterLeftPanBoundingBox.y);
 
         // pan down
-        await page.keyboard.down('Alt');
+        await Promise.all(panHotkey.map(x => page.keyboard.down(x)));
         await page.mouse.down();
         await page.mouse.move(imageCenterX, imageCenterY - 200, 10);
         await page.mouse.up();
-        await page.keyboard.up('Alt');
+        await Promise.all(panHotkey.map(x => page.keyboard.up(x)));
         const afterDownPanBoundingBox = await bgImageLocator.boundingBox();
         expect(afterDownPanBoundingBox.y).toBeLessThan(afterUpPanBoundingBox.y);
 
@@ -203,29 +198,29 @@ test.describe('Example Imagery', () => {
         expect.soft(resetBoundingBox.height).toEqual(initialBoundingBox.height);
         expect(resetBoundingBox.width).toEqual(initialBoundingBox.width);
     });
-    test('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
-        test.skip(process.platform === 'linux');
-        const bgImageLocator = await page.locator(backgroundImageSelector);
-        await bgImageLocator.hover();
-        const zoomInBtn = await page.locator('.t-btn-zoom-in');
-        await zoomInBtn.click();
+    // test('Image Pan/Zoom alt text is displayed (Linux)', async ({ page }) => {
+    //     test.skip(process.platform === 'linux');
+    //     const bgImageLocator = await page.locator(backgroundImageSelector);
+    //     await bgImageLocator.hover();
+    //     const zoomInBtn = await page.locator('.t-btn-zoom-in');
+    //     await zoomInBtn.click();
 
-        const expectedAltText = 'Ctrl+Alt drag to pan';
-        const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
-        expect(expectedAltText).toEqual(imageryHintsText);
-    });
+    //     const expectedAltText = 'Ctrl+Alt drag to pan';
+    //     const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
+    //     expect(expectedAltText).toEqual(imageryHintsText);
+    // });
 
-    test('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
-        test.skip(process.platform !== 'linux');
-        const bgImageLocator = await page.locator(backgroundImageSelector);
-        await bgImageLocator.hover();
-        const zoomInBtn = await page.locator('.t-btn-zoom-in');
-        await zoomInBtn.click();
+    // test('Image Pan/Zoom alt text is displayed (Other Platforms)', async ({ page }) => {
+    //     test.skip(process.platform !== 'linux');
+    //     const bgImageLocator = await page.locator(backgroundImageSelector);
+    //     await bgImageLocator.hover();
+    //     const zoomInBtn = await page.locator('.t-btn-zoom-in');
+    //     await zoomInBtn.click();
 
-        const expectedAltText = 'Alt drag to pan';
-        const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
-        expect(expectedAltText).toEqual(imageryHintsText);
-    });
+    //     const expectedAltText = 'Alt drag to pan';
+    //     const imageryHintsText = await page.locator('.c-imagery__hints').innerText();
+    //     expect(expectedAltText).toEqual(imageryHintsText);
+    // });
 
     //test.fixme('Can use Mouse Wheel to zoom in and out of previous image');
     //test.fixme('Can zoom into the latest image and the real-time/fixed-time imagery will pause');

--- a/src/api/telemetry/TelemetryCollection.js
+++ b/src/api/telemetry/TelemetryCollection.js
@@ -185,8 +185,8 @@ export class TelemetryCollection extends EventEmitter {
 
         for (let datum of data) {
             parsedValue = this.parseTime(datum);
-            beforeStartOfBounds = parsedValue < this.lastBounds.start;
-            afterEndOfBounds = parsedValue > this.lastBounds.end;
+            beforeStartOfBounds = parsedValue <= this.lastBounds.start;
+            afterEndOfBounds = parsedValue >= this.lastBounds.end;
 
             if (!afterEndOfBounds && !beforeStartOfBounds) {
                 let isDuplicate = false;

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -55,7 +55,7 @@
             <div
                 v-if="zoomFactor > 1"
                 class="c-imagery__hints"
-            >Alt-drag to pan</div>
+            >{{formatImageAltText}}</div>
             <div
                 ref="focusedImageWrapper"
                 class="image-wrapper"
@@ -478,6 +478,17 @@ export default {
                 width: this.sizedImageWidth,
                 height: this.sizedImageHeight
             };
+        },
+        formatImageAltText() {
+            const regexLinux = /Linux/;
+            const platform = window.navigator.platform || window.navigator.userAgentData.platform;
+
+            if (!regexLinux.test(platform)) {
+                return 'Ctrl+Alt drag to pan';
+            }
+
+            return 'Alt drag to pan';
+
         }
     },
     watch: {

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -483,12 +483,11 @@ export default {
             const regexLinux = /Linux/;
             const platform = window.navigator.platform || window.navigator.userAgentData.platform;
 
-            if (!regexLinux.test(platform)) {
+            if (regexLinux.test(platform)) {
                 return 'Ctrl+Alt drag to pan';
             }
 
             return 'Alt drag to pan';
-
         }
     },
     watch: {

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -481,7 +481,7 @@ export default {
         },
         formatImageAltText() {
             const regexLinux = /Linux/;
-            const navigator = window.navigator;
+            const navigator = window.navigator.userAgent;
 
             if (regexLinux.test(navigator)) {
                 return 'Ctrl+Alt drag to pan';

--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -481,9 +481,9 @@ export default {
         },
         formatImageAltText() {
             const regexLinux = /Linux/;
-            const platform = window.navigator.platform || window.navigator.userAgentData.platform;
+            const navigator = window.navigator;
 
-            if (regexLinux.test(platform)) {
+            if (regexLinux.test(navigator)) {
                 return 'Ctrl+Alt drag to pan';
             }
 


### PR DESCRIPTION

Closes #4848 and #5023

### Describe your changes:

- [x] Describe different alt text based on platform
- [x] Update tests to differentiate the help text based on platform.
- [x] Also adds some timing consistency to address #5023 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
