### PR TITLE
fix: remove 1px padding and re-enable autoscale snapshot test

### DIFF
--- a/e2e/tests/functional/plugins/plot/autoscale.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/autoscale.e2e.spec.js
@@ -32,7 +32,7 @@ test.use({
     }
 });
 
-test.fixme('ExportAsJSON', () => {
+test.describe('ExportAsJSON', () => {
     test('User can set autoscale with a valid range @snapshot', async ({ page, openmctConfig }) => {
         const { myItemsFolderName } = openmctConfig;
 

--- a/src/styles/_legacy-plots.scss
+++ b/src/styles/_legacy-plots.scss
@@ -664,7 +664,6 @@ mct-plot {
             border-radius: $smallCr;
             display: flex;
             justify-content: stretch;
-            padding: 1px;
 
             .plot-series-swatch-and-name,
             .plot-series-value {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6267 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Removes a seemingly unnecessary [1px padding to plot legend items](https://github.com/nasa/openmct/pull/6108/files#diff-2dbf1e2d399ba036135dbc9d1c8e86d1cb7ae10cf340420eee0d60b66505d3f1R667) that was squishing our plot and causing our snapshot tests to fail. Re-enables the autoscale snapshot tests.

Here is the plot legend item without 1px padding:
![image](https://user-images.githubusercontent.com/9259993/216475771-62980f48-6a99-4391-a076-074bbe43bdf5.png)


..and with:
![image](https://user-images.githubusercontent.com/9259993/216475725-5668248c-e2c7-4734-bdf1-5e0d28b3750e.png)

@charlesh88 thoughts? is this ok to remove or should we regenerate snapshots?

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
