### PR TITLE
[GHA] PRCop also consider uppercase-X checkboxes to be valid

### DIFF
--- a/.github/workflows/prcop-config.json
+++ b/.github/workflows/prcop-config.json
@@ -3,7 +3,7 @@
     {
       "name": "descriptionRegexp",
       "config": {
-        "regexp": "x] Testing instructions",
+        "regexp": "[x|X]] Testing instructions",
         "errorMessage": ":police_officer: PR Description does not confirm that associated issue(s) contain Testing instructions"
       }
     },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5526 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
A valid checkbox is `[x]` OR `[X]` so update PRCop config to reflect this

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [X] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
