### PR TITLE
Revert "#5621 for O4M 4.10 release"

### DIFF
--- a/src/api/indicators/IndicatorAPI.js
+++ b/src/api/indicators/IndicatorAPI.js
@@ -37,8 +37,8 @@ class IndicatorAPI extends EventEmitter {
         return sortedIndicators;
     }
 
-    simpleIndicator(key) {
-        return new SimpleIndicator(this.openmct, key);
+    simpleIndicator() {
+        return new SimpleIndicator(this.openmct);
     }
 
     /**
@@ -63,13 +63,6 @@ class IndicatorAPI extends EventEmitter {
      *
      */
     add(indicator) {
-        const keyExists = indicator.key !== undefined
-            && this.indicatorObjects.some(installedIndicator => indicator.key === installedIndicator.key);
-
-        if (keyExists) {
-            console.warn(`An Indicator with key { ${indicator.key} } has already been installed.`);
-        }
-
         if (!indicator.priority) {
             indicator.priority = this.openmct.priority.DEFAULT;
         }
@@ -79,22 +72,6 @@ class IndicatorAPI extends EventEmitter {
         this.emit('addIndicator', indicator);
     }
 
-    /**
-     * @param {string} key the key of the indicator
-     * @param {number} priority the priority to set
-     */
-    setPriority(key, priority) {
-        const indicatorToPrioritize = this.indicatorObjects
-            .find(indicator => indicator.key === key);
-
-        if (indicatorToPrioritize !== undefined) {
-            indicatorToPrioritize.priority = priority;
-
-            this.emit('setPriority', indicatorToPrioritize);
-        } else {
-            console.warn(`Could not find an installed indicator: ${key}`);
-        }
-    }
 }
 
 export default IndicatorAPI;

--- a/src/api/indicators/IndicatorAPISpec.js
+++ b/src/api/indicators/IndicatorAPISpec.js
@@ -22,8 +22,6 @@
 import { createOpenMct, resetApplicationState } from '../../utils/testing';
 import SimpleIndicator from './SimpleIndicator';
 
-const NOTIFICATIONS_INDICATOR_KEY = 'notifications-indicator';
-
 describe("The Indicator API", () => {
     let openmct;
 
@@ -41,7 +39,6 @@ describe("The Indicator API", () => {
         const textNode = document.createTextNode(label);
         element.appendChild(textNode);
         const testIndicator = {
-            key: className,
             element,
             priority
         };
@@ -49,22 +46,12 @@ describe("The Indicator API", () => {
         return testIndicator;
     }
 
-    it("installs the notifications indicator by default", () => {
-        let indicators = openmct.indicators.getIndicatorObjectsByPriority();
-        const notificationIndicator = indicators.find(indicator => indicator.key === NOTIFICATIONS_INDICATOR_KEY);
-
-        expect(notificationIndicator.key).toEqual(NOTIFICATIONS_INDICATOR_KEY);
-    });
-
     it("can register an indicator", () => {
-        let indicators = openmct.indicators.getIndicatorObjectsByPriority();
-        const defaultIndicatorsLength = indicators.length;
         const testIndicator = generateIndicator('test-indicator', 'This is a test indicator', 2);
-
         openmct.indicators.add(testIndicator);
-        indicators = openmct.indicators.getIndicatorObjectsByPriority();
-
-        expect(indicators.length).toBe(defaultIndicatorsLength + 1);
+        expect(openmct.indicators.indicatorObjects).toBeDefined();
+        // notifier indicator is installed by default
+        expect(openmct.indicators.indicatorObjects.length).toBe(2);
     });
 
     it("can order indicators based on priority", () => {
@@ -80,32 +67,10 @@ describe("The Indicator API", () => {
         const testIndicator4 = generateIndicator('test-indicator-4', 'This is yet another test indicator', openmct.priority.HIGH);
         openmct.indicators.add(testIndicator4);
 
-        let indicators = openmct.indicators.getIndicatorObjectsByPriority();
-
-        expect(indicators.length).toBe(5);
-        expect(indicators[2].priority).toBe(openmct.priority.DEFAULT);
-    });
-
-    it("can change priority of an installed indicator", () => {
-        const testIndicator1 = generateIndicator('test-indicator-1', 'This is a test indicator', openmct.priority.LOW);
-        openmct.indicators.add(testIndicator1);
-
-        const testIndicator2 = generateIndicator('test-indicator-2', 'This is another test indicator', openmct.priority.DEFAULT);
-        openmct.indicators.add(testIndicator2);
-
-        const testIndicator3 = generateIndicator('test-indicator-3', 'This is yet another test indicator', openmct.priority.LOW);
-        openmct.indicators.add(testIndicator3);
-
-        const testIndicator4 = generateIndicator('test-indicator-4', 'This is yet another test indicator', openmct.priority.HIGH);
-        openmct.indicators.add(testIndicator4);
-
-        let indicators = openmct.indicators.getIndicatorObjectsByPriority();
-
-        expect(indicators[0].key).toEqual('test-indicator-4');
-        openmct.indicators.setPriority('test-indicator-2', openmct.priority.HIGH + 1);
-        indicators = openmct.indicators.getIndicatorObjectsByPriority();
-
-        expect(indicators[0].key).toEqual('test-indicator-2');
+        expect(openmct.indicators.indicatorObjects.length).toBe(5);
+        const indicatorObjectsByPriority = openmct.indicators.getIndicatorObjectsByPriority();
+        expect(indicatorObjectsByPriority.length).toBe(5);
+        expect(indicatorObjectsByPriority[2].priority).toBe(openmct.priority.DEFAULT);
     });
 
     it("the simple indicator can be added", () => {

--- a/src/api/indicators/SimpleIndicator.js
+++ b/src/api/indicators/SimpleIndicator.js
@@ -27,11 +27,10 @@ import { convertTemplateToHTML } from '@/utils/template/templateHelpers';
 const DEFAULT_ICON_CLASS = 'icon-info';
 
 class SimpleIndicator extends EventEmitter {
-    constructor(openmct, key) {
+    constructor(openmct) {
         super();
 
         this.openmct = openmct;
-        this.key = key;
         this.element = convertTemplateToHTML(indicatorTemplate)[0];
         this.priority = openmct.priority.DEFAULT;
 

--- a/src/plugins/URLIndicatorPlugin/URLIndicatorPlugin.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicatorPlugin.js
@@ -23,7 +23,7 @@ define(['./URLIndicator'],
     function URLIndicatorPlugin(URLIndicator) {
         return function (opts) {
             return function install(openmct) {
-                const simpleIndicator = openmct.indicators.simpleIndicator('url-indicator');
+                const simpleIndicator = openmct.indicators.simpleIndicator();
                 const urlIndicator = new URLIndicator(opts, simpleIndicator);
 
                 openmct.indicators.add(simpleIndicator);

--- a/src/plugins/operatorStatus/operatorStatus/OperatorStatusIndicator.js
+++ b/src/plugins/operatorStatus/operatorStatus/OperatorStatusIndicator.js
@@ -49,7 +49,7 @@ export default class OperatorStatusIndicator extends AbstractStatusIndicator {
     }
 
     createIndicator() {
-        const operatorIndicator = this.openmct.indicators.simpleIndicator('operator-indicator');
+        const operatorIndicator = this.openmct.indicators.simpleIndicator();
 
         operatorIndicator.text("My Operator Status");
         operatorIndicator.description("Set my operator status");

--- a/src/plugins/operatorStatus/pollQuestion/PollQuestionIndicator.js
+++ b/src/plugins/operatorStatus/pollQuestion/PollQuestionIndicator.js
@@ -49,7 +49,7 @@ export default class PollQuestionIndicator extends AbstractStatusIndicator {
     }
 
     createIndicator() {
-        const pollQuestionIndicator = this.openmct.indicators.simpleIndicator('poll-question-indicator');
+        const pollQuestionIndicator = this.openmct.indicators.simpleIndicator();
 
         pollQuestionIndicator.text("Poll Question");
         pollQuestionIndicator.description("Set the current poll question");

--- a/src/plugins/performanceIndicator/plugin.js
+++ b/src/plugins/performanceIndicator/plugin.js
@@ -23,7 +23,7 @@ export default function PerformanceIndicator() {
     return function install(openmct) {
         let frames = 0;
         let lastCalculated = performance.now();
-        const indicator = openmct.indicators.simpleIndicator('performance-indicator');
+        const indicator = openmct.indicators.simpleIndicator();
 
         indicator.text('~ fps');
         indicator.statusClass('s-status-info');

--- a/src/plugins/persistence/couch/plugin.js
+++ b/src/plugins/persistence/couch/plugin.js
@@ -30,7 +30,7 @@ const COUCH_SEARCH_ONLY_NAMESPACE = `COUCH_SEARCH_${Date.now()}`;
 
 export default function CouchPlugin(options) {
     return function install(openmct) {
-        const simpleIndicator = openmct.indicators.simpleIndicator('couch-indicator');
+        const simpleIndicator = openmct.indicators.simpleIndicator();
         openmct.indicators.add(simpleIndicator);
         const couchStatusIndicator = new CouchStatusIndicator(simpleIndicator);
         install.couchProvider = new CouchObjectProvider(openmct, options, NAMESPACE, couchStatusIndicator);


### PR DESCRIPTION
Reverts nasa/openmct#5729

### Describe your changes:
Saving the yKey to each series of the plot

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [X] Changes address original issue?
* [X] Tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
