### PR TITLE
Only index if provider does not support search - mct5690

### DIFF
--- a/e2e/tests/functional/couchdb.e2e.spec.js
+++ b/e2e/tests/functional/couchdb.e2e.spec.js
@@ -26,6 +26,8 @@
 */
 
 const { test, expect } = require('../../baseFixtures');
+const { createDomainObjectWithDefaults } = require('../../appActions');
+const { v4: uuid } = require('uuid');
 
 test.describe("CouchDB Status Indicator @couchdb", () => {
     test.use({ failOnConsoleError: false });
@@ -105,4 +107,38 @@ test.describe("CouchDB initialization @couchdb", () => {
             timeout: 1000
         }).toBeGreaterThanOrEqual(1);
     });
+});
+
+test.describe("Grand Search @couchdb", () => {
+    const searchResultSelector = '.c-gsearch-result__title';
+
+    test('Validate single object in search result', async ({ page }) => {
+        //Go to baseURL
+        await page.goto("./", { waitUntil: "networkidle" });
+
+        // Create a folder object
+        const folderName = uuid();
+        await createDomainObjectWithDefaults(page, {
+            type: 'folder',
+            name: folderName
+        });
+
+        // Full search for object
+        await page.type("input[type=search]", folderName);
+
+        // Wait for search to complete
+        await waitForSearchCompletion(page);
+
+        // Get the search results
+        const searchResults = page.locator(searchResultSelector);
+
+        // Verify that one result is found
+        expect(await searchResults.count()).toBe(1);
+        await expect(searchResults).toHaveText(folderName);
+    });
+
+    async function waitForSearchCompletion(page) {
+        // Wait loading spinner to disappear
+        await page.waitForSelector('.c-tree-and-search__loading', { state: 'detached' });
+    }
 });

--- a/e2e/tests/functional/couchdb.e2e.spec.js
+++ b/e2e/tests/functional/couchdb.e2e.spec.js
@@ -26,8 +26,6 @@
 */
 
 const { test, expect } = require('../../baseFixtures');
-const { createDomainObjectWithDefaults } = require('../../appActions');
-const { v4: uuid } = require('uuid');
 
 test.describe("CouchDB Status Indicator @couchdb", () => {
     test.use({ failOnConsoleError: false });

--- a/e2e/tests/functional/couchdb.e2e.spec.js
+++ b/e2e/tests/functional/couchdb.e2e.spec.js
@@ -108,37 +108,3 @@ test.describe("CouchDB initialization @couchdb", () => {
         }).toBeGreaterThanOrEqual(1);
     });
 });
-
-test.describe("Grand Search @couchdb", () => {
-    const searchResultSelector = '.c-gsearch-result__title';
-
-    test('Validate single object in search result', async ({ page }) => {
-        //Go to baseURL
-        await page.goto("./", { waitUntil: "networkidle" });
-
-        // Create a folder object
-        const folderName = uuid();
-        await createDomainObjectWithDefaults(page, {
-            type: 'folder',
-            name: folderName
-        });
-
-        // Full search for object
-        await page.type("input[type=search]", folderName);
-
-        // Wait for search to complete
-        await waitForSearchCompletion(page);
-
-        // Get the search results
-        const searchResults = page.locator(searchResultSelector);
-
-        // Verify that one result is found
-        expect(await searchResults.count()).toBe(1);
-        await expect(searchResults).toHaveText(folderName);
-    });
-
-    async function waitForSearchCompletion(page) {
-        // Wait loading spinner to disappear
-        await page.waitForSelector('.c-tree-and-search__loading', { state: 'detached' });
-    }
-});

--- a/e2e/tests/functional/search.e2e.spec.js
+++ b/e2e/tests/functional/search.e2e.spec.js
@@ -24,6 +24,8 @@
  */
 
 const { test, expect } = require('../../pluginFixtures');
+const { createDomainObjectWithDefaults } = require('../../appActions');
+const { v4: uuid } = require('uuid');
 
 test.describe('Grand Search', () => {
     test('Can search for objects, and subsequent search dropdown behaves properly', async ({ page, openmctConfig }) => {
@@ -112,13 +114,16 @@ test.describe("Search Tests @unstable", () => {
         await expect(page.locator('text=No matching results.')).toBeVisible();
     });
 
-    test('Validate single object in search result', async ({ page }) => {
+    test('Validate single object in search result @couchdb', async ({ page }) => {
         //Go to baseURL
         await page.goto("./", { waitUntil: "networkidle" });
 
         // Create a folder object
-        const folderName = 'testFolder';
-        await createFolderObject(page, folderName);
+        const folderName = uuid();
+        await createDomainObjectWithDefaults(page, {
+            type: 'folder',
+            name: folderName
+        });
 
         // Full search for object
         await page.type("input[type=search]", folderName);
@@ -127,7 +132,7 @@ test.describe("Search Tests @unstable", () => {
         await waitForSearchCompletion(page);
 
         // Get the search results
-        const searchResults = await page.locator(searchResultSelector);
+        const searchResults = page.locator(searchResultSelector);
 
         // Verify that one result is found
         expect(await searchResults.count()).toBe(1);

--- a/src/api/objects/InMemorySearchProvider.js
+++ b/src/api/objects/InMemorySearchProvider.js
@@ -295,7 +295,11 @@ class InMemorySearchProvider {
         // using structuredClone. Thus we're using JSON.parse/JSON.stringify to discard
         // those functions.
         const nonMutableDomainObject = JSON.parse(JSON.stringify(newDomainObjectToIndex));
-        provider.index(nonMutableDomainObject);
+
+        const objectProvider = this.openmct.objects.getProvider(nonMutableDomainObject.identifier);
+        if (objectProvider === undefined || objectProvider.search === undefined) {
+            provider.index(nonMutableDomainObject);
+        }
     }
 
     onCompositionRemoved(domainObjectToRemoveIdentifier) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5690 

### Describe your changes:
Only index new objects if they don't have a search provider

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
