### PR TITLE
Unpause telemetry table on user bounds change (#5113)

### DIFF
--- a/src/plugins/telemetryTable/components/table.vue
+++ b/src/plugins/telemetryTable/components/table.vue
@@ -499,6 +499,8 @@ export default {
         this.table.tableRows.on('sort', this.updateVisibleRows);
         this.table.tableRows.on('filter', this.updateVisibleRows);
 
+        this.openmct.time.on('bounds', this.boundsChanged);
+
         //Default sort
         this.sortOptions = this.table.tableRows.sortBy();
         this.scrollable = this.$el.querySelector('.js-telemetry-table__body-w');
@@ -526,6 +528,8 @@ export default {
         this.table.tableRows.off('filter', this.updateVisibleRows);
 
         this.table.configuration.off('change', this.updateConfiguration);
+
+        this.openmct.time.off('bounds', this.boundsChanged);
 
         clearInterval(this.resizePollHandle);
 
@@ -846,6 +850,25 @@ export default {
             }
 
             this.isShowingMarkedRowsOnly = false;
+        },
+        boundsChanged(_bounds, isTick) {
+            if (isTick) {
+                return;
+            }
+
+            this.userBoundsChanged();
+        },
+        userBoundsChanged() {
+            if (this.paused) {
+                this.unpause(false);
+                // Handle the case where the table was paused by button,
+                // but unpaused by a user bounds change.
+                if (this.pausedByButton) {
+                    this.undoMarkedRows();
+                    this.table.unpause();
+                    this.paused = false;
+                }
+            }
         },
         togglePauseByButton() {
             if (this.paused) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5113 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

Unpauses the telemetry table when time bounds are changed by a user. The `TelemetryTable` Vue component will now listen for `'bounds'` events fired from the `TimeAPI`, filtering out any non-user-initiated bounds changes (e.g.: bounds changes caused by a tick).

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
