### PR TITLE
Add e2e files to npm publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,3 +22,9 @@
 !index.html
 !openmct.js
 !SECURITY.md
+
+# Add e2e tests to npm package
+!/e2e/
+
+# Except our test-data folder files
+/e2e/test-data/*.json

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "resolve-url-loader": "5.0.0",
     "sass": "1.55.0",
     "sass-loader": "13.0.2",
-    "sinon": "14.0.0",
+    "sinon": "14.0.1",
     "style-loader": "^3.3.1",
     "typescript": "4.8.4",
     "uuid": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "2.1.2-SNAPSHOT",
+  "version": "2.1.3-SNAPSHOT",
   "description": "The Open MCT core platform",
   "devDependencies": {
     "@babel/eslint-parser": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@playwright/test": "1.25.2",
     "@types/jasmine": "4.3.0",
     "@types/lodash": "4.14.186",
-    "babel-loader": "8.2.5",
+    "babel-loader": "9.0.0",
     "babel-plugin-istanbul": "6.1.1",
     "codecov": "3.8.3",
     "comma-separated-values": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "d3-axis": "3.0.0",
     "d3-scale": "3.3.0",
     "d3-selection": "3.0.0",
-    "eslint": "8.25.0",
+    "eslint": "8.26.0",
     "eslint-plugin-compat": "4.0.2",
     "eslint-plugin-playwright": "0.11.2",
     "eslint-plugin-vue": "9.6.0",


### PR DESCRIPTION
Closes #5928 https://github.com/nasa/openmct/issues/5928

### Describe your changes:
- [ ] Include e2e folder
- [ ] Ignore e2e/test-data/ files

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
