### PR TITLE
Replace structuredClone with JSON.parse

### DIFF
--- a/src/api/objects/MutableDomainObject.js
+++ b/src/api/objects/MutableDomainObject.js
@@ -75,7 +75,7 @@ class MutableDomainObject {
         return eventOff;
     }
     $set(path, value) {
-        const oldModel = structuredClone(this);
+        const oldModel = JSON.parse(JSON.stringify(this));
         const oldValue = _.get(oldModel, path);
         MutableDomainObject.mutateObject(this, path, value);
 
@@ -126,7 +126,7 @@ class MutableDomainObject {
         Object.assign(mutable, object);
 
         mutable.$observe('$_synchronize_model', (updatedObject) => {
-            let clone = structuredClone(updatedObject);
+            let clone = JSON.parse(JSON.stringify(updatedObject));
             utils.refresh(mutable, clone);
         });
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6236

### Describe your changes:
Replaces usage of `structuredClone` with `JSON.parse` to support functions in imagery metadata. `structuredClone` throws an error when trying to clone an object with function attributes.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
