### PR TITLE
Eliminate NaN conditions and clear stale duration in Freshness Indicators

### DIFF
--- a/src/plugins/imagery/components/ImageryView.vue
+++ b/src/plugins/imagery/components/ImageryView.vue
@@ -382,6 +382,9 @@ export default {
         formattedDuration() {
             let result = 'N/A';
             let negativeAge = -1;
+            if (!Number.isInteger(this.numericDuration)) {
+                return result;
+            }
 
             if (this.numericDuration > TWENTYFOUR_HOURS) {
                 negativeAge *= (this.numericDuration / TWENTYFOUR_HOURS);
@@ -834,8 +837,10 @@ export default {
             let currentTime = this.timeContext.clock() && this.timeContext.clock().currentValue();
             if (currentTime === undefined) {
                 this.numericDuration = currentTime;
-            } else {
+            } else if (Number.isInteger(this.parsedSelectedTime)) {
                 this.numericDuration = currentTime - this.parsedSelectedTime;
+            } else {
+                this.numericDuration = undefined;
             }
         },
         resetAgeCSS() {


### PR DESCRIPTION
Fixes VIPEROMCT-112

Rebased on `release/2.0.4`

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
* Removed the condition of `Invalid Date` appearing after clearing data. This was caused by NaN being assigned to `this.numericDuration` when `this.parsedSelectedTime` was undefined. Remedied this by checking for type of Integer and adding an else clause to mark numericDuration undefined so the N/A text would properly appear.
* Add an extra integer check in formattedDuration to clear the sticking duration
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)


### How To Test
1. Navigate to Example Imagery
2. Select Local clock
3. Activate the Clear Data action
4. Observe that the Freshness Indicator says N/A instead of Invalid Date