### PR TITLE
Last of the post-2.0.6 band-aid removal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,9 +220,8 @@ workflows:
           suite: full
     triggers:
       - schedule:
-          cron: "0 0,4,8,12,16,20 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
                 - master
-                - release/2.0.5


### PR DESCRIPTION
Closes #5437

### Describe your changes:
Some changes were put in specifically for the release/2.0.5 branch. While this particular change wouldn't have any negative affects, it's actually broken because of what was found in https://github.com/nasa/openmct/issues/5370

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
