### PR TITLE
[Timer] Update 3dot menu actions appropriately

### DIFF
--- a/e2e/tests/plugins/timer/timer.e2e.spec.js
+++ b/e2e/tests/plugins/timer/timer.e2e.spec.js
@@ -44,24 +44,30 @@ test.describe('Timer', () => {
         await expect(page.locator('.l-browse-bar__object-name')).toContainText('Unnamed Timer');
     });
 
-    test('Can start, pause, restart, and stop timer within context menu and 3dot menu', async ({ page }) => {
+    test('Can perform actions on the Timer', async ({ page }) => {
         test.info().annotations.push({
             type: 'issue',
             description: 'https://github.com/nasa/openmct/issues/4313'
         });
 
-        await test.step("Use Timer actions from the tree context menu", async () => {
+        await test.step("From the tree context menu", async () => {
             await triggerTimerContextMenuAction(page, 'Start');
             await triggerTimerContextMenuAction(page, 'Pause');
             await triggerTimerContextMenuAction(page, 'Restart at 0');
             await triggerTimerContextMenuAction(page, 'Stop');
         });
 
-        await test.step("Use Timer actions from the 3dot menu", async () => {
+        await test.step("From the 3dot menu", async () => {
             await triggerTimer3dotMenuAction(page, 'Start');
             await triggerTimer3dotMenuAction(page, 'Pause');
             await triggerTimer3dotMenuAction(page, 'Restart at 0');
             await triggerTimer3dotMenuAction(page, 'Stop');
+        });
+
+        await test.step("From the object view", async () => {
+            await triggerTimerViewAction(page, 'Start');
+            await triggerTimerViewAction(page, 'Pause');
+            await triggerTimerViewAction(page, 'Restart at 0');
         });
     });
 });
@@ -69,6 +75,11 @@ test.describe('Timer', () => {
 /**
  * Actions that can be performed on a timer from context menus.
  * @typedef {'Start' | 'Stop' | 'Pause' | 'Restart at 0'} TimerAction
+ */
+
+/**
+ * Actions that can be performed on a timer from the object view.
+ * @typedef {'Start' | 'Pause' | 'Restart at 0'} TimerViewAction
  */
 
 /**
@@ -121,6 +132,32 @@ async function triggerTimer3dotMenuAction(page, action) {
 
     await page.locator(menuAction).click();
     assertTimerStateAfterAction(page, action);
+}
+
+/**
+ * Trigger a timer action from the object view
+ * @param {import('@playwright/test').Page} page
+ * @param {TimerViewAction} action
+ */
+async function triggerTimerViewAction(page, action) {
+    const buttonTitle = buttonTitleFromAction(action);
+    await page.click(`button[title="${buttonTitle}"]`);
+    assertTimerStateAfterAction(page, action);
+}
+
+/**
+ * Takes in a TimerViewAction and returns the button title
+ * @param {TimerViewAction} action
+ */
+function buttonTitleFromAction(action) {
+    switch (action) {
+    case 'Start':
+        return 'Start';
+    case 'Pause':
+        return 'Pause';
+    case 'Restart at 0':
+        return 'Reset';
+    }
 }
 
 /**

--- a/e2e/tests/plugins/timer/timer.e2e.spec.js
+++ b/e2e/tests/plugins/timer/timer.e2e.spec.js
@@ -67,7 +67,8 @@ test.describe('Timer', () => {
 });
 
 /**
- * Open the timer context menu from the object tree
+ * Open the timer context menu from the object tree.
+ * Expands the 'My Items' folder if it is not already expanded.
  * @param {import('@playwright/test').Page} page
  */
 async function openTimerContextMenu(page) {

--- a/e2e/tests/plugins/timer/timer.e2e.spec.js
+++ b/e2e/tests/plugins/timer/timer.e2e.spec.js
@@ -1,0 +1,155 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+const { test } = require('../../../fixtures.js');
+const { expect } = require('@playwright/test');
+
+test.describe('Timer', () => {
+
+    test.beforeEach(async ({ page }) => {
+        //Go to baseURL
+        await page.goto('/', { waitUntil: 'networkidle' });
+
+        //Click the Create button
+        await page.click('button:has-text("Create")');
+
+        // Click 'Timer'
+        await page.click('text=Timer');
+
+        // Click text=OK
+        await Promise.all([
+            page.waitForNavigation({waitUntil: 'networkidle'}),
+            page.click('text=OK')
+        ]);
+
+        await expect(page.locator('.l-browse-bar__object-name')).toContainText('Unnamed Timer');
+    });
+
+    test('Can start, pause, restart, and stop timer within context menu and 3dot menu', async ({ page }) => {
+        test.info().annotations.push({
+            type: 'issue',
+            description: 'https://github.com/nasa/openmct/issues/4313'
+        });
+
+        await test.step("Use Timer actions from the tree context menu", async () => {
+            await triggerTimerContextMenuAction(page, 'Start');
+            await triggerTimerContextMenuAction(page, 'Pause');
+            await triggerTimerContextMenuAction(page, 'Restart at 0');
+            await triggerTimerContextMenuAction(page, 'Stop');
+        });
+
+        await test.step("Use Timer actions from the 3dot menu", async () => {
+            await triggerTimer3dotMenuAction(page, 'Start');
+            await triggerTimer3dotMenuAction(page, 'Pause');
+            await triggerTimer3dotMenuAction(page, 'Restart at 0');
+            await triggerTimer3dotMenuAction(page, 'Stop');
+        });
+    });
+});
+
+/**
+ * Open the timer context menu from the object tree
+ * @param {import('@playwright/test').Page} page
+ */
+async function openTimerContextMenu(page) {
+    const myItemsFolder = page.locator('text=Open MCT My Items >> span').nth(3);
+    const className = await myItemsFolder.getAttribute('class');
+    if (!className.includes('c-disclosure-triangle--expanded')) {
+        await myItemsFolder.click();
+    }
+
+    await page.locator(`a:has-text("Unnamed Timer")`).click({
+        button: 'right'
+    });
+}
+
+/**
+ * Trigger a timer action from the tree context menu
+ * @param {import('@playwright/test').Page} page
+ * @param {'Start' | 'Stop' | 'Pause' | 'Restart at 0'} action
+ */
+async function triggerTimerContextMenuAction(page, action) {
+    await openTimerContextMenu(page);
+    let menuOptions = page.locator('.c-menu ul');
+    await expect.soft(menuOptions).toContainText(action);
+    await page.locator(`.c-menu ul li:has-text("${action}")`).click();
+    await openTimerContextMenu(page);
+    menuOptions = page.locator('.c-menu ul');
+    await assertAvailableActions(menuOptions, action);
+}
+
+/**
+ * Trigger a timer action from the 3dot menu
+ * @param {import('@playwright/test').Page} page
+ * @param {'Start' | 'Stop' | 'Pause' | 'Restart at 0'} action
+ */
+async function triggerTimer3dotMenuAction(page, action) {
+    const threeDotMenuButton = 'button[title="More options"]';
+    await page.click(threeDotMenuButton);
+    await page.locator(`.c-menu ul li:has-text("${action}")`).click();
+
+    // FIXME: Figure out a way to not need an explicit wait here.
+    // Need to wait for 3dot menu options to update via event.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(200);
+
+    await page.click(threeDotMenuButton);
+    const menuOptions = page.locator('.c-menu ul');
+    await assertAvailableActions(menuOptions, action);
+
+    // Dismiss 3dot menu (click outside of it)
+    await page.click('.c-object-view');
+}
+
+/**
+ * Assert the available actions in the menu after performing the given action
+ * @param {import('@playwright/test').Locator} menuLocator
+ * @param {'Start' | 'Stop' | 'Pause' | 'Restart at 0'} action
+ */
+async function assertAvailableActions(menuLocator, action) {
+    switch (action) {
+    case 'Start':
+        await expect.soft(menuLocator).not.toContainText('Start');
+        await expect.soft(menuLocator).toContainText('Stop');
+        await expect.soft(menuLocator).toContainText('Pause');
+        await expect.soft(menuLocator).toContainText('Restart at 0');
+        break;
+    case 'Stop':
+        await expect.soft(menuLocator).toContainText('Start');
+        await expect.soft(menuLocator).not.toContainText('Stop');
+        await expect.soft(menuLocator).not.toContainText('Pause');
+        await expect.soft(menuLocator).not.toContainText('Restart at 0');
+        break;
+    case 'Pause':
+        await expect.soft(menuLocator).toContainText('Start');
+        await expect.soft(menuLocator).toContainText('Stop');
+        await expect.soft(menuLocator).not.toContainText('Pause');
+        await expect.soft(menuLocator).toContainText('Restart at 0');
+        break;
+    case 'Restart at 0':
+        await expect.soft(menuLocator).not.toContainText('Start');
+        await expect.soft(menuLocator).toContainText('Stop');
+        await expect.soft(menuLocator).toContainText('Pause');
+        await expect.soft(menuLocator).toContainText('Restart at 0');
+        break;
+    }
+}

--- a/src/api/actions/ActionCollection.js
+++ b/src/api/actions/ActionCollection.js
@@ -132,7 +132,6 @@ class ActionCollection extends EventEmitter {
     }
 
     _update() {
-        console.log('update emitted');
         this.emit('update', this.applicableActions);
     }
 

--- a/src/api/actions/ActionCollection.js
+++ b/src/api/actions/ActionCollection.js
@@ -85,8 +85,6 @@ class ActionCollection extends EventEmitter {
     }
 
     destroy() {
-        super.removeAllListeners();
-
         if (!this.skipEnvironmentObservers) {
             this.objectUnsubscribes.forEach(unsubscribe => {
                 unsubscribe();
@@ -96,6 +94,7 @@ class ActionCollection extends EventEmitter {
         }
 
         this.emit('destroy', this.view);
+        this.removeAllListeners();
     }
 
     getVisibleActions() {
@@ -133,6 +132,7 @@ class ActionCollection extends EventEmitter {
     }
 
     _update() {
+        console.log('update emitted');
         this.emit('update', this.applicableActions);
     }
 

--- a/src/plugins/timer/actions/PauseTimerAction.js
+++ b/src/plugins/timer/actions/PauseTimerAction.js
@@ -43,14 +43,19 @@ export default class PauseTimerAction {
 
         this.openmct.objects.mutate(domainObject, 'configuration', newConfiguration);
     }
-    appliesTo(objectPath) {
+    appliesTo(objectPath, view = {}) {
         const domainObject = objectPath[0];
         if (!domainObject || !domainObject.configuration) {
             return;
         }
 
+        // Use object configuration timerState for viewless context menus,
+        // otherwise manually show/hide based on the view's timerState
+        const viewKey = view.key;
         const { timerState } = domainObject.configuration;
 
-        return domainObject.type === 'timer' && timerState === 'started';
+        return viewKey
+            ? domainObject.type === 'timer'
+            : domainObject.type === 'timer' && timerState === 'started';
     }
 }

--- a/src/plugins/timer/actions/RestartTimerAction.js
+++ b/src/plugins/timer/actions/RestartTimerAction.js
@@ -44,14 +44,19 @@ export default class RestartTimerAction {
 
         this.openmct.objects.mutate(domainObject, 'configuration', newConfiguration);
     }
-    appliesTo(objectPath) {
+    appliesTo(objectPath, view = {}) {
         const domainObject = objectPath[0];
         if (!domainObject || !domainObject.configuration) {
             return;
         }
 
+        // Use object configuration timerState for viewless context menus,
+        // otherwise manually show/hide based on the view's timerState
+        const viewKey = view.key;
         const { timerState } = domainObject.configuration;
 
-        return domainObject.type === 'timer' && timerState !== 'stopped';
+        return viewKey
+            ? domainObject.type === 'timer'
+            : domainObject.type === 'timer' && timerState !== 'stopped';
     }
 }

--- a/src/plugins/timer/actions/StartTimerAction.js
+++ b/src/plugins/timer/actions/StartTimerAction.js
@@ -63,14 +63,19 @@ export default class StartTimerAction {
         newConfiguration.pausedTime = undefined;
         this.openmct.objects.mutate(domainObject, 'configuration', newConfiguration);
     }
-    appliesTo(objectPath) {
+    appliesTo(objectPath, view = {}) {
         const domainObject = objectPath[0];
         if (!domainObject || !domainObject.configuration) {
             return;
         }
 
+        // Use object configuration timerState for viewless context menus,
+        // otherwise manually show/hide based on the view's timerState
+        const viewKey = view.key;
         const { timerState } = domainObject.configuration;
 
-        return domainObject.type === 'timer' && timerState !== 'started';
+        return viewKey
+            ? domainObject.type === 'timer'
+            : domainObject.type === 'timer' && timerState !== 'started';
     }
 }

--- a/src/plugins/timer/actions/StopTimerAction.js
+++ b/src/plugins/timer/actions/StopTimerAction.js
@@ -44,14 +44,19 @@ export default class StopTimerAction {
 
         this.openmct.objects.mutate(domainObject, 'configuration', newConfiguration);
     }
-    appliesTo(objectPath) {
+    appliesTo(objectPath, view = {}) {
         const domainObject = objectPath[0];
         if (!domainObject || !domainObject.configuration) {
             return;
         }
 
+        // Use object configuration timerState for viewless context menus,
+        // otherwise manually show/hide based on the view's timerState
+        const viewKey = view.key;
         const { timerState } = domainObject.configuration;
 
-        return domainObject.type === 'timer' && timerState !== 'stopped';
+        return viewKey
+            ? domainObject.type === 'timer'
+            : domainObject.type === 'timer' && timerState !== 'stopped';
     }
 }

--- a/src/plugins/timer/components/Timer.vue
+++ b/src/plugins/timer/components/Timer.vue
@@ -179,6 +179,15 @@ export default {
             return timerSign;
         }
     },
+    watch: {
+        timerState() {
+            if (!this.viewActionsCollection) {
+                return;
+            }
+
+            this.showOrHideAvailableActions();
+        }
+    },
     mounted() {
         this.$nextTick(() => {
             if (this.configuration && this.configuration.timerState === undefined) {
@@ -190,6 +199,9 @@ export default {
             this.unlisten = ticker.listen(() => {
                 this.openmct.objects.refresh(this.domainObject);
             });
+
+            this.viewActionsCollection = this.openmct.actions.getActionsCollection(this.objectPath, this.currentView);
+            this.showOrHideAvailableActions();
         });
     },
     beforeDestroy() {
@@ -227,6 +239,22 @@ export default {
             const action = this.openmct.actions.getAction(actionKey);
             if (action) {
                 action.invoke(this.objectPath, this.currentView);
+            }
+        },
+        showOrHideAvailableActions() {
+            switch (this.timerState) {
+            case 'started':
+                this.viewActionsCollection.hide(['timer.start']);
+                this.viewActionsCollection.show(['timer.stop', 'timer.pause', 'timer.restart']);
+                break;
+            case 'paused':
+                this.viewActionsCollection.hide(['timer.pause']);
+                this.viewActionsCollection.show(['timer.stop', 'timer.start', 'timer.restart']);
+                break;
+            case 'stopped':
+                this.viewActionsCollection.hide(['timer.stop', 'timer.pause', 'timer.restart']);
+                this.viewActionsCollection.show(['timer.start']);
+                break;
             }
         }
     }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #4313 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

When clicking Timer actions in a 3dot menu, the available actions now update appropriately.

My initial approach was to observe all changes to the given `domainObject`, and refresh the `actionCollection` once any change was observed. However, this led to a lot of weird issues and edge cases such as menu options disappearing if the `actionCollection` was refreshed in a view/large view. Also, the Timer is unique in that it refreshes itself on every tick in order to remain in sync across browser instances. This approach meant triggering re-renders on every tick if working with a Timer.

I settled on a hybrid approach to action availability in regards to the Timer:

- If the actions are within a viewless context menu (such as right clicking on the Timer in the tree view), then the available actions are determined by object configuration state.
- If the actions are within a viewful (new word 😉) context menu, such as any 3-dot menu, all actions will be permitted and the Timer view will be responsible for showing/hiding actions as they are performed.

Also [fixed a tiny bug](https://github.com/nasa/openmct/pull/5387/commits/ecde8dd81dbe91b0af6c10620a346e7e93e899fb) that was causing `actionCollection` 'destroy' events to not get picked up by any listeners. The side effect of this was that cached `actionCollection`s [were not being updated](https://github.com/nasa/openmct/blob/ecde8dd81dbe91b0af6c10620a346e7e93e899fb/src/api/actions/ActionsAPI.js#L79) in some scenarios.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
