### PR TITLE
fix: Navigating from Recent Objects breadcrumb correctly updates the URL hash

### DIFF
--- a/src/ui/components/ObjectPath.vue
+++ b/src/ui/components/ObjectPath.vue
@@ -24,6 +24,8 @@
 <ul
     v-if="orderedPath.length"
     class="c-location"
+    :aria-label="`${domainObject.name} Breadcrumb`"
+    role="navigation"
 >
     <li
         v-for="pathObject in orderedPath"

--- a/src/ui/components/ObjectPath.vue
+++ b/src/ui/components/ObjectPath.vue
@@ -34,6 +34,7 @@
             :domain-object="pathObject.domainObject"
             :object-path="pathObject.objectPath"
             :read-only="readOnly"
+            :navigate-to-path="navigateToPath(pathObject.objectPath)"
         />
     </li>
 </ul>
@@ -109,6 +110,18 @@ export default {
                 // remove ROOT and object itself from path
                 this.orderedPath = pathWithDomainObject.slice(1, pathWithDomainObject.length - 1).reverse();
             }
+        }
+    },
+    methods: {
+        /**
+         * Generate the hash url for the given object path, removing the '/ROOT' prefix if present.
+         * @param {import('../../api/objects/ObjectAPI').DomainObject[]} objectPath
+         */
+        navigateToPath(objectPath) {
+            /** @type {String} */
+            const path = `/browse/${this.openmct.objects.getRelativePath(objectPath)}`;
+
+            return path.replace('ROOT/', '');
         }
     }
 };


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6151  <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Provides a `navigateToPath` to `ObjectLabel` so that navigation from a breadcrumb works correctly. Previously, the navigationPath generated by the `ObjectLink` mixin was also including params, which navigates correctly but sometimes fails to update the URL hash due to logic within the Router. Params are set after navigation, and unless they're being changed (or we're opening a link in a new tab), there's no reason to include these in the navigation path.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
