### PR TITLE
Use the current clock's timestamp to show the now line in the timestrip

### DIFF
--- a/src/ui/components/TimeSystemAxis.vue
+++ b/src/ui/components/TimeSystemAxis.vue
@@ -101,7 +101,8 @@ export default {
                 if (nowMarker) {
                     nowMarker.classList.remove('hidden');
                     nowMarker.style.height = this.contentHeight + 'px';
-                    const now = this.xScale(Date.now());
+                    const nowTimeStamp = this.openmct.time.clock().currentValue();
+                    const now = this.xScale(nowTimeStamp);
                     nowMarker.style.left = now + this.offset + 'px';
                 }
             }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #5629

### Describe your changes:
The time system axis time stamp uses the open mct clock's current value to show the now marker

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
