### PR TITLE
5439 clicking on a search entry does not navigate to entry in tree release

### DIFF
--- a/src/ui/layout/search/ObjectSearchResult.vue
+++ b/src/ui/layout/search/ObjectSearchResult.vue
@@ -107,7 +107,12 @@ export default {
                 this.preview();
             } else {
                 const objectPath = this.result.originalPath;
-                const resultUrl = objectPathToUrl(this.openmct, objectPath);
+                let resultUrl = objectPathToUrl(this.openmct, objectPath);
+                // get rid of ROOT if extant
+                if (resultUrl.includes('/ROOT')) {
+                    resultUrl = resultUrl.split('/ROOT').join('');
+                }
+
                 this.openmct.router.navigate(resultUrl);
             }
         },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5439 

### Describe your changes:
Getting rid of `ROOT` in the URL makes the URL match what the tree viewer is expecting.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
