### PR TITLE
Have webpack-dev-server write webpack assets to disk

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -46,8 +46,8 @@ module.exports = merge(common, {
         },
         watchFiles: ['**/*.css'],
         static: {
-            directory: path.join(__dirname, '/dist/'),
-            publicPath: '/dist/',
+            directory: path.join(__dirname, '/dist'),
+            publicPath: '/dist',
             watch: false
         },
         client: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -36,9 +36,19 @@ module.exports = merge(common, {
     ],
     devtool: 'eval-source-map',
     devServer: {
+        devMiddleware: {
+            writeToDisk: (filePathString) => {
+                const filePath = path.parse(filePathString);
+                const shouldWrite = !(filePath.base.includes('hot-update'));
+
+                return shouldWrite;
+            }
+        },
+        watchFiles: ['**/*.css'],
         static: {
             directory: path.join(__dirname, '/dist/'),
-            publicPath: '/dist'
+            publicPath: '/dist/',
+            watch: false
         },
         client: {
             progress: true,


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5832 

### Describe your changes:
Have the `webpack-dev-server` write to disk the external assets we're using, including CSS files.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
