### PR TITLE
Time conductor real time 4914

### DIFF
--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -67,3 +67,22 @@ test.describe('Time counductor operations', () => {
         expect(endDateValidityStatus).not.toBeTruthy();
     });
 });
+
+test.describe('Time counductor input fields real-time mode', () => {
+    test('validate input fields in real-time mode', async ({ page }) => {
+        //Go to baseURL
+        await page.goto('/', { waitUntil: 'networkidle' });
+
+        // Set a specific time range for consistency, otherwise it will change
+        // on every test to a range based on the current time.
+        const timeInputs = page.locator('input.c-input--datetime');
+
+        // Start time input
+        await timeInputs.first().click();
+        await timeInputs.first().fill('2022-03-29 22:00:00.000Z');
+
+        // End time input
+        await timeInputs.nth(1).click();
+        await timeInputs.nth(1).fill('2022-03-29 22:00:45.000Z');
+    });
+});

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -71,7 +71,7 @@ test.describe('Time counductor operations', () => {
 
 // Testing instructions:
 // Try to change the realtime offsets when in realtime (local clock) mode.
-test.describe('Time counductor input fields real-time mode', () => {
+test.describe('Time conductor input fields real-time mode', () => {
     test('validate input fields in real-time mode', async ({ page }) => {
         //Go to baseURL
         await page.goto('/', { waitUntil: 'networkidle' });

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -82,6 +82,13 @@ test.describe('Time counductor input fields real-time mode', () => {
         // Click Local Clock
         await page.locator('.icon-clock >> text=Local Clock').click();
 
+        // Set Time Offset
+        await page.locator('.c-conductor__delta-button >> text=00:30:00').click();
+
+        // Input Time Offset
+        await page.fill('.pr-time-controls__secs', '23');
+        
+
         // // Start time input
         // await timeInputs.first().click();
         // await timeInputs.first().fill('2022-03-29 22:00:00.000Z');

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -76,28 +76,26 @@ test.describe('Time counductor input fields real-time mode', () => {
         // Set realtime "local clock" mode offsets
         const timeInputs = page.locator('input.c-input--datetime');
 
-        // Click Fixed Timespan button
+        // Click fixed timespan button
         await page.locator('.c-button__label >> text=Fixed Timespan').click();
 
-        // Click Local Clock 
+        // Click local clock 
         await page.locator('.icon-clock >> text=Local Clock').click();
 
-        // Click Time Offset button
+        // Click time offset button
         await page.locator('.c-conductor__delta-button >> text=00:30:00').click();
 
-        // Input Time Offset
+        // Input time offset
         await page.fill('.pr-time-controls__secs', '23');
 
         // Click the check button
-        await page.locator('.icon-check').click
-        
+        await page.locator('.icon-check').click();
 
-        // // Start time input
-        // await timeInputs.first().click();
-        // await timeInputs.first().fill('2022-03-29 22:00:00.000Z');
+        // Verify time was updated on time offset button
+        const startTimeOffset = page.locator('.c-conductor__delta-button').first();
+        await expect(startTimeOffset).toContainText('00:30:23');
 
-        // // End time input
-        // await timeInputs.nth(1).click();
-        // await timeInputs.nth(1).fill('2022-03-29 22:00:45.000Z');
+        // Click time offset set preceding now button
+        await page.locator('.c-conductor__delta-button >> text=00:00:30').click();
     });
 });

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -68,6 +68,9 @@ test.describe('Time counductor operations', () => {
     });
 });
 
+
+// Testing instructions:
+// Try to change the realtime offsets when in realtime (local clock) mode.
 test.describe('Time counductor input fields real-time mode', () => {
     test('validate input fields in real-time mode', async ({ page }) => {
         //Go to baseURL

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -85,7 +85,7 @@ test.describe('Time counductor input fields real-time mode', () => {
         // Click time offset button
         await page.locator('.c-conductor__delta-button >> text=00:30:00').click();
 
-        // Input time offset
+        // Input start time offset
         await page.fill('.pr-time-controls__secs', '23');
 
         // Click the check button
@@ -97,5 +97,15 @@ test.describe('Time counductor input fields real-time mode', () => {
 
         // Click time offset set preceding now button
         await page.locator('.c-conductor__delta-button >> text=00:00:30').click();
+
+        // Input preceding time offset
+        await page.fill('.pr-time-controls__secs', '31')
+
+        // Click the check buttons
+        await page.locator('.icon-check').click();
+
+        // Verify time was updated on preceding time offset button
+        const precedingTimeOffset = page.locator('.c-conductor__delta-button').nth(1);
+        await expect(precedingTimeOffset).toContainText('00:00:31');
     });
 });

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -107,7 +107,6 @@ test.describe('Time conductor input fields real-time mode', () => {
         await page.locator('.icon-check').click();
 
         // Verify time was updated on preceding time offset button
-        const precedingTimeOffset = page.locator('.c-conductor__delta-button').nth(1);
-        await expect(precedingTimeOffset).toContainText('00:00:31');
+        await expect(page.locator('.c-conductor__delta-button').nth(1)).toContainText('00:00:31');
     });
 });

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -73,16 +73,21 @@ test.describe('Time counductor input fields real-time mode', () => {
         //Go to baseURL
         await page.goto('/', { waitUntil: 'networkidle' });
 
-        // Set a specific time range for consistency, otherwise it will change
-        // on every test to a range based on the current time.
+        // Set realtime "local clock" mode offsets
         const timeInputs = page.locator('input.c-input--datetime');
 
-        // Start time input
-        await timeInputs.first().click();
-        await timeInputs.first().fill('2022-03-29 22:00:00.000Z');
+        // Click Fixed Timespan button
+        await page.locator('.c-button__label >> text=Fixed Timespan').click();
 
-        // End time input
-        await timeInputs.nth(1).click();
-        await timeInputs.nth(1).fill('2022-03-29 22:00:45.000Z');
+        // Click Local Clock
+        await page.locator('.icon-clock >> text=Local Clock').click();
+
+        // // Start time input
+        // await timeInputs.first().click();
+        // await timeInputs.first().fill('2022-03-29 22:00:00.000Z');
+
+        // // End time input
+        // await timeInputs.nth(1).click();
+        // await timeInputs.nth(1).fill('2022-03-29 22:00:45.000Z');
     });
 });

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -95,8 +95,7 @@ test.describe('Time conductor input fields real-time mode', () => {
         await page.locator('.icon-check').click();
 
         // Verify time was updated on time offset button
-        const startTimeOffset = page.locator('.c-conductor__delta-button').first();
-        await expect(startTimeOffset).toContainText('00:30:23');
+        await expect(page.locator('.c-conductor__delta-button').first()).toContainText('00:30:23');
 
         // Click time offset set preceding now button
         await page.locator('.c-conductor__delta-button >> text=00:00:30').click();

--- a/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -79,14 +79,17 @@ test.describe('Time counductor input fields real-time mode', () => {
         // Click Fixed Timespan button
         await page.locator('.c-button__label >> text=Fixed Timespan').click();
 
-        // Click Local Clock
+        // Click Local Clock 
         await page.locator('.icon-clock >> text=Local Clock').click();
 
-        // Set Time Offset
+        // Click Time Offset button
         await page.locator('.c-conductor__delta-button >> text=00:30:00').click();
 
         // Input Time Offset
         await page.fill('.pr-time-controls__secs', '23');
+
+        // Click the check button
+        await page.locator('.icon-check').click
         
 
         // // Start time input


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->
#4914 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Created test: Time conductor input fields real-time mode
The test Clicks on realtime "Local Clock" mode and updates the start offset and the preceding offset time in seconds. The test validates the new expected offset times. 

### All Submissions:

* [ x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ x] Has this been smoke tested?
* [ x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
