### PR TITLE
Lock model

### DIFF
--- a/src/MCT.js
+++ b/src/MCT.js
@@ -96,7 +96,6 @@ define([
         };
 
         this.destroy = this.destroy.bind(this);
-<<<<<<< HEAD
         [
             /**
             * Tracks current selection state of the application.
@@ -197,7 +196,7 @@ define([
              * @memberof module:openmct.MCT#
              * @name telemetry
              */
-            ['telemetry', () => new api.TelemetryAPI(this)],
+            ['telemetry', () => new api.TelemetryAPI.default(this)],
 
             /**
              * An interface for creating new indicators and changing them dynamically.
@@ -258,163 +257,6 @@ define([
                 writable: true
             });
         });
-=======
-        /**
-         * Tracks current selection state of the application.
-         * @private
-         */
-        this.selection = new Selection(this);
-
-        /**
-         * MCT's time conductor, which may be used to synchronize view contents
-         * for telemetry- or time-based views.
-         * @type {module:openmct.TimeConductor}
-         * @memberof module:openmct.MCT#
-         * @name conductor
-         */
-        this.time = new api.TimeAPI(this);
-
-        /**
-         * An interface for interacting with the composition of domain objects.
-         * The composition of a domain object is the list of other domain
-         * objects it "contains" (for instance, that should be displayed
-         * beneath it in the tree.)
-         *
-         * `composition` may be called as a function, in which case it acts
-         * as [`composition.get`]{@link module:openmct.CompositionAPI#get}.
-         *
-         * @type {module:openmct.CompositionAPI}
-         * @memberof module:openmct.MCT#
-         * @name composition
-         */
-        this.composition = new api.CompositionAPI(this);
-
-        /**
-         * Registry for views of domain objects which should appear in the
-         * main viewing area.
-         *
-         * @type {module:openmct.ViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name objectViews
-         */
-        this.objectViews = new ViewRegistry();
-
-        /**
-         * Registry for views which should appear in the Inspector area.
-         * These views will be chosen based on the selection state.
-         *
-         * @type {module:openmct.InspectorViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name inspectorViews
-         */
-        this.inspectorViews = new InspectorViewRegistry();
-
-        /**
-         * Registry for views which should appear in Edit Properties
-         * dialogs, and similar user interface elements used for
-         * modifying domain objects external to its regular views.
-         *
-         * @type {module:openmct.ViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name propertyEditors
-         */
-        this.propertyEditors = new ViewRegistry();
-
-        /**
-         * Registry for views which should appear in the status indicator area.
-         * @type {module:openmct.ViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name indicators
-         */
-        this.indicators = new ViewRegistry();
-
-        /**
-         * Registry for views which should appear in the toolbar area while
-         * editing. These views will be chosen based on the selection state.
-         *
-         * @type {module:openmct.ToolbarRegistry}
-         * @memberof module:openmct.MCT#
-         * @name toolbars
-         */
-        this.toolbars = new ToolbarRegistry();
-
-        /**
-         * Registry for domain object types which may exist within this
-         * instance of Open MCT.
-         *
-         * @type {module:openmct.TypeRegistry}
-         * @memberof module:openmct.MCT#
-         * @name types
-         */
-        this.types = new api.TypeRegistry();
-
-        /**
-         * An interface for interacting with domain objects and the domain
-         * object hierarchy.
-         *
-         * @type {module:openmct.ObjectAPI}
-         * @memberof module:openmct.MCT#
-         * @name objects
-         */
-        this.objects = new api.ObjectAPI.default(this.types, this);
-
-        /**
-         * An interface for retrieving and interpreting telemetry data associated
-         * with a domain object.
-         *
-         * @type {module:openmct.TelemetryAPI}
-         * @memberof module:openmct.MCT#
-         * @name telemetry
-         */
-        this.telemetry = new api.TelemetryAPI.default(this);
-
-        /**
-         * An interface for creating new indicators and changing them dynamically.
-         *
-         * @type {module:openmct.IndicatorAPI}
-         * @memberof module:openmct.MCT#
-         * @name indicators
-         */
-        this.indicators = new api.IndicatorAPI(this);
-
-        /**
-         * MCT's user awareness management, to enable user and
-         * role specific functionality.
-         * @type {module:openmct.UserAPI}
-         * @memberof module:openmct.MCT#
-         * @name user
-         */
-        this.user = new api.UserAPI(this);
-
-        this.notifications = new api.NotificationAPI();
-
-        this.editor = new api.EditorAPI.default(this);
-
-        this.overlays = new OverlayAPI.default();
-
-        this.menus = new api.MenuAPI(this);
-
-        this.actions = new api.ActionsAPI(this);
-
-        this.status = new api.StatusAPI(this);
-
-        this.priority = api.PriorityAPI;
-
-        this.router = new ApplicationRouter(this);
-        this.faults = new api.FaultManagementAPI.default(this);
-        this.forms = new api.FormsAPI.default(this);
-
-        this.branding = BrandingAPI.default;
-
-        /**
-         * MCT's annotation API that enables
-         * human-created comments and categorization linked to data products
-         * @type {module:openmct.AnnotationAPI}
-         * @memberof module:openmct.MCT#
-         * @name annotation
-         */
-        this.annotation = new api.AnnotationAPI(this);
->>>>>>> release/2.0.5
 
         // Plugins that are installed by default
         this.install(this.plugins.Plot());

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -96,161 +96,166 @@ define([
         };
 
         this.destroy = this.destroy.bind(this);
-        /**
-         * Tracks current selection state of the application.
-         * @private
-         */
-        this.selection = new Selection(this);
+        [
+            /**
+            * Tracks current selection state of the application.
+            * @private
+            */
+            ['selection', () => new Selection(this)],
 
-        /**
-         * MCT's time conductor, which may be used to synchronize view contents
-         * for telemetry- or time-based views.
-         * @type {module:openmct.TimeConductor}
-         * @memberof module:openmct.MCT#
-         * @name conductor
-         */
-        this.time = new api.TimeAPI(this);
+            /**
+             * MCT's time conductor, which may be used to synchronize view contents
+             * for telemetry- or time-based views.
+             * @type {module:openmct.TimeConductor}
+             * @memberof module:openmct.MCT#
+             * @name conductor
+             */
+            ['time', () => new api.TimeAPI(this)],
 
-        /**
-         * An interface for interacting with the composition of domain objects.
-         * The composition of a domain object is the list of other domain
-         * objects it "contains" (for instance, that should be displayed
-         * beneath it in the tree.)
-         *
-         * `composition` may be called as a function, in which case it acts
-         * as [`composition.get`]{@link module:openmct.CompositionAPI#get}.
-         *
-         * @type {module:openmct.CompositionAPI}
-         * @memberof module:openmct.MCT#
-         * @name composition
-         */
-        this.composition = new api.CompositionAPI(this);
+            /**
+             * An interface for interacting with the composition of domain objects.
+             * The composition of a domain object is the list of other domain
+             * objects it "contains" (for instance, that should be displayed
+             * beneath it in the tree.)
+             *
+             * `composition` may be called as a function, in which case it acts
+             * as [`composition.get`]{@link module:openmct.CompositionAPI#get}.
+             *
+             * @type {module:openmct.CompositionAPI}
+             * @memberof module:openmct.MCT#
+             * @name composition
+             */
+            ['composition', () => new api.CompositionAPI(this)],
 
-        /**
-         * Registry for views of domain objects which should appear in the
-         * main viewing area.
-         *
-         * @type {module:openmct.ViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name objectViews
-         */
-        this.objectViews = new ViewRegistry();
+            /**
+             * Registry for views of domain objects which should appear in the
+             * main viewing area.
+             *
+             * @type {module:openmct.ViewRegistry}
+             * @memberof module:openmct.MCT#
+             * @name objectViews
+             */
+            ['objectViews', () => new ViewRegistry()],
 
-        /**
-         * Registry for views which should appear in the Inspector area.
-         * These views will be chosen based on the selection state.
-         *
-         * @type {module:openmct.InspectorViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name inspectorViews
-         */
-        this.inspectorViews = new InspectorViewRegistry();
+            /**
+             * Registry for views which should appear in the Inspector area.
+             * These views will be chosen based on the selection state.
+             *
+             * @type {module:openmct.InspectorViewRegistry}
+             * @memberof module:openmct.MCT#
+             * @name inspectorViews
+             */
+            ['inspectorViews', () => new InspectorViewRegistry()],
 
-        /**
-         * Registry for views which should appear in Edit Properties
-         * dialogs, and similar user interface elements used for
-         * modifying domain objects external to its regular views.
-         *
-         * @type {module:openmct.ViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name propertyEditors
-         */
-        this.propertyEditors = new ViewRegistry();
+            /**
+             * Registry for views which should appear in Edit Properties
+             * dialogs, and similar user interface elements used for
+             * modifying domain objects external to its regular views.
+             *
+             * @type {module:openmct.ViewRegistry}
+             * @memberof module:openmct.MCT#
+             * @name propertyEditors
+             */
+            ['propertyEditors', () => new ViewRegistry()],
 
-        /**
-         * Registry for views which should appear in the status indicator area.
-         * @type {module:openmct.ViewRegistry}
-         * @memberof module:openmct.MCT#
-         * @name indicators
-         */
-        this.indicators = new ViewRegistry();
+            /**
+             * Registry for views which should appear in the toolbar area while
+             * editing. These views will be chosen based on the selection state.
+             *
+             * @type {module:openmct.ToolbarRegistry}
+             * @memberof module:openmct.MCT#
+             * @name toolbars
+             */
+            ['toolbars', () => new ToolbarRegistry()],
 
-        /**
-         * Registry for views which should appear in the toolbar area while
-         * editing. These views will be chosen based on the selection state.
-         *
-         * @type {module:openmct.ToolbarRegistry}
-         * @memberof module:openmct.MCT#
-         * @name toolbars
-         */
-        this.toolbars = new ToolbarRegistry();
+            /**
+             * Registry for domain object types which may exist within this
+             * instance of Open MCT.
+             *
+             * @type {module:openmct.TypeRegistry}
+             * @memberof module:openmct.MCT#
+             * @name types
+             */
+            ['types', () => new api.TypeRegistry()],
 
-        /**
-         * Registry for domain object types which may exist within this
-         * instance of Open MCT.
-         *
-         * @type {module:openmct.TypeRegistry}
-         * @memberof module:openmct.MCT#
-         * @name types
-         */
-        this.types = new api.TypeRegistry();
+            /**
+             * An interface for interacting with domain objects and the domain
+             * object hierarchy.
+             *
+             * @type {module:openmct.ObjectAPI}
+             * @memberof module:openmct.MCT#
+             * @name objects
+             */
+            ['objects', () => new api.ObjectAPI.default(this.types, this)],
 
-        /**
-         * An interface for interacting with domain objects and the domain
-         * object hierarchy.
-         *
-         * @type {module:openmct.ObjectAPI}
-         * @memberof module:openmct.MCT#
-         * @name objects
-         */
-        this.objects = new api.ObjectAPI.default(this.types, this);
+            /**
+             * An interface for retrieving and interpreting telemetry data associated
+             * with a domain object.
+             *
+             * @type {module:openmct.TelemetryAPI}
+             * @memberof module:openmct.MCT#
+             * @name telemetry
+             */
+            ['telemetry', () => new api.TelemetryAPI(this)],
 
-        /**
-         * An interface for retrieving and interpreting telemetry data associated
-         * with a domain object.
-         *
-         * @type {module:openmct.TelemetryAPI}
-         * @memberof module:openmct.MCT#
-         * @name telemetry
-         */
-        this.telemetry = new api.TelemetryAPI(this);
+            /**
+             * An interface for creating new indicators and changing them dynamically.
+             *
+             * @type {module:openmct.IndicatorAPI}
+             * @memberof module:openmct.MCT#
+             * @name indicators
+             */
+            ['indicators', () => new api.IndicatorAPI(this)],
 
-        /**
-         * An interface for creating new indicators and changing them dynamically.
-         *
-         * @type {module:openmct.IndicatorAPI}
-         * @memberof module:openmct.MCT#
-         * @name indicators
-         */
-        this.indicators = new api.IndicatorAPI(this);
+            /**
+             * MCT's user awareness management, to enable user and
+             * role specific functionality.
+             * @type {module:openmct.UserAPI}
+             * @memberof module:openmct.MCT#
+             * @name user
+             */
+            ['user', () => new api.UserAPI(this)],
 
-        /**
-         * MCT's user awareness management, to enable user and
-         * role specific functionality.
-         * @type {module:openmct.UserAPI}
-         * @memberof module:openmct.MCT#
-         * @name user
-         */
-        this.user = new api.UserAPI(this);
+            ['notifications', () => new api.NotificationAPI()],
 
-        this.notifications = new api.NotificationAPI();
+            ['editor', () => new api.EditorAPI.default(this)],
 
-        this.editor = new api.EditorAPI.default(this);
+            ['overlays', () => new OverlayAPI.default()],
 
-        this.overlays = new OverlayAPI.default();
+            ['menus', () => new api.MenuAPI(this)],
 
-        this.menus = new api.MenuAPI(this);
+            ['actions', () => new api.ActionsAPI(this)],
 
-        this.actions = new api.ActionsAPI(this);
+            ['status', () => new api.StatusAPI(this)],
 
-        this.status = new api.StatusAPI(this);
+            ['priority', () => api.PriorityAPI],
 
-        this.priority = api.PriorityAPI;
+            ['router', () => new ApplicationRouter(this)],
 
-        this.router = new ApplicationRouter(this);
-        this.faults = new api.FaultManagementAPI.default(this);
-        this.forms = new api.FormsAPI.default(this);
+            ['faults', () => new api.FaultManagementAPI.default(this)],
 
-        this.branding = BrandingAPI.default;
+            ['forms', () => new api.FormsAPI.default(this)],
 
-        /**
-         * MCT's annotation API that enables
-         * human-created comments and categorization linked to data products
-         * @type {module:openmct.AnnotationAPI}
-         * @memberof module:openmct.MCT#
-         * @name annotation
-         */
-        this.annotation = new api.AnnotationAPI(this);
+            ['branding', () => BrandingAPI.default],
+
+            /**
+             * MCT's annotation API that enables
+             * human-created comments and categorization linked to data products
+             * @type {module:openmct.AnnotationAPI}
+             * @memberof module:openmct.MCT#
+             * @name annotation
+             */
+            ['annotation', () => new api.AnnotationAPI(this)]
+        ].forEach(apiEntry => {
+            const apiName = apiEntry[0];
+            const apiObject = apiEntry[1]();
+
+            Object.defineProperty(this, apiName, {
+                value: apiObject,
+                enumerable: false,
+                configurable: false
+            });
+        });
 
         // Plugins that are installed by default
         this.install(this.plugins.Plot());

--- a/src/MCT.js
+++ b/src/MCT.js
@@ -253,7 +253,8 @@ define([
             Object.defineProperty(this, apiName, {
                 value: apiObject,
                 enumerable: false,
-                configurable: false
+                configurable: false,
+                writable: true
             });
         });
 

--- a/src/plugins/plot/configuration/Model.js
+++ b/src/plugins/plot/configuration/Model.js
@@ -34,6 +34,12 @@ export default class Model extends EventEmitter {
      */
     constructor(options) {
         super();
+        Object.defineProperty(this, '_events', {
+            value: this._events,
+            enumerable: false,
+            configurable: false,
+            writable: true
+        });
 
         //need to do this as we're already extending EventEmitter
         eventHelpers.extend(this);


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes VIPEROMCT-89

### Describe your changes:
Defines the `openmct` object in such a way that its properties will not be reactified by Vue if the `openmct` object itself is assigned to a reactive property on a Vue model accidentally. Note that this does not entirely prevent specific APIs or their products (eg telemetry) from being reactified if they are separately assigned to a reactive property.

Also introduces a small change to the `Model` class used in the Plots code to prevent some of the inner workings of EventEmitters becoming reactified. Together, these two fixes prevent a recursion event with Vue reactivity that was causing the UI to freeze when viewing numerical telemetry from a map layer.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
