### PR TITLE
[Plot] Set yKey on each plot series

### DIFF
--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -1098,7 +1098,9 @@ export default {
         },
 
         setYAxisKey(yKey) {
-            this.config.series.models[0].set('yKey', yKey);
+            this.config.series.models.forEach((model) => {
+                model.set('yKey', yKey);
+            });
         },
 
         pause() {

--- a/src/plugins/plot/pluginSpec.js
+++ b/src/plugins/plot/pluginSpec.js
@@ -410,6 +410,20 @@ describe("the plugin", function () {
             expect(options[1].value).toBe("Another attribute");
         });
 
+        it("Updates the Y-axis label when changed", () => {
+            const configId = openmct.objects.makeKeyString(testTelemetryObject.identifier);
+            const config = configStore.get(configId);
+            const yAxisElement = element.querySelectorAll(".gl-plot-axis-area.gl-plot-y")[0].__vue__;
+            config.yAxis.seriesCollection.models.forEach((plotSeries) => {
+                expect(plotSeries.model.yKey).toBe('some-key');
+            });
+            yAxisElement.$emit('yKeyChanged', 'test-key');
+            config.yAxis.seriesCollection.models.forEach((plotSeries) => {
+                console.log(plotSeries.model.yKey);
+                expect(plotSeries.model.yKey).toBe('test-key');
+            });
+        });
+
         it('hides the pause and play controls', () => {
             let pauseEl = element.querySelectorAll(".c-button-set .icon-pause");
             let playEl = element.querySelectorAll(".c-button-set .icon-arrow-right");


### PR DESCRIPTION
Closes #5785 

### Describe your changes:
Saving the yKey to each series of the plot

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [X] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate unit tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
