### PR TITLE
Fix tick values for plots ticks in log mode and null check

### DIFF
--- a/src/plugins/plot/MctTicks.vue
+++ b/src/plugins/plot/MctTicks.vue
@@ -204,6 +204,8 @@ export default {
 
         updateTicks(forceRegeneration = false) {
             const range = this.axis.get('displayRange');
+            const logMode = this.axis.get('logMode');
+
             if (!range) {
                 delete this.min;
                 delete this.max;
@@ -231,7 +233,7 @@ export default {
                     step: newTicks[1] - newTicks[0]
                 };
 
-                newTicks = getFormattedTicks(newTicks, format);
+                newTicks = getFormattedTicks(newTicks, format, logMode);
 
                 this.ticks = newTicks;
                 this.shouldCheckWidth = true;

--- a/src/plugins/plot/configuration/YAxisModel.js
+++ b/src/plugins/plot/configuration/YAxisModel.js
@@ -215,6 +215,10 @@ export default class YAxisModel extends Model {
 
             const _range = this.get('displayRange');
 
+            if (!_range) {
+                return;
+            }
+
             if (this.get('logMode')) {
                 _range.min = antisymlog(_range.min, 10);
                 _range.max = antisymlog(_range.max, 10);

--- a/src/plugins/plot/tickUtils.js
+++ b/src/plugins/plot/tickUtils.js
@@ -131,14 +131,12 @@ export function commonSuffix(a, b) {
     return a.slice(a.length - breakpoint);
 }
 
-export function getFormattedTicks(newTicks, format, useWholeNumbers) {
+export function getFormattedTicks(newTicks, format, formatFloat) {
     newTicks = newTicks
         .map(function (tickValue) {
             let formattedValue = format(tickValue);
-            if (useWholeNumbers === true
-                && typeof formattedValue === 'number'
-                && !Number.isInteger(formattedValue)) {
-                formattedValue = Math.round(formattedValue);
+            if (formatFloat === true && typeof formattedValue === 'number' && !Number.isInteger(formattedValue)) {
+                formattedValue = parseFloat(formattedValue).toFixed(2);
             }
 
             return {

--- a/src/plugins/plot/tickUtils.js
+++ b/src/plugins/plot/tickUtils.js
@@ -135,12 +135,8 @@ export function getFormattedTicks(newTicks, format) {
     newTicks = newTicks
         .map(function (tickValue) {
             let formattedValue = format(tickValue);
-            if (typeof formattedValue === 'number') {
-                if (Number.isInteger(formattedValue)) {
-                    return formattedValue;
-                } else {
-                    return parseFloat(formattedValue).toPrecision(2);
-                }
+            if (typeof formattedValue === 'number' && !Number.isInteger(formattedValue)) {
+                formattedValue = parseFloat(formattedValue).toPrecision(2);
             }
 
             return {

--- a/src/plugins/plot/tickUtils.js
+++ b/src/plugins/plot/tickUtils.js
@@ -134,9 +134,18 @@ export function commonSuffix(a, b) {
 export function getFormattedTicks(newTicks, format) {
     newTicks = newTicks
         .map(function (tickValue) {
+            let formattedValue = format(tickValue);
+            if (typeof formattedValue === 'number') {
+                if (Number.isInteger(formattedValue)) {
+                    return formattedValue;
+                } else {
+                    return parseFloat(formattedValue).toPrecision(2);
+                }
+            }
+
             return {
                 value: tickValue,
-                text: format(tickValue)
+                text: formattedValue
             };
         });
 

--- a/src/plugins/plot/tickUtils.js
+++ b/src/plugins/plot/tickUtils.js
@@ -131,12 +131,14 @@ export function commonSuffix(a, b) {
     return a.slice(a.length - breakpoint);
 }
 
-export function getFormattedTicks(newTicks, format) {
+export function getFormattedTicks(newTicks, format, useWholeNumbers) {
     newTicks = newTicks
         .map(function (tickValue) {
             let formattedValue = format(tickValue);
-            if (typeof formattedValue === 'number' && !Number.isInteger(formattedValue)) {
-                formattedValue = parseFloat(formattedValue).toPrecision(2);
+            if (useWholeNumbers === true
+                && typeof formattedValue === 'number'
+                && !Number.isInteger(formattedValue)) {
+                formattedValue = Math.round(formattedValue);
             }
 
             return {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #2297 

### Describe your changes:
1. If there is no range and no display range, then don't try to set the default range to anything.
2. In log mode, set the tick values to toFixed(2).

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
