### PR TITLE
[CouchDB] Re-establish feed connection if EventSource is closed due to error

### DIFF
--- a/src/plugins/persistence/couch/CouchChangesFeed.js
+++ b/src/plugins/persistence/couch/CouchChangesFeed.js
@@ -3,6 +3,7 @@
     let connected = false;
     let couchEventSource;
     let changesFeedUrl;
+    const keepAliveTime = 20 * 1000;
     let keepAliveTimer;
     const controller = new AbortController();
 
@@ -71,7 +72,11 @@
             clearTimeout(keepAliveTimer);
         }
 
-        keepAliveTimer = setTimeout(self.listenForChanges, 20 * 1000);
+        /**
+         * Once the connection has been opened, poll every 20 seconds to see if the EventSource has closed unexpectedly.
+         * If it has, attempt to reconnect.
+         */
+        keepAliveTimer = setTimeout(self.listenForChanges, keepAliveTime);
 
         if (!couchEventSource || couchEventSource.readyState === EventSource.CLOSED) {
             console.debug('⇿ Opening CouchDB change feed connection ⇿');

--- a/src/plugins/persistence/couch/CouchChangesFeed.js
+++ b/src/plugins/persistence/couch/CouchChangesFeed.js
@@ -2,6 +2,7 @@
     const connections = [];
     let connected = false;
     let couchEventSource;
+    let changesFeedUrl;
     const controller = new AbortController();
 
     self.onconnect = function (e) {
@@ -35,7 +36,8 @@
                     return;
                 }
 
-                self.listenForChanges(event.data.url);
+                changesFeedUrl = event.data.url;
+                self.listenForChanges(changesFeedUrl);
             }
         };
 
@@ -45,6 +47,11 @@
     self.onerror = function (error) {
         self.updateCouchStateIndicator();
         console.error('🚨 Error on CouchDB feed 🚨', error);
+
+        if (error.target.readyState === EventSource.CLOSED) {
+            connected = false;
+            self.listenForChanges(changesFeedUrl);
+        }
     };
 
     self.onopen = function () {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5406 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
In certain scenarios (such as receiving a 4xx or 5xx HTTP response code), the Couch changes feed `EventSource` can become closed. This means that the status indicator will no longer receive live updates, since the `EventSource` cannot receive messages from couch, and is not actively trying to reconnect.

This PR adds a keep-alive timer which will attempt to reconnect to the most recently used `changesFeedUrl` if the `EventSource` has become closed for whatever reason.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
