### PR TITLE
Keep transaction open on failed editor save

### DIFF
--- a/src/api/Editor.js
+++ b/src/api/Editor.js
@@ -63,10 +63,9 @@ export default class Editor extends EventEmitter {
             .then(() => {
                 this.editing = false;
                 this.emit('isEditing', false);
+                this.openmct.objects.endTransaction();
             }).catch(error => {
                 throw error;
-            }).finally(() => {
-                this.openmct.objects.endTransaction();
             });
     }
 

--- a/src/api/EditorSpec.js
+++ b/src/api/EditorSpec.js
@@ -1,0 +1,80 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2022, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import {
+    createOpenMct, resetApplicationState
+} from '../utils/testing';
+
+describe('The Editor API', () => {
+    let openmct;
+
+    beforeEach((done) => {
+        openmct = createOpenMct();
+        openmct.on('start', done);
+
+        spyOn(openmct.objects, 'endTransaction');
+
+        openmct.startHeadless();
+    });
+
+    afterEach(() => {
+        return resetApplicationState(openmct);
+    });
+
+    it('opens a transaction on edit', () => {
+        expect(
+            openmct.objects.isTransactionActive()
+        ).toBeFalse();
+        openmct.editor.edit();
+        expect(
+            openmct.objects.isTransactionActive()
+        ).toBeTrue();
+    });
+
+    it('closes an open transaction on successful save', async () => {
+        spyOn(openmct.objects, 'getActiveTransaction')
+            .and.returnValue({
+                commit: () => Promise.resolve(true)
+            });
+
+        openmct.editor.edit();
+        await openmct.editor.save();
+
+        expect(
+            openmct.objects.endTransaction
+        ).toHaveBeenCalled();
+    });
+
+    it('does not close an open transaction on failed save', async () => {
+        spyOn(openmct.objects, 'getActiveTransaction')
+            .and.returnValue({
+                commit: () => Promise.reject()
+            });
+
+        openmct.editor.edit();
+        await openmct.editor.save().catch(() => {console.log('here');});
+
+        expect(
+            openmct.objects.endTransaction
+        ).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5802

### Describe your changes:
Moved ending transaction out of the `finally` block and into the successful `then` block of editor save.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
