### PR TITLE
Gauge fixes for Firefox and units display

### DIFF
--- a/example/generator/plugin.js
+++ b/example/generator/plugin.js
@@ -81,7 +81,7 @@ define([
                 {
                     name: "Amplitude",
                     control: "numberfield",
-                    cssClass: "l-input-sm l-numeric",
+                    cssClass: "l-numeric",
                     key: "amplitude",
                     required: true,
                     property: [
@@ -92,7 +92,7 @@ define([
                 {
                     name: "Offset",
                     control: "numberfield",
-                    cssClass: "l-input-sm l-numeric",
+                    cssClass: "l-numeric",
                     key: "offset",
                     required: true,
                     property: [

--- a/src/plugins/gauge/GaugePluginSpec.js
+++ b/src/plugins/gauge/GaugePluginSpec.js
@@ -472,7 +472,7 @@ describe('Gauge plugin', () => {
         it('renders major elements', () => {
             const wrapperElement = gaugeHolder.querySelector('.js-gauge-wrapper');
             const rangeElement = gaugeHolder.querySelector('.js-gauge-meter-range');
-            const valueElement = gaugeHolder.querySelector('.js-meter-current-value');
+            const valueElement = gaugeHolder.querySelector('.js-gauge-current-value');
 
             const hasMajorElements = Boolean(wrapperElement && rangeElement && valueElement);
 
@@ -485,7 +485,7 @@ describe('Gauge plugin', () => {
 
         it('renders correct current value', (done) => {
             function WatchUpdateValue() {
-                const textElement = gaugeHolder.querySelector('.js-meter-current-value');
+                const textElement = gaugeHolder.querySelector('.js-gauge-current-value');
                 expect(Number(textElement.textContent).toFixed(gaugeViewObject.configuration.gaugeController.precision)).toBe(randomValue.toFixed(gaugeViewObject.configuration.gaugeController.precision));
                 done();
             }
@@ -570,7 +570,7 @@ describe('Gauge plugin', () => {
         it('renders major elements', () => {
             const wrapperElement = gaugeHolder.querySelector('.js-gauge-wrapper');
             const rangeElement = gaugeHolder.querySelector('.js-gauge-meter-range');
-            const valueElement = gaugeHolder.querySelector('.js-meter-current-value');
+            const valueElement = gaugeHolder.querySelector('.js-gauge-current-value');
 
             const hasMajorElements = Boolean(wrapperElement && rangeElement && valueElement);
 

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -168,27 +168,14 @@
                 />
             </g>
             <g class="c-dial__text">
-                <g
-                    v-if="displayCurVal"
-                    class="c-dial__current-value-text-wrapper"
-                >
-                    <text
-                        class="c-dial__current-value-text js-dial-current-value"
-                        y="55%"
-                        lengthAdjust="spacing"
-                        :font-size="curValFontSize"
-                        text-anchor="middle"
-                        transform="translate(5)"
-                    >{{ curVal }}</text>
-                    <text
-                        v-if="displayUnits"
-                        class="c-dial__units-text"
-                        y="68%"
-                        font-size="8%"
-                        text-anchor="middle"
-                        transform="translate(5)"
-                    >{{ units }}</text>
-                </g>
+                <text
+                    x="50%"
+                    y="70%"
+                    text-anchor="middle"
+                    class="c-gauge__units"
+                    font-size="8%"
+                >{{ units }}</text>
+
                 <g
                     v-if="displayMinMax"
                     class="c-dial__range-text"
@@ -207,7 +194,7 @@
             </g>
 
             <svg
-                v-if="!valueInBounds"
+                v-if="!valueInBounds && valueExpected"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 512 512"
                 xml:space="preserve"
@@ -219,6 +206,33 @@
             ><path
                 d="M448 0H64C28.7.1.1 28.7 0 64v384c.1 35.3 28.7 63.9 64 64h384c35.3-.1 63.9-28.7 64-64V64c-.1-35.3-28.7-63.9-64-64zM288 448h-64v-64h64v64zm10.9-192L280 352h-48l-18.9-96V64H299v192h-.1z"
             /></svg>
+
+            <svg
+                class="c-gauge__current-value-text-wrapper"
+                :viewBox="curValViewBox"
+                preserveAspectRatio="xMidYMid meet"
+            >
+                <rect
+                    class="svg-viewbox-debug"
+                    x="0"
+                    y="0"
+                    width="100%"
+                    height="100%"
+                />
+                <text
+                    class="c-dial__current-value-text js-gauge-current-value"
+                    font-size="3.5"
+                    lengthAdjust="spacing"
+                    text-anchor="middle"
+                    dominant-baseline="middle"
+                    x="50%"
+                    y="50%"
+                >
+                    <template v-if="displayCurVal">
+                        <tspan>{{ curVal }}</tspan>
+                    </template>
+                </text>
+            </svg>
 
         </svg>
     </template>
@@ -233,15 +247,16 @@
                 <div class="c-meter__range__low">{{ rangeLow }}</div>
             </div>
             <div class="c-meter__bg">
-                <svg
-                    v-if="!valueInBounds"
+                <div
+                    v-if="!valueInBounds && valueExpected"
+                    class="c-meter__value-oor-indicator"
+                ><svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 512 512"
                     :preserveAspectRatio="meterOorRangeIndicatorAspectRatio"
-                    class="c-meter__value-oor-indicator"
                 ><path
                     d="M448 0H64C28.7.1.1 28.7 0 64v384c.1 35.3 28.7 63.9 64 64h384c35.3-.1 63.9-28.7 64-64V64c-.1-35.3-28.7-63.9-64-64zM288 448h-64v-64h64v64zm10.9-192L280 352h-48l-18.9-96V64H299v192h-.1z"
-                /></svg>
+                /></svg></div>
 
                 <template v-if="typeMeterVertical">
                     <div
@@ -282,19 +297,19 @@
                 </template>
 
                 <svg
-                    class="c-meter__current-value-text-wrapper"
-                    :viewBox="meterVerticalCurValViewBox"
+                    class="c-gauge__current-value-text-wrapper"
+                    :viewBox="curValViewBox"
                     preserveAspectRatio="xMidYMid meet"
                 >
                     <rect
-                        class="c-meter__viewbox-debug"
+                        class="svg-viewbox-debug"
                         x="0"
                         y="0"
                         width="100%"
                         height="100%"
                     />
                     <text
-                        class="c-meter__current-value-text js-meter-current-value"
+                        class="c-meter__current-value-text js-gauge-current-value"
                         font-size="4"
                         lengthAdjust="spacing"
                         text-anchor="middle"
@@ -372,23 +387,16 @@ export default {
             return this.percentToDegrees(this.valToPercent(this.limitLow));
         },
         meterOorRangeIndicatorAspectRatio() {
-            return this.typeMeterVertical ? 'xMidYMin meet' : 'xMinYMid meet';
+            return this.typeMeterVertical ? 'xMidYMax meet' : 'xMinYMid meet';
         },
         meterTextBaseline() {
             return this.typeMeterVertical ? 'auto' : 'middle';
         },
-        meterVerticalCurValViewBox() {
+        curValViewBox() {
             const DIGITS_RATIO = 3;
             const VIEWBOX_STR = '0 0 X 10';
 
             return VIEWBOX_STR.replace('X', this.digits * DIGITS_RATIO);
-        },
-        curValFontSize() {
-            const CHAR_THRESHOLD = 2;
-            const START_PERC = 27;
-            const REDUCE_PERC = 2.5;
-
-            return this.fontSizeFromChars(this.digits, CHAR_THRESHOLD, START_PERC, REDUCE_PERC);
         },
         rangeFontSize() {
             const CHAR_THRESHOLD = 3;
@@ -479,6 +487,9 @@ export default {
         },
         meterLowLimitPerc() {
             return 100 - this.valToPercentMeter(this.limitLow);
+        },
+        valueExpected() {
+            return this.curVal.toString().indexOf(DEFAULT_CURRENT_VALUE) === -1;
         },
         valueInBounds() {
             return (this.curVal >= this.rangeLow && this.curVal <= this.rangeHigh);

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -24,78 +24,37 @@
     class="c-gauge__wrapper js-gauge-wrapper"
     :class="`c-gauge--${gaugeType}`"
 >
-    <template v-if="typeDial">
-        <svg
-            width="0"
-            height="0"
-            class="c-dial__clip-paths"
-        >
-            <defs>
-                <clipPath
-                    id="gaugeBgMask"
-                    clipPathUnits="objectBoundingBox"
-                >
-                    <path d="M0.853553 0.853553C0.944036 0.763071 1 0.638071 1 0.5C1 0.223858 0.776142 0 0.5 0C0.223858 0 0 0.223858 0 0.5C0 0.638071 0.0559644 0.763071 0.146447 0.853553L0.285934 0.714066C0.23115 0.659281 0.197266 0.583598 0.197266 0.5C0.197266 0.332804 0.332804 0.197266 0.5 0.197266C0.667196 0.197266 0.802734 0.332804 0.802734 0.5C0.802734 0.583598 0.76885 0.659281 0.714066 0.714066L0.853553 0.853553Z" />
-                </clipPath>
-                <clipPath
-                    id="gaugeValueMask"
-                    clipPathUnits="objectBoundingBox"
-                >
-                    <path d="M0.18926 0.81074C0.109735 0.731215 0.0605469 0.621351 0.0605469 0.5C0.0605469 0.257298 0.257298 0.0605469 0.5 0.0605469C0.742702 0.0605469 0.939453 0.257298 0.939453 0.5C0.939453 0.621351 0.890265 0.731215 0.81074 0.81074L0.714066 0.714066C0.76885 0.659281 0.802734 0.583599 0.802734 0.5C0.802734 0.332804 0.667196 0.197266 0.5 0.197266C0.332804 0.197266 0.197266 0.332804 0.197266 0.5C0.197266 0.583599 0.23115 0.659281 0.285934 0.714066L0.18926 0.81074Z" />
-                </clipPath>
-            </defs>
-        </svg>
+    <svg
+        v-if="typeDial"
+        class="c-gauge c-dial"
+        viewBox="0 0 10 10"
+    >
+        <g class="c-dial__masks">
+            <mask id="gaugeValueMask">
+                <path
+                    d="M1.8926 8.1074C1.09734 7.31215 0.605469 6.21352 0.605469 5C0.605469 2.57297 2.57297 0.605469 5 0.605469C7.42703 0.605469 9.39453 2.57297 9.39453 5C9.39453 6.21352 8.90266 7.31215 8.1074 8.1074L7.14066 7.14066C7.6885 6.59281 8.02734 5.83598 8.02734 5C8.02734 3.32804 6.67196 1.97266 5 1.97266C3.32804 1.97266 1.97266 3.32804 1.97266 5C1.97266 5.83598 2.3115 6.59281 2.85934 7.14066L1.8926 8.1074Z"
+                    fill="white"
+                />
+            </mask>
+            <mask id="gaugeBgMask">
+                <path
+                    d="M8.53553 8.53553C9.44036 7.63071 10 6.38071 10 5C10 2.23858 7.76142 0 5 0C2.23858 0 0 2.23858 0 5C0 6.38071 0.559644 7.63071 1.46447 8.53553L2.85934 7.14066C2.3115 6.59281 1.97266 5.83598 1.97266 5C1.97266 3.32804 3.32804 1.97266 5 1.97266C6.67196 1.97266 8.02734 3.32804 8.02734 5C8.02734 5.83598 7.6885 6.59281 7.14066 7.14066L8.53553 8.53553Z"
+                    fill="white"
+                />
+            </mask>
+        </g>
 
-        <svg
-            class="c-dial__range c-gauge__range js-gauge-dial-range"
-            viewBox="0 0 512 512"
+        <g
+            class="c-dial__graphics"
+            mask="url(#gaugeBgMask)"
         >
-            <text
-                v-if="displayMinMax"
-                font-size="35"
-                transform="translate(105 455) rotate(-45)"
-            >{{ rangeLow }}</text>
-            <text
-                v-if="displayMinMax"
-                font-size="35"
-                transform="translate(407 455) rotate(45)"
-                text-anchor="end"
-            >{{ rangeHigh }}</text>
-        </svg>
-
-        <svg
-            v-if="displayCurVal"
-            class="c-dial__current-value-text-wrapper"
-            viewBox="0 0 512 512"
-        >
-            <svg
-                class="c-dial__current-value-text-sizer"
-                :viewBox="curValViewBox"
-            >
-                <text
-                    class="c-dial__current-value-text js-dial-current-value"
-                    lengthAdjust="spacing"
-                    text-anchor="middle"
-                    style="transform: translate(50%, 70%)"
-                >{{ curVal }}</text>
-            </svg>
-            <svg
-                class="c-gauge__units c-dial__units"
-                viewBox="0 0 50 100"
-            >
-                <text
-                    class="c-dial__units-text"
-                    lengthAdjust="spacing"
-                    text-anchor="middle"
-                    style="transform: translate(50%, 72%)"
-                >{{ units }}</text>
-            </svg>
-        </svg>
-
-        <svg
-            class="c-dial__bg"
-            viewBox="0 0 10 10"
-        >
+            <rect
+                class="c-dial__bg"
+                x="0"
+                y="0"
+                width="10"
+                height="10"
+            />
             <g
                 v-if="isDialLowLimit"
                 class="c-dial__limit-low"
@@ -126,7 +85,6 @@
                     height="5"
                 />
             </g>
-
             <g
                 v-if="isDialHighLimit"
                 class="c-dial__limit-high"
@@ -157,14 +115,14 @@
                     height="5"
                 />
             </g>
-        </svg>
+        </g>
 
-        <svg
-            v-if="typeFilledDial"
-            class="c-dial__filled-value-wrapper"
-            viewBox="0 0 10 10"
+        <g
+            class="c-dial__graphics"
+            mask="url(#gaugeValueMask)"
         >
             <g
+                v-if="typeFilledDial"
                 class="c-dial__filled-value"
                 :style="`transform: rotate(${degValueFilledDial}deg)`"
             >
@@ -193,21 +151,53 @@
                     height="5"
                 />
             </g>
-        </svg>
-
-        <svg
-            v-if="valueInBounds && typeNeedleDial"
-            class="c-dial__needle-value-wrapper"
-            viewBox="0 0 10 10"
-        >
             <g
+                v-if="valueInBounds && typeNeedleDial"
                 class="c-dial__needle-value"
                 :style="`transform: rotate(${degValue}deg)`"
             >
                 <path d="M4.90234 9.39453L5.09766 9.39453L5.30146 8.20874C6.93993 8.05674 8.22265 6.67817 8.22266 5C8.22266 3.22018 6.77982 1.77734 5 1.77734C3.22018 1.77734 1.77734 3.22018 1.77734 5C1.77734 6.67817 3.06007 8.05674 4.69854 8.20874L4.90234 9.39453Z" />
             </g>
-        </svg>
-    </template>
+        </g>
+        <g class="c-dial__text">
+            <g
+                v-if="displayCurVal"
+                class="c-dial__current-value-text-wrapper"
+            >
+                <text
+                    class="c-dial__current-value-text js-dial-current-value"
+                    y="55%"
+                    lengthAdjust="spacing"
+                    :font-size="curValFontSize"
+                    text-anchor="middle"
+                    transform="translate(5)"
+                >{{ curVal }}</text>
+                <text
+                    v-if="displayUnits"
+                    class="c-dial__units-text"
+                    y="68%"
+                    font-size="8%"
+                    text-anchor="middle"
+                    transform="translate(5)"
+                >{{ units }}</text>
+            </g>
+            <g
+                v-if="displayMinMax"
+                class="c-dial__range-text"
+                :font-size="rangeFontSize"
+            >
+                <text
+                    transform="translate(1.5 8.7) rotate(-45)"
+                    dominant-baseline="hanging"
+                >{{ rangeLow }}</text>
+                <text
+                    transform="translate(8.4 8.7) rotate(45)"
+                    dominant-baseline="hanging"
+                    text-anchor="end"
+                >{{ rangeHigh }}</text>
+            </g>
+        </g>
+    </svg>
 
     <template v-if="typeMeter">
         <div class="c-meter">
@@ -349,8 +339,23 @@ export default {
 
             return VIEWBOX_STR.replace('X', this.digits * DIGITS_RATIO);
         },
+        curValFontSize() {
+            const CHAR_THRESHOLD = 2;
+            const START_PERC = 27;
+            const REDUCE_PERC = 2.5;
+
+            return this.fontSizeFromChars(this.digits, CHAR_THRESHOLD, START_PERC, REDUCE_PERC);
+        },
+        rangeFontSize() {
+            const CHAR_THRESHOLD = 3;
+            const START_PERC = 8.5;
+            const REDUCE_PERC = 0.8;
+            const RANGE_CHARS_MAX = Math.max(this.rangeLow.toString().length, this.rangeHigh.toString().length);
+
+            return this.fontSizeFromChars(RANGE_CHARS_MAX, CHAR_THRESHOLD, START_PERC, REDUCE_PERC);
+        },
         isDialLowLimit() {
-            return this.limitLow.length > 0 && this.dialLowLimitDeg < getLimitDegree('low', 'max');
+            return this.limitLow.toString().length > 0 && this.dialLowLimitDeg < getLimitDegree('low', 'max');
         },
         isDialLowLimitLow() {
             return this.dialLowLimitDeg >= getLimitDegree('low', 'q1');
@@ -362,7 +367,7 @@ export default {
             return this.dialLowLimitDeg >= getLimitDegree('low', 'q3');
         },
         isDialHighLimit() {
-            return this.limitHigh.length > 0 && this.dialHighLimitDeg < getLimitDegree('high', 'max');
+            return this.limitHigh.toString().length > 0 && this.dialHighLimitDeg < getLimitDegree('high', 'max');
         },
         isDialHighLimitLow() {
             return this.dialHighLimitDeg <= getLimitDegree('high', 'max');
@@ -383,10 +388,10 @@ export default {
             return this.degValue >= getLimitDegree('low', 'q3');
         },
         isMeterLimitHigh() {
-            return this.limitHigh.length > 0 && this.meterHighLimitPerc > 0;
+            return this.limitHigh.toString().length > 0 && this.meterHighLimitPerc > 0;
         },
         isMeterLimitLow() {
-            return this.limitLow.length > 0 && this.meterLowLimitPerc > 0;
+            return this.limitLow.toString().length > 0 && this.meterLowLimitPerc > 0;
         },
         typeDial() {
             return this.matchGaugeType('dial');
@@ -503,6 +508,11 @@ export default {
                     }
                 ]
             });
+        },
+        fontSizeFromChars(charNum, charThreshold, startPerc, reducePerc) {
+            const fs = (charNum <= charThreshold) ? startPerc : (startPerc - ((charNum - charThreshold) * reducePerc));
+
+            return fs.toString() + "%";
         },
         matchGaugeType(str) {
             return this.gaugeType.indexOf(str) !== -1;

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -23,181 +23,205 @@
 <div
     class="c-gauge__wrapper js-gauge-wrapper"
     :class="`c-gauge--${gaugeType}`"
+    :title="gaugeTitle"
 >
-    <svg
-        v-if="typeDial"
-        class="c-gauge c-dial"
-        viewBox="0 0 10 10"
-    >
-        <g class="c-dial__masks">
-            <mask id="gaugeValueMask">
-                <path
-                    d="M1.8926 8.1074C1.09734 7.31215 0.605469 6.21352 0.605469 5C0.605469 2.57297 2.57297 0.605469 5 0.605469C7.42703 0.605469 9.39453 2.57297 9.39453 5C9.39453 6.21352 8.90266 7.31215 8.1074 8.1074L7.14066 7.14066C7.6885 6.59281 8.02734 5.83598 8.02734 5C8.02734 3.32804 6.67196 1.97266 5 1.97266C3.32804 1.97266 1.97266 3.32804 1.97266 5C1.97266 5.83598 2.3115 6.59281 2.85934 7.14066L1.8926 8.1074Z"
-                    fill="white"
-                />
-            </mask>
-            <mask id="gaugeBgMask">
-                <path
-                    d="M8.53553 8.53553C9.44036 7.63071 10 6.38071 10 5C10 2.23858 7.76142 0 5 0C2.23858 0 0 2.23858 0 5C0 6.38071 0.559644 7.63071 1.46447 8.53553L2.85934 7.14066C2.3115 6.59281 1.97266 5.83598 1.97266 5C1.97266 3.32804 3.32804 1.97266 5 1.97266C6.67196 1.97266 8.02734 3.32804 8.02734 5C8.02734 5.83598 7.6885 6.59281 7.14066 7.14066L8.53553 8.53553Z"
-                    fill="white"
-                />
-            </mask>
-        </g>
-
-        <g
-            class="c-dial__graphics"
-            mask="url(#gaugeBgMask)"
+    <template v-if="typeDial">
+        <svg
+            class="c-gauge c-dial"
+            viewBox="0 0 10 10"
         >
-            <rect
-                class="c-dial__bg"
-                x="0"
-                y="0"
-                width="10"
-                height="10"
-            />
-            <g
-                v-if="isDialLowLimit"
-                class="c-dial__limit-low"
-                :style="`transform: rotate(${dialLowLimitDeg}deg)`"
-            >
-                <rect
-                    v-if="isDialLowLimitLow"
-                    class="c-dial__low-limit__low"
-                    x="5"
-                    y="5"
-                    width="5"
-                    height="5"
-                />
-                <rect
-                    v-if="isDialLowLimitMid"
-                    class="c-dial__low-limit__mid"
-                    x="5"
-                    y="0"
-                    width="5"
-                    height="5"
-                />
-                <rect
-                    v-if="isDialLowLimitHigh"
-                    class="c-dial__low-limit__high"
-                    x="0"
-                    y="0"
-                    width="5"
-                    height="5"
-                />
+            <g class="c-dial__masks">
+                <mask id="gaugeValueMask">
+                    <path
+                        d="M1.8926 8.1074C1.09734 7.31215 0.605469 6.21352 0.605469 5C0.605469 2.57297 2.57297 0.605469 5 0.605469C7.42703 0.605469 9.39453 2.57297 9.39453 5C9.39453 6.21352 8.90266 7.31215 8.1074 8.1074L7.14066 7.14066C7.6885 6.59281 8.02734 5.83598 8.02734 5C8.02734 3.32804 6.67196 1.97266 5 1.97266C3.32804 1.97266 1.97266 3.32804 1.97266 5C1.97266 5.83598 2.3115 6.59281 2.85934 7.14066L1.8926 8.1074Z"
+                        fill="white"
+                    />
+                </mask>
+                <mask id="gaugeBgMask">
+                    <path
+                        d="M8.53553 8.53553C9.44036 7.63071 10 6.38071 10 5C10 2.23858 7.76142 0 5 0C2.23858 0 0 2.23858 0 5C0 6.38071 0.559644 7.63071 1.46447 8.53553L2.85934 7.14066C2.3115 6.59281 1.97266 5.83598 1.97266 5C1.97266 3.32804 3.32804 1.97266 5 1.97266C6.67196 1.97266 8.02734 3.32804 8.02734 5C8.02734 5.83598 7.6885 6.59281 7.14066 7.14066L8.53553 8.53553Z"
+                        fill="white"
+                    />
+                </mask>
             </g>
-            <g
-                v-if="isDialHighLimit"
-                class="c-dial__limit-high"
-                :style="`transform: rotate(${dialHighLimitDeg}deg)`"
-            >
-                <rect
-                    v-if="isDialHighLimitLow"
-                    class="c-dial__high-limit__low"
-                    x="0"
-                    y="5"
-                    width="5"
-                    height="5"
-                />
-                <rect
-                    v-if="isDialHighLimitMid"
-                    class="c-dial__high-limit__mid"
-                    x="0"
-                    y="0"
-                    width="5"
-                    height="5"
-                />
-                <rect
-                    v-if="isDialHighLimitHigh"
-                    class="c-dial__high-limit__high"
-                    x="5"
-                    y="0"
-                    width="5"
-                    height="5"
-                />
-            </g>
-        </g>
 
-        <g
-            class="c-dial__graphics"
-            mask="url(#gaugeValueMask)"
-        >
             <g
-                v-if="typeFilledDial"
-                class="c-dial__filled-value"
-                :style="`transform: rotate(${degValueFilledDial}deg)`"
+                class="c-dial__graphics"
+                mask="url(#gaugeBgMask)"
             >
                 <rect
-                    v-if="isDialFilledValueLow"
-                    class="c-dial__filled-value__low"
-                    x="5"
-                    y="5"
-                    width="5"
-                    height="5"
-                />
-                <rect
-                    v-if="isDialFilledValueMid"
-                    class="c-dial__filled-value__mid"
-                    x="5"
-                    y="0"
-                    width="5"
-                    height="5"
-                />
-                <rect
-                    v-if="isDialFilledValueHigh"
-                    class="c-dial__filled-value__high"
+                    class="c-dial__bg"
                     x="0"
                     y="0"
-                    width="5"
-                    height="5"
+                    width="10"
+                    height="10"
+                />
+                <g
+                    v-if="isDialLowLimit"
+                    class="c-dial__limit-low"
+                    :style="`transform: rotate(${dialLowLimitDeg}deg)`"
+                >
+                    <rect
+                        v-if="isDialLowLimitLow"
+                        class="c-dial__low-limit__low"
+                        x="5"
+                        y="5"
+                        width="5"
+                        height="5"
+                    />
+                    <rect
+                        v-if="isDialLowLimitMid"
+                        class="c-dial__low-limit__mid"
+                        x="5"
+                        y="0"
+                        width="5"
+                        height="5"
+                    />
+                    <rect
+                        v-if="isDialLowLimitHigh"
+                        class="c-dial__low-limit__high"
+                        x="0"
+                        y="0"
+                        width="5"
+                        height="5"
+                    />
+                </g>
+                <g
+                    v-if="isDialHighLimit"
+                    class="c-dial__limit-high"
+                    :style="`transform: rotate(${dialHighLimitDeg}deg)`"
+                >
+                    <rect
+                        v-if="isDialHighLimitLow"
+                        class="c-dial__high-limit__low"
+                        x="0"
+                        y="5"
+                        width="5"
+                        height="5"
+                    />
+                    <rect
+                        v-if="isDialHighLimitMid"
+                        class="c-dial__high-limit__mid"
+                        x="0"
+                        y="0"
+                        width="5"
+                        height="5"
+                    />
+                    <rect
+                        v-if="isDialHighLimitHigh"
+                        class="c-dial__high-limit__high"
+                        x="5"
+                        y="0"
+                        width="5"
+                        height="5"
+                    />
+                </g>
+            </g>
+
+            <g
+                class="c-dial__graphics"
+                mask="url(#gaugeValueMask)"
+            >
+                <g
+                    v-if="typeFilledDial"
+                    class="c-dial__filled-value"
+                    :style="`transform: rotate(${degValueFilledDial}deg)`"
+                >
+                    <rect
+                        v-if="isDialFilledValueLow"
+                        class="c-dial__filled-value__low"
+                        x="5"
+                        y="5"
+                        width="5"
+                        height="5"
+                    />
+                    <rect
+                        v-if="isDialFilledValueMid"
+                        class="c-dial__filled-value__mid"
+                        x="5"
+                        y="0"
+                        width="5"
+                        height="5"
+                    />
+                    <rect
+                        v-if="isDialFilledValueHigh"
+                        class="c-dial__filled-value__high"
+                        x="0"
+                        y="0"
+                        width="5"
+                        height="5"
+                    />
+                </g>
+                <g
+                    v-if="valueInBounds && typeNeedleDial"
+                    class="c-dial__needle-value"
+                    :style="`transform: rotate(${degValue}deg)`"
+                >
+                    <path d="M4.90234 9.39453L5.09766 9.39453L5.30146 8.20874C6.93993 8.05674 8.22265 6.67817 8.22266 5C8.22266 3.22018 6.77982 1.77734 5 1.77734C3.22018 1.77734 1.77734 3.22018 1.77734 5C1.77734 6.67817 3.06007 8.05674 4.69854 8.20874L4.90234 9.39453Z" />
+                </g>
+                <path
+                    id="dialTextPath"
+                    class="c-dial__range-msg-path"
+                    d="M8.3501 5.0001C8.3501 6.85025 6.85025 8.3501 5.0001 8.3501C3.14994 8.3501 1.6501 6.85025 1.6501 5.0001C1.6501 3.14994 3.14994 1.6501 5.0001 1.6501C6.85025 1.6501 8.3501 3.14994 8.3501 5.0001Z"
+                    fill="none"
+                    style="transform-origin: center; transform: rotate(182deg)"
                 />
             </g>
-            <g
-                v-if="valueInBounds && typeNeedleDial"
-                class="c-dial__needle-value"
-                :style="`transform: rotate(${degValue}deg)`"
-            >
-                <path d="M4.90234 9.39453L5.09766 9.39453L5.30146 8.20874C6.93993 8.05674 8.22265 6.67817 8.22266 5C8.22266 3.22018 6.77982 1.77734 5 1.77734C3.22018 1.77734 1.77734 3.22018 1.77734 5C1.77734 6.67817 3.06007 8.05674 4.69854 8.20874L4.90234 9.39453Z" />
+            <g class="c-dial__text">
+                <g
+                    v-if="displayCurVal"
+                    class="c-dial__current-value-text-wrapper"
+                >
+                    <text
+                        class="c-dial__current-value-text js-dial-current-value"
+                        y="55%"
+                        lengthAdjust="spacing"
+                        :font-size="curValFontSize"
+                        text-anchor="middle"
+                        transform="translate(5)"
+                    >{{ curVal }}</text>
+                    <text
+                        v-if="displayUnits"
+                        class="c-dial__units-text"
+                        y="68%"
+                        font-size="8%"
+                        text-anchor="middle"
+                        transform="translate(5)"
+                    >{{ units }}</text>
+                </g>
+                <g
+                    v-if="displayMinMax"
+                    class="c-dial__range-text"
+                    :font-size="rangeFontSize"
+                >
+                    <text
+                        transform="translate(1.5 8.7) rotate(-45)"
+                        dominant-baseline="hanging"
+                    >{{ rangeLow }}</text>
+                    <text
+                        transform="translate(8.4 8.7) rotate(45)"
+                        dominant-baseline="hanging"
+                        text-anchor="end"
+                    >{{ rangeHigh }}</text>
+                </g>
             </g>
-        </g>
-        <g class="c-dial__text">
-            <g
-                v-if="displayCurVal"
-                class="c-dial__current-value-text-wrapper"
-            >
-                <text
-                    class="c-dial__current-value-text js-dial-current-value"
-                    y="55%"
-                    lengthAdjust="spacing"
-                    :font-size="curValFontSize"
-                    text-anchor="middle"
-                    transform="translate(5)"
-                >{{ curVal }}</text>
-                <text
-                    v-if="displayUnits"
-                    class="c-dial__units-text"
-                    y="68%"
-                    font-size="8%"
-                    text-anchor="middle"
-                    transform="translate(5)"
-                >{{ units }}</text>
-            </g>
-            <g
-                v-if="displayMinMax"
-                class="c-dial__range-text"
-                :font-size="rangeFontSize"
-            >
-                <text
-                    transform="translate(1.5 8.7) rotate(-45)"
-                    dominant-baseline="hanging"
-                >{{ rangeLow }}</text>
-                <text
-                    transform="translate(8.4 8.7) rotate(45)"
-                    dominant-baseline="hanging"
-                    text-anchor="end"
-                >{{ rangeHigh }}</text>
-            </g>
-        </g>
-    </svg>
+
+            <svg
+                v-if="!valueInBounds"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 512 512"
+                xml:space="preserve"
+                class="c-dial__value-oor-indicator"
+                x="45%"
+                y="80%"
+                width="1"
+                height="1"
+            ><path
+                d="M448 0H64C28.7.1.1 28.7 0 64v384c.1 35.3 28.7 63.9 64 64h384c35.3-.1 63.9-28.7 64-64V64c-.1-35.3-28.7-63.9-64-64zM288 448h-64v-64h64v64zm10.9-192L280 352h-48l-18.9-96V64H299v192h-.1z"
+            /></svg>
+
+        </svg>
+    </template>
 
     <template v-if="typeMeter">
         <div class="c-meter">
@@ -209,6 +233,16 @@
                 <div class="c-meter__range__low">{{ rangeLow }}</div>
             </div>
             <div class="c-meter__bg">
+                <svg
+                    v-if="!valueInBounds"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 512 512"
+                    :preserveAspectRatio="meterOorRangeIndicatorAspectRatio"
+                    class="c-meter__value-oor-indicator"
+                ><path
+                    d="M448 0H64C28.7.1.1 28.7 0 64v384c.1 35.3 28.7 63.9 64 64h384c35.3-.1 63.9-28.7 64-64V64c-.1-35.3-28.7-63.9-64-64zM288 448h-64v-64h64v64zm10.9-192L280 352h-48l-18.9-96V64H299v192h-.1z"
+                /></svg>
+
                 <template v-if="typeMeterVertical">
                     <div
                         class="c-meter__value"
@@ -249,37 +283,41 @@
 
                 <svg
                     class="c-meter__current-value-text-wrapper"
-                    viewBox="0 0 512 512"
+                    :viewBox="meterVerticalCurValViewBox"
+                    preserveAspectRatio="xMidYMid meet"
                 >
-                    <svg
-                        v-if="displayCurVal"
-                        class="c-meter__current-value-text-sizer"
-                        :viewBox="curValViewBox"
-                        preserveAspectRatio="xMidYMid meet"
+                    <rect
+                        class="c-meter__viewbox-debug"
+                        x="0"
+                        y="0"
+                        width="100%"
+                        height="100%"
+                    />
+                    <text
+                        class="c-meter__current-value-text js-meter-current-value"
+                        font-size="4"
+                        lengthAdjust="spacing"
+                        text-anchor="middle"
+                        :dominant-baseline="meterTextBaseline"
+                        x="50%"
+                        y="50%"
                     >
-                        <text
-                            class="c-dial__current-value-text js-meter-current-value"
-                            lengthAdjust="spacing"
-                            text-anchor="middle"
-                            style="transform: translate(50%, 70%)"
-                        >
+                        <template v-if="displayCurVal">
                             <tspan>{{ curVal }}</tspan>
                             <tspan
                                 v-if="typeMeterHorizontal && displayUnits"
                                 class="c-gauge__units"
-                                font-size="10"
+                                font-size="80%"
                             >{{ units }}</tspan>
-                        </text>
-                        <text
-                            v-if="typeMeterVertical && displayUnits"
-                            dy="12"
-                            class="c-gauge__units"
-                            font-size="10"
-                            lengthAdjust="spacing"
-                            text-anchor="middle"
-                            style="transform: translate(50%, 70%)"
-                        >{{ units }}</text>
-                    </svg>
+                            <tspan
+                                v-if="typeMeterVertical && displayUnits"
+                                x="50%"
+                                dy="3.5"
+                                class="c-gauge__units"
+                                font-size="80%"
+                            >{{ units }}</tspan>
+                        </template>
+                    </text>
                 </svg>
             </div>
         </div>
@@ -333,9 +371,15 @@ export default {
         dialLowLimitDeg() {
             return this.percentToDegrees(this.valToPercent(this.limitLow));
         },
-        curValViewBox() {
-            const DIGITS_RATIO = 10;
-            const VIEWBOX_STR = '0 0 X 15';
+        meterOorRangeIndicatorAspectRatio() {
+            return this.typeMeterVertical ? 'xMidYMin meet' : 'xMinYMid meet';
+        },
+        meterTextBaseline() {
+            return this.typeMeterVertical ? 'auto' : 'middle';
+        },
+        meterVerticalCurValViewBox() {
+            const DIGITS_RATIO = 3;
+            const VIEWBOX_STR = '0 0 X 10';
 
             return VIEWBOX_STR.replace('X', this.digits * DIGITS_RATIO);
         },
@@ -392,6 +436,9 @@ export default {
         },
         isMeterLimitLow() {
             return this.limitLow.toString().length > 0 && this.meterLowLimitPerc > 0;
+        },
+        gaugeTitle() {
+            return this.valueInBounds ? 'Gauge' : 'Value is currently out of range and cannot be graphically displayed';
         },
         typeDial() {
             return this.matchGaugeType('dial');

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -178,7 +178,7 @@
 
                 <g
                     v-if="displayMinMax"
-                    class="c-dial__range-text"
+                    class="c-dial__range-text js-gauge-dial-range"
                     :font-size="rangeFontSize"
                 >
                     <text
@@ -220,7 +220,7 @@
                     height="100%"
                 />
                 <text
-                    class="c-dial__current-value-text js-gauge-current-value"
+                    class="c-dial__current-value-text js-dial-current-value"
                     font-size="3.5"
                     lengthAdjust="spacing"
                     text-anchor="middle"

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -253,7 +253,7 @@
                 ><svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 512 512"
-                    :preserveAspectRatio="meterOorRangeIndicatorAspectRatio"
+                    :preserveAspectRatio="meterOutOfRangeIndicatorAspectRatio"
                 ><path
                     d="M448 0H64C28.7.1.1 28.7 0 64v384c.1 35.3 28.7 63.9 64 64h384c35.3-.1 63.9-28.7 64-64V64c-.1-35.3-28.7-63.9-64-64zM288 448h-64v-64h64v64zm10.9-192L280 352h-48l-18.9-96V64H299v192h-.1z"
                 /></svg></div>
@@ -390,7 +390,7 @@ export default {
         dialLowLimitDeg() {
             return this.percentToDegrees(this.valToPercent(this.limitLow));
         },
-        meterOorRangeIndicatorAspectRatio() {
+        meterOutOfRangeIndicatorAspectRatio() {
             return this.typeMeterVertical ? 'xMidYMax meet' : 'xMinYMid meet';
         },
         meterTextBaseline() {
@@ -503,6 +503,10 @@ export default {
             return 100 - this.valToPercentMeter(this.limitLow);
         },
         valueExpected() {
+            if (this.curVal === undefined || Object.is(this.curVal, 'null')) {
+                return false;
+            }
+
             return this.curVal.toString().indexOf(DEFAULT_CURRENT_VALUE) === -1;
         },
         valueInBounds() {

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -260,6 +260,7 @@
 
                 <template v-if="typeMeterVertical">
                     <div
+                        v-if="valueExpected"
                         class="c-meter__value"
                         :class="{'c-meter__value-needle' : typeNeedleMeter }"
                         :style="`transform: translateY(${meterValueToPerc}%)`"
@@ -280,6 +281,7 @@
 
                 <template v-if="typeMeterHorizontal">
                     <div
+                        v-if="valueExpected"
                         class="c-meter__value"
                         :class="{'c-meter__value-needle' : typeNeedleMeter }"
                         :style="`transform: translateX(${meterValueToPerc * -1}%)`"

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -472,10 +472,10 @@ export default {
             return this.matchGaugeType('inverted');
         },
         typeFilledMeter() {
-            return true; // TODO: enhance Gauge props to support this
+            return true; // Stubbing in for future capability
         },
         typeNeedleMeter() {
-            return false; // TODO: enhance Gauge props to support this
+            return false; // Stubbing in for future capability
         },
         meterValueToPerc() {
             const meterDirection = (this.typeMeterInverted) ? -1 : 1;

--- a/src/plugins/gauge/components/Gauge.vue
+++ b/src/plugins/gauge/components/Gauge.vue
@@ -261,6 +261,7 @@
                 <template v-if="typeMeterVertical">
                     <div
                         class="c-meter__value"
+                        :class="{'c-meter__value-needle' : typeNeedleMeter }"
                         :style="`transform: translateY(${meterValueToPerc}%)`"
                     ></div>
 
@@ -280,6 +281,7 @@
                 <template v-if="typeMeterHorizontal">
                     <div
                         class="c-meter__value"
+                        :class="{'c-meter__value-needle' : typeNeedleMeter }"
                         :style="`transform: translateX(${meterValueToPerc * -1}%)`"
                     ></div>
 
@@ -469,15 +471,25 @@ export default {
         typeMeterInverted() {
             return this.matchGaugeType('inverted');
         },
+        typeFilledMeter() {
+            return true; // TODO: enhance Gauge props to support this
+        },
+        typeNeedleMeter() {
+            return false; // TODO: enhance Gauge props to support this
+        },
         meterValueToPerc() {
             const meterDirection = (this.typeMeterInverted) ? -1 : 1;
 
-            if (this.curVal <= this.rangeLow) {
-                return meterDirection * 100;
-            }
+            if (this.typeFilledMeter) {
+                // Filled meter is a filled rectangle that is transformed along a vertical or horizontal axis
+                // So never move it below the low range more than 100%, or above the high range more than 0%
+                if (this.curVal <= this.rangeLow) {
+                    return meterDirection * 100;
+                }
 
-            if (this.curVal >= this.rangeHigh) {
-                return 0;
+                if (this.curVal >= this.rangeHigh) {
+                    return 0;
+                }
             }
 
             return this.valToPercentMeter(this.curVal) * meterDirection;

--- a/src/plugins/gauge/gauge.scss
+++ b/src/plugins/gauge/gauge.scss
@@ -19,6 +19,7 @@
   &__range,
   &__units,
   &__units text {
+    // TODO: MAKE THIS METER-SPECIFIC
     $c: $colorGaugeRange;
     color: $c;
     fill: $c;
@@ -31,44 +32,40 @@
 }
 
 /********************************************** DIAL GAUGE */
-svg[class*='c-dial'] {
+.c-dial {
   max-height: 100%;
   max-width: 100%;
-  position: absolute;
 
-  g {
-    transform-origin: center;
-  }
-}
-
-.c-dial {
   &__bg {
-    background: $colorGaugeBg;
-    clip-path: url(#gaugeBgMask);
+    fill: $colorGaugeBg;
   }
-
-  &__limit-high rect { fill: $colorGaugeLimitHigh; }
-  &__limit-low rect { fill: $colorGaugeLimitLow; }
-
-  &__filled-value-wrapper {
-    clip-path: url(#gaugeValueMask);
+  &__limit-high rect {
+    fill: $colorGaugeLimitHigh;
   }
-
-  &__needle-value-wrapper {
-    clip-path: url(#gaugeValueMask);
+  &__limit-low rect {
+    fill: $colorGaugeLimitLow;
   }
-
-  &__filled-value { fill: $colorGaugeValue; }
-
+  &__filled-value {
+    fill: $colorGaugeValue;
+  }
   &__needle-value {
     fill: $colorGaugeValue;
     transition: transform $transitionTimeGauge;
   }
-
-  &__current-value-text,
-  &__units-text {
+  &__current-value-text {
     fill: $colorGaugeTextValue;
     font-family: $heroFont;
+  }
+
+  &__units-text,
+  &__range-text {
+    $c: $colorGaugeRange;
+    fill: $c;
+  }
+
+  &__graphics g {
+    transform-origin: center;
+    opacity: 0.5; // TEMP
   }
 }
 

--- a/src/plugins/gauge/gauge.scss
+++ b/src/plugins/gauge/gauge.scss
@@ -29,11 +29,19 @@
     @include abs();
     overflow: hidden;
   }
+
+  &__current-value-text-wrapper {
+    // SVG
+    position: absolute;
+    height: 100%;
+    width: 100%;
+  }
 }
 
 .c-dial__value-oor-indicator,
 .c-meter__value-oor-indicator {
   fill: $colorGaugeRange;
+  opacity: 0.5;
 }
 
 /********************************************** DIAL GAUGE */
@@ -56,7 +64,6 @@
   }
   &__needle-value {
     fill: $colorGaugeValue;
-    transition: transform $transitionTimeGauge;
   }
   &__current-value-text {
     fill: $colorGaugeTextValue;
@@ -77,7 +84,7 @@
 /********************************************** METER GAUGE */
 .c-meter {
   // Common styles for c-meter
-  $meterOutOfRangeIndicatorMax: 50%;
+  $meterOutOfRangeIndicatorMaxSize: 50%;
   @include abs();
   display: flex;
 
@@ -98,32 +105,30 @@
     // Filled area
     position: absolute;
     background: $colorGaugeValue;
-    transition: transform $transitionTimeGauge;
     z-index: 1;
   }
 
   &__value-oor-indicator {
-    opacity: 50%;
+    $mxPx: 50px;
+    $wh: 50%;
     position: absolute;
-    max-height: $meterOutOfRangeIndicatorMax;
-    max-width: $meterOutOfRangeIndicatorMax;
-  }
+    height: $wh;
+    width: $wh;
+    max-height: $mxPx;
+    max-width: $mxPx;
 
-  &__current-value-text-wrapper {
-    // SVG
-    position: absolute;
-    height: 100%;
-    width: 100%;
+    svg {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      max-height: 100%;
+      max-width: 100%;
+    }
   }
 
   &__current-value-text {
     fill: $colorGaugeTextValue;
     font-family: $heroFont;
-  }
-
-  &__viewbox-debug {
-    //fill: rgba(deeppink, 0.5);
-    display: none;
   }
 
   .c-gauge__curval {
@@ -168,7 +173,7 @@
     }
 
     .c-meter__value-oor-indicator {
-      bottom: 2%;
+      bottom: 10%;
       left: 50%;
       transform: translateX(-50%);
     }
@@ -247,9 +252,14 @@
     }
 
     .c-meter__value-oor-indicator {
+      // Horizontal meter
       left: 2%;
       top: 50%;
       transform: translateY(-50%);
     }
   }
+}
+.svg-viewbox-debug {
+  fill: rgba(deeppink, 0.5);
+  display: none;
 }

--- a/src/plugins/gauge/gauge.scss
+++ b/src/plugins/gauge/gauge.scss
@@ -1,3 +1,6 @@
+$meterNeedlePerc: 1%; // Todo: move this into a constant
+$meterNeedleMinPx: 2px;
+
 .is-object-type-gauge {
   overflow: hidden;
 }
@@ -77,7 +80,6 @@
 
   &__graphics g {
     transform-origin: center;
-    opacity: 0.5; // TEMP
   }
 }
 
@@ -106,6 +108,16 @@
     position: absolute;
     background: $colorGaugeValue;
     z-index: 1;
+  }
+
+  &__value-needle {
+    background: none !important;
+    &:before {
+      @include abs();
+      content: '';
+      display: block;
+      background: $colorGaugeValue;
+    }
   }
 
   &__value-oor-indicator {
@@ -187,6 +199,17 @@
     &__limit-high {
       top: 0;
     }
+
+    &__value-needle {
+      left: 0;
+
+      &:before {
+        bottom: auto;
+        height: $meterNeedlePerc;
+        min-height: $meterNeedleMinPx;
+        transform: translateY(-50%);
+      }
+    }
   }
 
   .c-gauge--meter-vertical-inverted & {
@@ -204,6 +227,17 @@
 
     &__range__high {
       order: 2;
+    }
+
+    &__value-needle {
+      left: 0;
+
+      &:before {
+        top: auto;
+        height: $meterNeedlePerc;
+        min-height: $meterNeedleMinPx;
+        transform: translateY(50%);
+      }
     }
   }
 
@@ -236,6 +270,17 @@
       bottom: $m;
       left: 0;
       right: 0;
+    }
+
+    &__value-needle {
+      bottom: 0;
+
+      &:before {
+        left: auto;
+        width: $meterNeedlePerc;
+        min-height: $meterNeedleMinPx;
+        transform: translateX(50%);
+      }
     }
 
     [class*='limit'] {

--- a/src/plugins/gauge/gauge.scss
+++ b/src/plugins/gauge/gauge.scss
@@ -1,5 +1,7 @@
-$meterNeedlePerc: 1%; // Todo: move this into a constant
-$meterNeedleMinPx: 2px;
+$meterNeedlePerc: 1%;
+$meterNeedleMinPx: 4px;
+$meterNeedleMaxPx: 20px;
+$meterNeedleBorderRadius: 5px;
 
 .is-object-type-gauge {
   overflow: hidden;
@@ -22,7 +24,6 @@ $meterNeedleMinPx: 2px;
   &__range,
   &__units,
   &__units text {
-    // TODO: MAKE THIS METER-SPECIFIC
     $c: $colorGaugeRange;
     color: $c;
     fill: $c;
@@ -179,6 +180,18 @@ $meterNeedleMinPx: 2px;
       bottom: 0;
     }
 
+    &__value-needle {
+      right: 0;
+
+      &:before {
+        border-bottom-left-radius: $meterNeedleBorderRadius;
+        border-top-left-radius: $meterNeedleBorderRadius;
+        height: $meterNeedlePerc;
+        min-height: $meterNeedleMinPx;
+        max-height: $meterNeedleMaxPx;
+      }
+    }
+
     [class*='limit'] {
       left: 0;
       right: 0;
@@ -201,12 +214,8 @@ $meterNeedleMinPx: 2px;
     }
 
     &__value-needle {
-      left: 0;
-
       &:before {
         bottom: auto;
-        height: $meterNeedlePerc;
-        min-height: $meterNeedleMinPx;
         transform: translateY(-50%);
       }
     }
@@ -230,12 +239,8 @@ $meterNeedleMinPx: 2px;
     }
 
     &__value-needle {
-      left: 0;
-
       &:before {
         top: auto;
-        height: $meterNeedlePerc;
-        min-height: $meterNeedleMinPx;
         transform: translateY(50%);
       }
     }
@@ -273,12 +278,15 @@ $meterNeedleMinPx: 2px;
     }
 
     &__value-needle {
-      bottom: 0;
+      top: 0;
 
       &:before {
+        border-bottom-left-radius: $meterNeedleBorderRadius;
+        border-bottom-right-radius: $meterNeedleBorderRadius;
         left: auto;
         width: $meterNeedlePerc;
-        min-height: $meterNeedleMinPx;
+        min-width: $meterNeedleMinPx;
+        max-width: $meterNeedleMaxPx;
         transform: translateX(50%);
       }
     }

--- a/src/plugins/gauge/gauge.scss
+++ b/src/plugins/gauge/gauge.scss
@@ -31,6 +31,11 @@
   }
 }
 
+.c-dial__value-oor-indicator,
+.c-meter__value-oor-indicator {
+  fill: $colorGaugeRange;
+}
+
 /********************************************** DIAL GAUGE */
 .c-dial {
   max-height: 100%;
@@ -45,7 +50,8 @@
   &__limit-low rect {
     fill: $colorGaugeLimitLow;
   }
-  &__filled-value {
+  &__filled-value,
+  &__range-msg-text {
     fill: $colorGaugeValue;
   }
   &__needle-value {
@@ -59,8 +65,7 @@
 
   &__units-text,
   &__range-text {
-    $c: $colorGaugeRange;
-    fill: $c;
+    fill: $colorGaugeRange;
   }
 
   &__graphics g {
@@ -72,15 +77,9 @@
 /********************************************** METER GAUGE */
 .c-meter {
   // Common styles for c-meter
+  $meterOutOfRangeIndicatorMax: 50%;
   @include abs();
   display: flex;
-
-  svg {
-    // current-value-text
-    position: absolute;
-    height: 100%;
-    width: 100%;
-  }
 
   &__range {
     display: flex;
@@ -101,6 +100,30 @@
     background: $colorGaugeValue;
     transition: transform $transitionTimeGauge;
     z-index: 1;
+  }
+
+  &__value-oor-indicator {
+    opacity: 50%;
+    position: absolute;
+    max-height: $meterOutOfRangeIndicatorMax;
+    max-width: $meterOutOfRangeIndicatorMax;
+  }
+
+  &__current-value-text-wrapper {
+    // SVG
+    position: absolute;
+    height: 100%;
+    width: 100%;
+  }
+
+  &__current-value-text {
+    fill: $colorGaugeTextValue;
+    font-family: $heroFont;
+  }
+
+  &__viewbox-debug {
+    //fill: rgba(deeppink, 0.5);
+    display: none;
   }
 
   .c-gauge__curval {
@@ -142,6 +165,12 @@
     [class*='limit'] {
       left: 0;
       right: 0;
+    }
+
+    .c-meter__value-oor-indicator {
+      bottom: 2%;
+      left: 50%;
+      transform: translateX(-50%);
     }
   }
 
@@ -215,6 +244,12 @@
 
     &__limit-high {
       right: 0;
+    }
+
+    .c-meter__value-oor-indicator {
+      left: 2%;
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
 }


### PR DESCRIPTION
![Screen Shot 2022-06-24 at 11 00 26 AM](https://user-images.githubusercontent.com/1056412/175646939-b4683d29-8e78-49b4-9851-6e9efc4d75b7.png)

- Significant work refactoring SVG markup and CSS for dial gauge;
- Fixed missing `v-if` to control display of units for #5325;
- Fixed bad `.length` test for limit properties;
- Fixed cross-browser problems with current value display in dial gauge;
- Added "out of range" indicator (yellow arrows) and hover tooltip;
- Range text (purple arrows) now dynamically sizes to fit based on character length;

Closes #5323 
Closes #5325
Closes #5139

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
