### PR TITLE
cherry-pick(#6171): fix(elementItemGroup): 🚫👶📜📊

### DIFF
--- a/src/ui/inspector/elements.scss
+++ b/src/ui/inspector/elements.scss
@@ -39,7 +39,6 @@
 
     &__group {
         flex: 1 1 auto;
-        overflow: auto;
         margin-top: $interiorMarginLg;
     }
 


### PR DESCRIPTION
- translation: remove the baby scroll bars from element item groups