### PR TITLE
Override terser-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "node": ">=14.19.1"
   },
   "overrides": {
-    "core-js": "3.21.1"
+    "core-js": "3.21.1",
+    "terser-webpack-plugin": "5.3.3"
   },
   "browserslist": [
     "Firefox ESR",


### PR DESCRIPTION
### Describe your changes:
Temporarily overrides the terser-webpack-plugin to 5.3.3 until other plugins are fixed

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
