### PR TITLE
Fix couchdb no response part deux

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -240,7 +240,11 @@ export default class ObjectAPI {
 
             delete this.cache[keystring];
 
-            result = this.applyGetInterceptors(identifier);
+            if (!result) {
+                //no result means resource either doesn't exist or is missing
+                //otherwise it's an error, and we shouldn't apply interceptors
+                result = this.applyGetInterceptors(identifier);
+            }
 
             return result;
         });


### PR DESCRIPTION
Closes #5441

### Describe your changes:

Adds back deleted code originally fixed in #5474

Handle no response on bulk get requests to couchdb:
* set couchdb status to disconnected 
* skip applying interceptors.

Also, only set the created date on document creation.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Unit tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate unit tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Commit messages meet standards?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
