### PR TITLE
Fix couchdb no response

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -233,7 +233,11 @@ export default class ObjectAPI {
 
             delete this.cache[keystring];
 
-            result = this.applyGetInterceptors(identifier);
+            if (!result) {
+                //no result means resource either doesn't exist or is missing
+                //otherwise it's an error, and we shouldn't apply interceptors
+                result = this.applyGetInterceptors(identifier);
+            }
 
             return result;
         });

--- a/src/plugins/persistence/couch/CouchDocument.js
+++ b/src/plugins/persistence/couch/CouchDocument.js
@@ -45,8 +45,7 @@ export default function CouchDocument(id, model, rev, markDeleted) {
             "category": "domain object",
             "type": model.type,
             "owner": "admin",
-            "name": model.name,
-            "created": Date.now()
+            "name": model.name
         },
         "model": model
     };

--- a/src/plugins/persistence/couch/CouchObjectProvider.js
+++ b/src/plugins/persistence/couch/CouchObjectProvider.js
@@ -215,6 +215,8 @@ class CouchObjectProvider {
             // Network error, CouchDB unreachable.
             if (response === null) {
                 this.indicator.setIndicatorToState(DISCONNECTED);
+                console.error(error.message);
+                throw new Error(`CouchDB Error - No response"`);
             }
 
             console.error(error.message);
@@ -377,15 +379,7 @@ class CouchObjectProvider {
         };
 
         return this.request(ALL_DOCS, 'POST', query, signal).then((response) => {
-            if (!response) {
-                //There was no response - no error code, no rows, nothing - this is bad and should not happen
-                // Network error, CouchDB unreachable.
-                if (response === null) {
-                    this.indicator.setIndicatorToState(DISCONNECTED);
-                }
-
-                console.error('Failed to retrieve response: #bulkGet');
-            } else if (response.rows !== undefined) {
+            if (response && response.rows !== undefined) {
                 return response.rows.reduce((map, row) => {
                     //row.doc === null if the document does not exist.
                     //row.doc === undefined if the document is not found.

--- a/src/plugins/persistence/couch/CouchObjectProvider.js
+++ b/src/plugins/persistence/couch/CouchObjectProvider.js
@@ -377,8 +377,18 @@ class CouchObjectProvider {
         };
 
         return this.request(ALL_DOCS, 'POST', query, signal).then((response) => {
-            if (response && response.rows !== undefined) {
+            if (!response) {
+                //There was no response - no error code, no rows, nothing - this is bad and should not happen
+                // Network error, CouchDB unreachable.
+                if (response === null) {
+                    this.indicator.setIndicatorToState(DISCONNECTED);
+                }
+
+                console.error('Failed to retrieve response: #bulkGet');
+            } else if (response.rows !== undefined) {
                 return response.rows.reduce((map, row) => {
+                    //row.doc === null if the document does not exist.
+                    //row.doc === undefined if the document is not found.
                     if (row.doc !== undefined) {
                         map[row.key] = this.#getModel(row.doc);
                     }

--- a/src/plugins/persistence/couch/CouchObjectProvider.js
+++ b/src/plugins/persistence/couch/CouchObjectProvider.js
@@ -647,6 +647,7 @@ class CouchObjectProvider {
             this.objectQueue[key].pending = true;
             const queued = this.objectQueue[key].dequeue();
             let document = new CouchDocument(key, queued.model);
+            document.metadata.created = Date.now();
             this.request(key, "PUT", document).then((response) => {
                 console.log('create check response', key);
                 this.#checkResponse(response, queued.intermediateResponse, key);


### PR DESCRIPTION
Closes #5441 #5472

### Describe your changes:
Handle no response on bulk get requests to couchdb:
* set couchdb status to disconnected 
* skip applying interceptors.

Also, only set the created date on document creation.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
