### PR TITLE
Compass rose rotation fixes

### DIFF
--- a/src/plugins/imagery/components/Compass/CompassRose.vue
+++ b/src/plugins/imagery/components/Compass/CompassRose.vue
@@ -107,48 +107,53 @@
                         height="100"
                     />
                 </mask>
-
-                <!-- Equipment (spacecraft) body holder. Transforms relative to the camera position. -->
                 <g
-                    v-if="hasHeading"
-                    class="cr-vrover"
-                    :style="camAngleAndPositionStyle"
-                >
-                    <!-- Equipment body. Rotates relative to the camera gimbal value for cams that gimbal. -->
-                    <path
-                        class="cr-vrover__body"
-                        :style="camGimbalAngleStyle"
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M5 0C2.23858 0 0 2.23858 0 5V95C0 97.7614 2.23858 100 5 100H95C97.7614 100 100 97.7614 100 95V5C100 2.23858 97.7614 0 95 0H5ZM85 59L50 24L15 59H33V75H67.0455V59H85Z"
-                    />
-                </g>
-
-                <g
-                    class="c-cr__cam-fov"
+                    class="c-cr-cam-and-body"
                     :style="cameraHeadingStyle"
                 >
-                    <g mask="url(#mask2)">
-                        <rect
-                            class="c-cr__cam-fov-r"
-                            x="49"
-                            width="51"
-                            height="100"
-                            :style="cameraFOVStyleRightHalf"
+                    <!-- Equipment (spacecraft) body holder. Transforms relative to the camera position. -->
+                    <g
+                        v-if="hasHeading"
+                        class="cr-vrover"
+                        :style="camAngleAndPositionStyle"
+                    >
+                        <!-- Equipment body. Rotates relative to the camera pan value for cams that gimbal. -->
+                        <path
+                            class="cr-vrover__body"
+                            :style="camGimbalAngleStyle"
+                            x
+                            fill-rule="evenodd"
+                            clip-rule="evenodd"
+                            d="M5 0C2.23858 0 0 2.23858 0 5V95C0 97.7614 2.23858 100 5 100H95C97.7614 100 100 97.7614 100 95V5C100 2.23858 97.7614 0 95 0H5ZM85 59L50 24L15 59H33V75H67.0455V59H85Z"
                         />
                     </g>
-                    <g mask="url(#mask1)">
-                        <rect
-                            class="c-cr__cam-fov-l"
-                            width="51"
-                            height="100"
-                            :style="cameraFOVStyleLeftHalf"
+
+                    <g
+                        class="c-cr__cam-fov"
+                    >
+                        <g mask="url(#mask2)">
+                            <rect
+                                class="c-cr__cam-fov-r"
+                                x="49"
+                                width="51"
+                                height="100"
+                                :style="cameraFOVStyleRightHalf"
+                            />
+                        </g>
+                        <g mask="url(#mask1)">
+                            <rect
+                                class="c-cr__cam-fov-l"
+                                width="51"
+                                height="100"
+                                :style="cameraFOVStyleLeftHalf"
+                            />
+                        </g>
+                        <polygon
+                            class="c-cr__cam"
+                            points="0,0 100,0 70,40 70,100 30,100 30,40"
                         />
                     </g>
-                    <polygon
-                        class="c-cr__cam"
-                        points="0,0 100,0 70,40 70,100 30,100 30,40"
-                    />
+
                 </g>
             </g>
 
@@ -305,7 +310,7 @@ export default {
             return { transform: `translate(${translateX}%, ${translateY}%) rotate(${rotation}deg) scale(${scale})` };
         },
         camGimbalAngleStyle() {
-            const rotation = rotate(this.north, this.heading);
+            const rotation = rotate(this.heading);
 
             return {
                 transform: `rotate(${ rotation }deg)`
@@ -331,14 +336,6 @@ export default {
         },
         hasHeading() {
             return this.heading !== undefined;
-        },
-        headingStyle() {
-            /* Replaced with computed camGimbalStyle, but left here just in case. */
-            const rotation = rotate(this.north, this.heading);
-
-            return {
-                transform: `rotate(${ rotation }deg)`
-            };
         },
         hasSunHeading() {
             return this.sunHeading !== undefined;


### PR DESCRIPTION
Closes #6257
- Moved rotation styling into new `<g>` element that holds both cam FOV and `vrover` element.
- Removed `this.north` from `camGimbalAngleStyle` computed value.
- Code cleanup.

<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
