### PR TITLE
[Multiple Y-Axes] feat(ElementItem): optionally hide grippy

### DIFF
--- a/src/ui/inspector/ElementItem.vue
+++ b/src/ui/inspector/ElementItem.vue
@@ -38,6 +38,7 @@
         }"
     >
         <span
+            v-if="showGrippy"
             class="c-elements-pool__grippy c-grippy c-grippy--vertical-drag"
         ></span>
         <object-label
@@ -81,6 +82,10 @@ export default {
         },
         allowDrop: {
             type: Boolean
+        },
+        showGrippy: {
+            type: Boolean,
+            default: true
         }
     },
     data() {

--- a/src/ui/inspector/PlotElementsPool.vue
+++ b/src/ui/inspector/PlotElementsPool.vue
@@ -55,6 +55,7 @@
                     :element-object="element"
                     :parent-object="parentObject"
                     :allow-drop="allowDrop"
+                    :show-grippy="false"
                     @dragstart-custom="moveFrom($event, yAxis.id)"
                     @drop-custom="moveTo($event, index, yAxis.id)"
                 />


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
#6135  <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
 
Add a prop to optionally hide the "grippy" icon on ElementItems. Click/Drag between Y-Axis buckets doesn't work properly if dragged from the grippy icon due to the structure of ElementItem and its child components.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
