### PR TITLE
Fix time list

### DIFF
--- a/src/plugins/timelist/Timelist.vue
+++ b/src/plugins/timelist/Timelist.vue
@@ -188,7 +188,8 @@ export default {
             if (domainObject.type === 'plan') {
                 this.getPlanDataAndSetConfig({
                     ...this.domainObject,
-                    selectFile: domainObject.selectFile
+                    selectFile: domainObject.selectFile,
+                    sourceMap: domainObject.sourceMap
                 });
             }
         },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/nasa/openmct/issues/5605

### Describe your changes:
Ensures the `sourcemap` gets passed to the `getValidatedData` function. The plan schema changed at some point and the `sourceMap` supports mapping from the new schema to the schema supported by Open MCT.

The absence of the source map was causing `undefined` to be passed into `moment` which for inexplicable reasons is the equivalent of doing `Date.now()`.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
