### PR TITLE
Bugfix/issue 5657

### DIFF
--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -443,7 +443,7 @@ export default class PlotSeries extends Model {
      * @private
      */
     isValueInvalid(val) {
-        return Number.isNaN(val) || val === undefined || val === Infinity;
+        return Number.isNaN(val) || [undefined, Infinity, -Infinity].includes(val);
     }
 
     /**

--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -439,7 +439,7 @@ export default class PlotSeries extends Model {
      * @private
      */
     isValueInvalid(val) {
-        return Number.isNaN(val) || val === undefined;
+        return Number.isNaN(val) || val === undefined || val === Infinity;
     }
 
     /**

--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -83,6 +83,8 @@ export default class PlotSeries extends Model {
         // Model.apply(this, arguments);
         this.onXKeyChange(this.get('xKey'));
         this.onYKeyChange(this.get('yKey'));
+
+        this.unPlottableValues = [undefined, Infinity, -Infinity];
     }
 
     /**
@@ -443,7 +445,7 @@ export default class PlotSeries extends Model {
      * @private
      */
     isValueInvalid(val) {
-        return Number.isNaN(val) || [undefined, Infinity, -Infinity].includes(val);
+        return Number.isNaN(val) || this.unPlottableValues.includes(val);
     }
 
     /**

--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -361,7 +361,11 @@ export default class PlotSeries extends Model {
         const value = this.getYVal(point);
         let stats = this.get('stats');
         let changed = false;
-        if (!stats && ![Infinity, -Infinity].includes(value)) {
+        if (!stats) {
+            if ([Infinity, -Infinity].includes(value)) {
+                return;
+            }
+
             stats = {
                 minValue: value,
                 minPoint: point,

--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -361,7 +361,7 @@ export default class PlotSeries extends Model {
         const value = this.getYVal(point);
         let stats = this.get('stats');
         let changed = false;
-        if (!stats) {
+        if (!stats && ![Infinity, -Infinity].includes(value)) {
             stats = {
                 minValue: value,
                 minPoint: point,
@@ -370,13 +370,13 @@ export default class PlotSeries extends Model {
             };
             changed = true;
         } else {
-            if (stats.maxValue < value) {
+            if (stats.maxValue < value && value !== Infinity) {
                 stats.maxValue = value;
                 stats.maxPoint = point;
                 changed = true;
             }
 
-            if (stats.minValue > value) {
+            if (stats.minValue > value && value !== -Infinity) {
                 stats.minValue = value;
                 stats.minPoint = point;
                 changed = true;

--- a/src/plugins/plot/configuration/YAxisModel.js
+++ b/src/plugins/plot/configuration/YAxisModel.js
@@ -106,7 +106,6 @@ export default class YAxisModel extends Model {
         }
     }
     updateStats(seriesStats) {
-        console.log(seriesStats.maxValue);
         if (!this.has('stats')) {
             this.set('stats', {
                 min: seriesStats.minValue,
@@ -139,7 +138,6 @@ export default class YAxisModel extends Model {
         this.unset('stats');
         this.seriesCollection.forEach(series => {
             if (series.has('stats')) {
-                debugger;
                 this.updateStats(series.get('stats'));
             }
         });

--- a/src/plugins/plot/configuration/YAxisModel.js
+++ b/src/plugins/plot/configuration/YAxisModel.js
@@ -107,6 +107,10 @@ export default class YAxisModel extends Model {
     }
     updateStats(seriesStats) {
         if (!this.has('stats')) {
+            if (seriesStats.maxValue === Infinity) {
+                seriesStats.maxValue = null;
+            }
+
             this.set('stats', {
                 min: seriesStats.minValue,
                 max: seriesStats.maxValue
@@ -122,7 +126,7 @@ export default class YAxisModel extends Model {
             stats.min = seriesStats.minValue;
         }
 
-        if (stats.max < seriesStats.maxValue) {
+        if (seriesStats.maxValue !== Infinity && stats.max < seriesStats.maxValue) {
             changed = true;
             stats.max = seriesStats.maxValue;
         }

--- a/src/plugins/plot/configuration/YAxisModel.js
+++ b/src/plugins/plot/configuration/YAxisModel.js
@@ -106,11 +106,8 @@ export default class YAxisModel extends Model {
         }
     }
     updateStats(seriesStats) {
+        console.log(seriesStats.maxValue);
         if (!this.has('stats')) {
-            if (seriesStats.maxValue === Infinity) {
-                seriesStats.maxValue = null;
-            }
-
             this.set('stats', {
                 min: seriesStats.minValue,
                 max: seriesStats.maxValue
@@ -126,7 +123,7 @@ export default class YAxisModel extends Model {
             stats.min = seriesStats.minValue;
         }
 
-        if (seriesStats.maxValue !== Infinity && stats.max < seriesStats.maxValue) {
+        if (stats.max < seriesStats.maxValue) {
             changed = true;
             stats.max = seriesStats.maxValue;
         }
@@ -142,6 +139,7 @@ export default class YAxisModel extends Model {
         this.unset('stats');
         this.seriesCollection.forEach(series => {
             if (series.has('stats')) {
+                debugger;
                 this.updateStats(series.get('stats'));
             }
         });


### PR DESCRIPTION
Closes #5657 

### Describe your changes:
This change allows plots to ignore +Infinity and -Infinity when setting min/max values for y-axis autoscaling.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [X] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
