### PR TITLE
Fix persistence timestamp

### DIFF
--- a/src/api/objects/MutableDomainObject.js
+++ b/src/api/objects/MutableDomainObject.js
@@ -75,11 +75,7 @@ class MutableDomainObject {
         return eventOff;
     }
     $set(path, value) {
-        _.set(this, path, value);
-
-        if (path !== 'persisted' && path !== 'modified') {
-            _.set(this, 'modified', Date.now());
-        }
+        MutableDomainObject.mutateObject(this, path, value);
 
         //Emit secret synchronization event first, so that all objects are in sync before subsequent events fired.
         this._globalEventEmitter.emit(qualifiedEventName(this, '$_synchronize_model'), this);
@@ -136,8 +132,11 @@ class MutableDomainObject {
     }
 
     static mutateObject(object, path, value) {
+        if (path !== 'persisted') {
+            _.set(object, 'modified', Date.now());
+        }
+
         _.set(object, path, value);
-        _.set(object, 'modified', Date.now());
     }
 }
 

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -363,7 +363,6 @@ export default class ObjectAPI {
         } else if (this.#hasAlreadyBeenPersisted(domainObject)) {
             result = Promise.resolve(true);
         } else {
-            const persistedTime = Date.now();
             const username = await this.#getCurrentUsername();
             const isNewObject = domainObject.persisted === undefined;
             let savedResolve;
@@ -375,15 +374,20 @@ export default class ObjectAPI {
                 savedReject = reject;
             });
 
-            this.#mutate(domainObject, 'persisted', persistedTime);
             this.#mutate(domainObject, 'modifiedBy', username);
 
             if (isNewObject) {
+                const persistedTime = Date.now();
+
+                this.#mutate(domainObject, 'persisted', persistedTime);
                 this.#mutate(domainObject, 'created', persistedTime);
                 this.#mutate(domainObject, 'createdBy', username);
 
                 savedObjectPromise = provider.create(domainObject);
             } else {
+                const persistedTime = Date.now();
+                this.#mutate(domainObject, 'persisted', persistedTime);
+
                 savedObjectPromise = provider.update(domainObject);
             }
 

--- a/src/api/objects/ObjectAPISpec.js
+++ b/src/api/objects/ObjectAPISpec.js
@@ -94,6 +94,35 @@ describe("The Object API", () => {
                 expect(mockProvider.create).not.toHaveBeenCalled();
                 expect(mockProvider.update).toHaveBeenCalled();
             });
+            describe("the persisted timestamp for existing objects", () => {
+                let persistedTimestamp;
+                beforeEach(() => {
+                    persistedTimestamp = Date.now() - FIFTEEN_MINUTES;
+                    mockDomainObject.persisted = persistedTimestamp;
+                    mockDomainObject.modified = Date.now();
+                });
+
+                it("is updated", async () => {
+                    await objectAPI.save(mockDomainObject);
+                    expect(mockDomainObject.persisted).toBeDefined();
+                    expect(mockDomainObject.persisted > persistedTimestamp).toBe(true);
+                });
+                it("is >= modified timestamp", async () => {
+                    await objectAPI.save(mockDomainObject);
+                    expect(mockDomainObject.persisted >= mockDomainObject.modified).toBe(true);
+                });
+            });
+            describe("the persisted timestamp for new objects", () => {
+                it("is updated", async () => {
+                    await objectAPI.save(mockDomainObject);
+                    expect(mockDomainObject.persisted).toBeDefined();
+                });
+                it("is >= modified timestamp", async () => {
+                    await objectAPI.save(mockDomainObject);
+                    expect(mockDomainObject.persisted >= mockDomainObject.modified).toBe(true);
+                });
+            });
+
             it("Sets the current user for 'createdBy' on new objects", async () => {
                 await objectAPI.save(mockDomainObject);
                 expect(mockDomainObject.createdBy).toBe(USERNAME);

--- a/src/plugins/notebook/components/Notebook.vue
+++ b/src/plugins/notebook/components/Notebook.vue
@@ -895,19 +895,17 @@ export default {
             }
         },
         saveTransaction() {
-            if (this.transaction === undefined) {
-                return;
+            if (this.transaction !== undefined) {
+                this.transaction.commit()
+                    .catch(error => {
+                        throw error;
+                    }).finally(() => {
+                        this.openmct.objects.endTransaction();
+                    });
             }
-
-            return this.transaction.commit()
-                .catch(error => {
-                    throw error;
-                }).finally(() => {
-                    this.openmct.objects.endTransaction();
-                });
         },
         cancelTransaction() {
-            if (this.transaction) {
+            if (this.transaction !== undefined) {
                 this.transaction.cancel()
                     .catch(error => {
                         throw error;

--- a/src/plugins/notebook/components/Notebook.vue
+++ b/src/plugins/notebook/components/Notebook.vue
@@ -889,22 +889,17 @@ export default {
             this.syncUrlWithPageAndSection();
             this.filterAndSortEntries();
         },
-        activeTransaction() {
-            return this.openmct.objects.getActiveTransaction();
-        },
         startTransaction() {
-            if (!this.openmct.editor.isEditing()) {
-                this.openmct.objects.startTransaction();
+            if (!this.openmct.objects.isTransactionActive()) {
+                this.transaction = this.openmct.objects.startTransaction();
             }
         },
         saveTransaction() {
-            const transaction = this.activeTransaction();
-
-            if (!transaction || this.openmct.editor.isEditing()) {
+            if (this.transaction === undefined) {
                 return;
             }
 
-            return transaction.commit()
+            return this.transaction.commit()
                 .catch(error => {
                     throw error;
                 }).finally(() => {
@@ -912,9 +907,8 @@ export default {
                 });
         },
         cancelTransaction() {
-            if (!this.openmct.editor.isEditing()) {
-                const transaction = this.activeTransaction();
-                transaction.cancel()
+            if (this.transaction) {
+                this.transaction.cancel()
                     .catch(error => {
                         throw error;
                     }).finally(() => {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/nasa/openmct/issues/5919

### Describe your changes:
Changes when the persisted timestamp is evaluated to avoid issues with timing ambiguity. The persisted timestamp is now always calculated _after_ the last modification.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
