### PR TITLE
cherry-pick(#6255): [Notebook] Sanitize entries before save for extra…

### DIFF
--- a/src/plugins/notebook/components/NotebookEntry.vue
+++ b/src/plugins/notebook/components/NotebookEntry.vue
@@ -77,13 +77,13 @@
                     aria-label="Notebook Entry Input"
                     tabindex="0"
                     :contenteditable="canEdit"
+                    v-bind.prop="formattedText"
                     @mouseover="checkEditability($event)"
                     @mouseleave="canEdit = true"
                     @focus="editingEntry()"
                     @blur="updateEntryValue($event)"
                     @keydown.enter.exact.prevent
                     @keyup.enter.exact.prevent="forceBlur($event)"
-                    v-html="formattedText"
                 >
                 </div>
             </template>
@@ -250,7 +250,7 @@ export default {
             let text = sanitizeHtml(this.entry.text, SANITIZATION_SCHEMA);
 
             if (this.editMode || !this.urlWhitelist) {
-                return text;
+                return { innerText: text };
             }
 
             text = text.replace(URL_REGEX, (match) => {
@@ -268,7 +268,7 @@ export default {
                 return result;
             });
 
-            return text;
+            return { innerHTML: text };
         },
         isSelectedEntry() {
             return this.selectedEntryId === this.entry.id;
@@ -456,7 +456,7 @@ export default {
             this.editMode = false;
             const value = $event.target.innerText;
             if (value !== this.entry.text && value.match(/\S/)) {
-                this.entry.text = value;
+                this.entry.text = sanitizeHtml(value, SANITIZATION_SCHEMA);
                 this.timestampAndUpdate();
             } else {
                 this.$emit('cancelEdit');


### PR DESCRIPTION
Issue: #6202 

* Sanitizing before save as well to be be doubly safe

---------

Co-authored-by: Andrew Henry <akhenry@gmail.com>

<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
