### PR TITLE
[Flexible Layout] Fix draggable status for layout items while in browse mode

### DIFF
--- a/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
+++ b/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
@@ -39,7 +39,7 @@ test.describe('Testing Flexible Layout @unstable', () => {
             name: "Test Clock"
         });
     });
-    test('flexible layout panes have the appropriate draggable attribute while in Edit and Browse modes', async ({ page }) => {
+    test('panes have the appropriate draggable attribute while in Edit and Browse modes', async ({ page }) => {
         // Create a Flexible Layout
         await createDomainObjectWithDefaults(page, {
             type: 'Flexible Layout',

--- a/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
+++ b/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
@@ -40,7 +40,7 @@ test.describe('Testing Flexible Layout @unstable', () => {
             name: "Test Clock"
         });
     });
-    test('dragging a pane in browse mode does not show drop locations', async ({ page }) => {
+    test('flexible layout panes have the appropriate draggable attribute while in Edit and Browse modes', async ({ page }) => {
         // Create a Flexible Layout
         await createDomainObjectWithDefaults(page, {
             type: 'Flexible Layout',

--- a/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
+++ b/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
@@ -1,0 +1,67 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+const { test, expect } = require('../../../../pluginFixtures');
+const { createDomainObjectWithDefaults, setRealTimeMode } = require('../../../../appActions');
+
+test.describe('Testing Flexible Layout @unstable', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('./', { waitUntil: 'networkidle' });
+        await setRealTimeMode(page);
+
+        // Create Sine Wave Generator
+        await createDomainObjectWithDefaults(page, {
+            type: 'Sine Wave Generator',
+            name: "Test Sine Wave Generator"
+        });
+
+        // Create Clock Object
+        await createDomainObjectWithDefaults(page, {
+            type: 'Clock',
+            name: "Test Clock"
+        });
+    });
+    test('dragging a pane in browse mode does not show drop locations', async ({ page }) => {
+        // Create a Flexible Layout
+        await createDomainObjectWithDefaults(page, {
+            type: 'Flexible Layout',
+            name: "Test Flexible Layout"
+        });
+        // Edit Flexible Layout
+        await page.locator('[title="Edit"]').click();
+
+        // Expand the 'My Items' folder in the left tree
+        await page.locator('.c-tree__item__view-control.c-disclosure-triangle').first().click();
+        // Add the Sine Wave Generator and Clock to the Flexible Layout
+        await page.dragAndDrop('text=Test Sine Wave Generator', '.c-fl__container.is-empty');
+        await page.dragAndDrop('text=Test Clock', '.c-fl__container.is-empty');
+        // Check that panes can be dragged while Flexible Layout is in Edit mode
+        let dragWrapper = await page.locator('.c-fl-container__frames-holder .c-fl-frame__drag-wrapper').first();
+        await expect(dragWrapper).toHaveAttribute('draggable', 'true');
+        // Save Flexible Layout
+        await page.locator('button[title="Save"]').click();
+        await page.locator('text=Save and Finish Editing').click();
+        // Check that panes are not draggable while Flexible Layout is in Browse mode
+        dragWrapper = await page.locator('.c-fl-container__frames-holder .c-fl-frame__drag-wrapper').first();
+        await expect(dragWrapper).toHaveAttribute('draggable', 'false');
+    });
+});

--- a/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
+++ b/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
@@ -21,12 +21,11 @@
  *****************************************************************************/
 
 const { test, expect } = require('../../../../pluginFixtures');
-const { createDomainObjectWithDefaults, setRealTimeMode } = require('../../../../appActions');
+const { createDomainObjectWithDefaults } = require('../../../../appActions');
 
 test.describe('Testing Flexible Layout @unstable', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('./', { waitUntil: 'networkidle' });
-        await setRealTimeMode(page);
 
         // Create Sine Wave Generator
         await createDomainObjectWithDefaults(page, {

--- a/src/plugins/flexibleLayout/components/flexibleLayout.vue
+++ b/src/plugins/flexibleLayout/components/flexibleLayout.vue
@@ -281,6 +281,10 @@ export default {
                 return false;
             }
 
+            if (!this.isEditing) {
+                return false;
+            }
+
             let containerId = event.dataTransfer.getData('containerid');
             let container = this.containers.filter((c) => c.id === containerId)[0];
             let containerPos = this.containers.indexOf(container);

--- a/src/plugins/flexibleLayout/components/frame.vue
+++ b/src/plugins/flexibleLayout/components/frame.vue
@@ -31,7 +31,7 @@
     <div
         ref="frame"
         class="c-frame c-fl-frame__drag-wrapper is-selectable u-inspectable is-moveable"
-        draggable="true"
+        :draggable="draggable"
         @dragstart="initDrag"
     >
         <object-frame
@@ -93,6 +93,9 @@ export default {
     computed: {
         hasFrame() {
             return !this.frame.noFrame;
+        },
+        draggable() {
+            return this.isEditing;
         }
     },
     mounted() {


### PR DESCRIPTION
Closes #5389 

### Describe your changes:
This change set the draggable property on the panes to false when in browse mode to prevent drag and drop while not editing.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [X] Changes address original issue?
* [X] Tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)