### PR TITLE
cherry-pick(#6241): [Staleness] Fix removed object error and clean up

### DIFF
--- a/example/generator/SinewaveStalenessProvider.js
+++ b/example/generator/SinewaveStalenessProvider.js
@@ -23,14 +23,18 @@
 import EventEmitter from 'EventEmitter';
 
 export default class SinewaveLimitProvider extends EventEmitter {
+    #openmct;
+    #observingStaleness;
+    #watchingTheClock;
+    #isRealTime;
 
     constructor(openmct) {
         super();
 
-        this.openmct = openmct;
-        this.observingStaleness = {};
-        this.watchingTheClock = false;
-        this.isRealTime = undefined;
+        this.#openmct = openmct;
+        this.#observingStaleness = {};
+        this.#watchingTheClock = false;
+        this.#isRealTime = undefined;
     }
 
     supportsStaleness(domainObject) {
@@ -38,114 +42,116 @@ export default class SinewaveLimitProvider extends EventEmitter {
     }
 
     isStale(domainObject, options) {
-        if (!this.providingStaleness(domainObject)) {
+        if (!this.#providingStaleness(domainObject)) {
             return Promise.resolve({
                 isStale: false,
                 utc: 0
             });
         }
 
-        const id = this.getObjectKeyString(domainObject);
+        const id = this.#getObjectKeyString(domainObject);
 
-        if (!this.observerExists(id)) {
-            this.createObserver(id);
+        if (!this.#observerExists(id)) {
+            this.#createObserver(id);
         }
 
-        return Promise.resolve(this.observingStaleness[id].isStale);
+        return Promise.resolve(this.#observingStaleness[id].isStale);
     }
 
     subscribeToStaleness(domainObject, callback) {
-        const id = this.getObjectKeyString(domainObject);
+        const id = this.#getObjectKeyString(domainObject);
 
-        if (this.isRealTime === undefined) {
-            this.updateRealTime(this.openmct.time.clock());
+        if (this.#isRealTime === undefined) {
+            this.#updateRealTime(this.#openmct.time.clock());
         }
 
-        this.handleClockUpdate();
+        this.#handleClockUpdate();
 
-        if (this.observerExists(id)) {
-            this.addCallbackToObserver(id, callback);
+        if (this.#observerExists(id)) {
+            this.#addCallbackToObserver(id, callback);
         } else {
-            this.createObserver(id, callback);
+            this.#createObserver(id, callback);
         }
 
         const intervalId = setInterval(() => {
-            if (this.providingStaleness(domainObject)) {
-                this.updateStaleness(id, !this.observingStaleness[id].isStale);
+            if (this.#providingStaleness(domainObject)) {
+                this.#updateStaleness(id, !this.#observingStaleness[id].isStale);
             }
         }, 10000);
 
         return () => {
             clearInterval(intervalId);
-            this.updateStaleness(id, false);
-            this.handleClockUpdate();
-            this.destroyObserver(id);
+            this.#updateStaleness(id, false);
+            this.#handleClockUpdate();
+            this.#destroyObserver(id);
         };
     }
 
-    handleClockUpdate() {
-        let observers = Object.values(this.observingStaleness).length > 0;
+    #handleClockUpdate() {
+        let observers = Object.values(this.#observingStaleness).length > 0;
 
-        if (observers && !this.watchingTheClock) {
-            this.watchingTheClock = true;
-            this.openmct.time.on('clock', this.updateRealTime, this);
-        } else if (!observers && this.watchingTheClock) {
-            this.watchingTheClock = false;
-            this.openmct.time.off('clock', this.updateRealTime, this);
+        if (observers && !this.#watchingTheClock) {
+            this.#watchingTheClock = true;
+            this.#openmct.time.on('clock', this.#updateRealTime, this);
+        } else if (!observers && this.#watchingTheClock) {
+            this.#watchingTheClock = false;
+            this.#openmct.time.off('clock', this.#updateRealTime, this);
         }
     }
 
-    updateRealTime(clock) {
-        this.isRealTime = clock !== undefined;
+    #updateRealTime(clock) {
+        this.#isRealTime = clock !== undefined;
 
-        if (!this.isRealTime) {
-            Object.keys(this.observingStaleness).forEach((id) => {
-                this.updateStaleness(id, false);
+        if (!this.#isRealTime) {
+            Object.keys(this.#observingStaleness).forEach((id) => {
+                this.#updateStaleness(id, false);
             });
         }
     }
 
-    updateStaleness(id, isStale) {
-        this.observingStaleness[id].isStale = isStale;
-        this.observingStaleness[id].utc = Date.now();
-        this.observingStaleness[id].callback({
-            isStale: this.observingStaleness[id].isStale,
-            utc: this.observingStaleness[id].utc
+    #updateStaleness(id, isStale) {
+        this.#observingStaleness[id].isStale = isStale;
+        this.#observingStaleness[id].utc = Date.now();
+        this.#observingStaleness[id].callback({
+            isStale: this.#observingStaleness[id].isStale,
+            utc: this.#observingStaleness[id].utc
         });
         this.emit('stalenessEvent', {
             id,
-            isStale: this.observingStaleness[id].isStale
+            isStale: this.#observingStaleness[id].isStale
         });
     }
 
-    createObserver(id, callback) {
-        this.observingStaleness[id] = {
+    #createObserver(id, callback) {
+        this.#observingStaleness[id] = {
             isStale: false,
             utc: Date.now()
         };
 
         if (typeof callback === 'function') {
-            this.addCallbackToObserver(id, callback);
+            this.#addCallbackToObserver(id, callback);
         }
     }
 
-    destroyObserver(id) {
-        delete this.observingStaleness[id];
+    #destroyObserver(id) {
+        if (this.#observingStaleness[id]) {
+            delete this.#observingStaleness[id];
+        }
     }
 
-    providingStaleness(domainObject) {
-        return domainObject.telemetry?.staleness === true && this.isRealTime;
+    #providingStaleness(domainObject) {
+        return domainObject.telemetry?.staleness === true && this.#isRealTime;
     }
 
-    getObjectKeyString(object) {
-        return this.openmct.objects.makeKeyString(object.identifier);
+    #getObjectKeyString(object) {
+        return this.#openmct.objects.makeKeyString(object.identifier);
     }
 
-    addCallbackToObserver(id, callback) {
-        this.observingStaleness[id].callback = callback;
+    #addCallbackToObserver(id, callback) {
+        this.#observingStaleness[id].callback = callback;
     }
 
-    observerExists(id) {
-        return this.observingStaleness?.[id];
+    #observerExists(id) {
+        return this.#observingStaleness?.[id];
     }
 }

--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -218,6 +218,7 @@ export default {
                 this.stalenessSubscription[keystring].unsubscribe();
                 this.stalenessSubscription[keystring].stalenessUtils.destroy();
                 this.handleStaleness(keystring, { isStale: false }, SKIP_CHECK);
+                delete this.stalenessSubscription[keystring];
             };
         },
         handleStaleness(id, stalenessResponse, skipCheck = false) {

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -232,7 +232,9 @@ export default {
             this.stalenessSubscription[keyString].stalenessUtils = new StalenessUtils(this.openmct, domainObject);
 
             this.openmct.telemetry.isStale(domainObject).then((stalenessResponse) => {
-                this.hanldeStaleness(keyString, stalenessResponse);
+                if (stalenessResponse !== undefined) {
+                    this.hanldeStaleness(keyString, stalenessResponse);
+                }
             });
             const stalenessSubscription = this.openmct.telemetry.subscribeToStaleness(domainObject, (stalenessResponse) => {
                 this.hanldeStaleness(keyString, stalenessResponse);
@@ -259,6 +261,7 @@ export default {
                     keyString,
                     isStale: false
                 });
+                delete this.stalenessSubscription[keyString];
             }
         },
         hanldeStaleness(keyString, stalenessResponse) {

--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -83,6 +83,11 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
             if (!this.stalenessSubscription[id]) {
                 this.stalenessSubscription[id] = {};
                 this.stalenessSubscription[id].stalenessUtils = new StalenessUtils(this.openmct, telemetryObject);
+                this.openmct.telemetry.isStale(telemetryObject).then((stalenessResponse) => {
+                    if (stalenessResponse !== undefined) {
+                        this.handleStaleTelemetry(id, stalenessResponse);
+                    }
+                });
                 this.stalenessSubscription[id].unsubscribe = this.openmct.telemetry.subscribeToStaleness(
                     telemetryObject,
                     (stalenessResponse) => {

--- a/src/plugins/plot/Plot.vue
+++ b/src/plugins/plot/Plot.vue
@@ -166,6 +166,7 @@ export default {
             this.stalenessSubscription[keystring].unsubscribe();
             this.stalenessSubscription[keystring].stalenessUtils.destroy();
             this.handleStaleness(keystring, { isStale: false }, SKIP_CHECK);
+            delete this.stalenessSubscription[keystring];
         },
         handleStaleness(id, stalenessResponse, skipCheck = false) {
             if (skipCheck || this.stalenessSubscription[id].stalenessUtils.shouldUpdateStaleness(stalenessResponse, id)) {

--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -293,6 +293,7 @@ define([
             this.stalenessSubscription[keyString].unsubscribe();
             this.stalenessSubscription[keyString].stalenessUtils.destroy();
             this.handleStaleness(keyString, { isStale: false }, SKIP_CHECK);
+            delete this.stalenessSubscription[keyString];
         }
 
         clearData() {


### PR DESCRIPTION
Issue #6160 
* fixing error from plots when removing swg and making methods and props private for swg staleness provider

* removing unsubscribes from destroy hooks if the item has been removed already and reverting an unneccesary change

* checking for undefined staleness response

* removed un-neccesary code