### PR TITLE
Replacement for Visual Test for Gauge PR

### DIFF
--- a/e2e/tests/persistence/persistability.e2e.spec.js
+++ b/e2e/tests/persistence/persistability.e2e.spec.js
@@ -28,9 +28,7 @@ const { test } = require('../../fixtures.js');
 const { expect } = require('@playwright/test');
 const path = require('path');
 
-// https://github.com/nasa/openmct/issues/4323#issuecomment-1067282651
-
-test.describe('Persistence operations', () => {
+test.describe('Persistence operations @addInit', () => {
     // add non persistable root item
     test.beforeEach(async ({ page }) => {
         // eslint-disable-next-line no-undef
@@ -38,6 +36,10 @@ test.describe('Persistence operations', () => {
     });
 
     test('Persistability should be respected in the create form location field', async ({ page }) => {
+        test.info().annotations.push({
+            type: 'issue',
+            description: 'https://github.com/nasa/openmct/issues/4323'
+        });
         // Go to baseURL
         await page.goto('/', { waitUntil: 'networkidle' });
 

--- a/e2e/tests/plugins/gauge/addInitGauge.js
+++ b/e2e/tests/plugins/gauge/addInitGauge.js
@@ -1,0 +1,30 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+// this will be called from the test suite with
+// await page.addInitScript({ path: path.join(__dirname, 'addInitGauge.js') });
+// it will install the Gauge since it is not installed by default
+
+document.addEventListener('DOMContentLoaded', () => {
+    const openmct = window.openmct;
+    openmct.install(openmct.plugins.Gauge());
+});

--- a/e2e/tests/plugins/notebook/restrictedNotebook.e2e.spec.js
+++ b/e2e/tests/plugins/notebook/restrictedNotebook.e2e.spec.js
@@ -125,17 +125,17 @@ async function openContextMenuRestrictedNotebook(page) {
     return;
 }
 
-test.describe('Restricted Notebook', () => {
+test.describe('Restricted Notebook @addInit', () => {
 
     test.beforeEach(async ({ page }) => {
         await startAndAddNotebookObject(page);
     });
 
-    test('Can be renamed', async ({ page }) => {
+    test('Can be renamed @addInit', async ({ page }) => {
         await expect.soft(page.locator('.l-browse-bar__object-name')).toContainText(`Unnamed ${CUSTOM_NAME}`);
     });
 
-    test('Can be deleted if there are no locked pages', async ({ page }) => {
+    test('Can be deleted if there are no locked pages @addInit', async ({ page }) => {
         await openContextMenuRestrictedNotebook(page);
 
         const menuOptions = page.locator('.c-menu ul');
@@ -158,7 +158,7 @@ test.describe('Restricted Notebook', () => {
         expect.soft(await restrictedNotebookTreeObject.count()).toEqual(0);
     });
 
-    test('Can be locked if at least one page has one entry', async ({ page }) => {
+    test('Can be locked if at least one page has one entry @addInit', async ({ page }) => {
 
         await enterTextEntry(page);
 
@@ -168,7 +168,7 @@ test.describe('Restricted Notebook', () => {
 
 });
 
-test.describe('Restricted Notebook with at least one entry and with the page locked', () => {
+test.describe('Restricted Notebook with at least one entry and with the page locked @addInit', () => {
 
     test.beforeEach(async ({ page }) => {
         await startAndAddNotebookObject(page);
@@ -179,7 +179,7 @@ test.describe('Restricted Notebook with at least one entry and with the page loc
         await page.locator('button.c-notebook__toggle-nav-button').click();
     });
 
-    test('Locked page should now be in a locked state', async ({ page }) => {
+    test('Locked page should now be in a locked state @addInit', async ({ page }) => {
         // main lock message on page
         const lockMessage = page.locator('text=This page has been committed and cannot be modified or removed');
         expect.soft(await lockMessage.count()).toEqual(1);
@@ -197,7 +197,7 @@ test.describe('Restricted Notebook with at least one entry and with the page loc
 
     });
 
-    test('Can still: add page, rename, add entry, delete unlocked pages', async ({ page }) => {
+    test('Can still: add page, rename, add entry, delete unlocked pages @addInit', async ({ page }) => {
         // Click text=Page Add >> button
         await Promise.all([
             page.waitForNavigation(),
@@ -237,14 +237,14 @@ test.describe('Restricted Notebook with at least one entry and with the page loc
     });
 });
 
-test.describe('Restricted Notebook with a page locked and with an embed', () => {
+test.describe('Restricted Notebook with a page locked and with an embed @addInit', () => {
 
     test.beforeEach(async ({ page }) => {
         await startAndAddNotebookObject(page);
         await dragAndDropEmbed(page);
     });
 
-    test('Allows embeds to be deleted if page unlocked', async ({ page }) => {
+    test('Allows embeds to be deleted if page unlocked @addInit', async ({ page }) => {
         // Click .c-ne__embed__name .c-popup-menu-button
         await page.locator('.c-ne__embed__name .c-popup-menu-button').click(); // embed popup menu
 
@@ -252,7 +252,7 @@ test.describe('Restricted Notebook with a page locked and with an embed', () => 
         await expect.soft(embedMenu).toContainText('Remove This Embed');
     });
 
-    test('Disallows embeds to be deleted if page locked', async ({ page }) => {
+    test('Disallows embeds to be deleted if page locked @addInit', async ({ page }) => {
         await lockPage(page);
         // Click .c-ne__embed__name .c-popup-menu-button
         await page.locator('.c-ne__embed__name .c-popup-menu-button').click(); // embed popup menu

--- a/e2e/tests/visual/addInit.visual.spec.js
+++ b/e2e/tests/visual/addInit.visual.spec.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-undef */
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*
+Collection of Visual Tests set to run with modified init scripts to inject plugins not otherwise available in the default contexts.
+
+These should only use functional expect statements to verify assumptions about the state
+in a test and not for functional verification of correctness. Visual tests are not supposed
+to "fail" on assertions. Instead, they should be used to detect changes between builds or branches.
+
+Note: Larger testsuite sizes are OK due to the setup time associated with these tests.
+*/
+
+const { test } = require('@playwright/test');
+const percySnapshot = require('@percy/playwright');
+const path = require('path');
+const sinon = require('sinon');
+
+const VISUAL_GRACE_PERIOD = 5 * 1000; //Lets the application "simmer" before the snapshot is taken
+
+// Snippet from https://github.com/microsoft/playwright/issues/6347#issuecomment-965887758
+// Will replace with cy.clock() equivalent
+test.beforeEach(async ({ context }) => {
+    await context.addInitScript({
+        path: path.join(__dirname, '../../..', './node_modules/sinon/pkg/sinon.js')
+    });
+    await context.addInitScript(() => {
+        window.__clock = sinon.useFakeTimers({
+            now: 0,
+            shouldAdvanceTime: true
+        }); //Set browser clock to UNIX Epoch
+    });
+});
+
+test('Visual - Default Gauge is correct @addInit', async ({ page }) => {
+
+    await page.addInitScript({ path: path.join(__dirname, '../plugins/gauge', './addInitGauge.js') });
+    //Go to baseURL
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    //Click the Create button
+    await page.click('button:has-text("Create")');
+
+    await page.click('text=Gauge');
+
+    await page.click('text=OK');
+
+    // Take a snapshot of the newly created Gauge object
+    await page.waitForTimeout(VISUAL_GRACE_PERIOD);
+    await percySnapshot(page, 'Default Gauge');
+
+});


### PR DESCRIPTION
Covers #5323 

### Describe your changes:
Adds a visual test for gauges using the addInit method to inject a non-default plugin.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
