### PR TITLE
[CLA Approved] test: add e2e test for tracking time conductor history in fixed mode

### DIFF
--- a/e2e/tests/functional/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/functional/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -148,9 +148,39 @@ test.describe('Time conductor input fields real-time mode', () => {
         expect(page.url()).toContain(`endDelta=${endDelta}`);
     });
 
-    test.fixme('time conductor history in fixed time mode will track changing start and end times', async ({ page }) => {
-        // change start time, verify it's tracked in history
-        // change end time, verify it's tracked in history
+    test('time conductor history in fixed time mode will track changing start and end times', async ({ page }) => {
+        // Navigate to Open MCT in Fixed Time Mode, UTC Time System
+        await page.goto('./#/browse/mine?view=grid&tc.mode=fixed&tc.timeSystem=utc', { waitUntil: 'networkidle' });
+
+        // Change start time
+        const year = new Date().getFullYear();
+
+        let startDate = 'xxxx-01-01 01:00:00.000Z';
+        startDate = year + startDate.substring(4);
+
+        const startTimeLocator = page.locator(`input[type='text']`).first();
+
+        await startTimeLocator.click();
+        await startTimeLocator.fill(startDate.toString());
+
+        // Verify that the start time is tracked in time conductor history
+        const historyLocator = page.locator(`[aria-label='Time Conductor History']`);
+        await historyLocator.click();
+
+        let lastTimeframe = page.locator(`[class='icon-history']`).first();
+        await expect(lastTimeframe).toContainText(`${year}-01-01 01:00:00`);
+
+        // Change end time
+        let endDate = 'xxxx-01-02 01:00:00.000Z';
+        endDate = year + endDate.substring(4);
+
+        const endTimeLocator = page.locator(`input[type='text']`).nth(1);
+        await endTimeLocator.click();
+        await endTimeLocator.fill(endDate.toString());
+
+        // Verify that the end time is tracked in time conductor history
+        await historyLocator.click();
+        await expect(lastTimeframe).toHaveAttribute('title', `${year}-01-01 01:00:00.000 - ${year}-01-02 01:00:00.000`);
     });
 
     test.fixme('time conductor history in realtime mode will track changing start and end times', async ({ page }) => {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5905

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

E2E tests were added for tracking time conductor history in fixed mode. The test updates the start and end times and checks that the time conductor history is also updated.

NB: I am seeing a bug with the feature being tested. When the end time is updated, the history does not always update. The error happens more than half of the times I have tested it. 

### Testing
To test the changes, run `npm run test:e2e:local -- timeConductor`.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
