### PR TITLE
fix: DisplayLayout shapes can be selected and manipulated again

### DIFF
--- a/src/ui/inspector/Inspector.vue
+++ b/src/ui/inspector/Inspector.vue
@@ -109,6 +109,8 @@ import StylesInspectorView from "@/ui/inspector/styles/StylesInspectorView.vue";
 import SavedStylesInspectorView from "@/ui/inspector/styles/SavedStylesInspectorView.vue";
 import AnnotationsInspectorView from "./annotations/AnnotationsInspectorView.vue";
 
+const OVERLAY_PLOT_TYPE = "telemetry.plot.overlay";
+
 export default {
     components: {
         StylesInspectorView,
@@ -189,12 +191,12 @@ export default {
         },
         refreshComposition(selection) {
             if (selection.length > 0 && selection[0].length > 0) {
-                let parentObject = selection[0][0].context.item;
+                const parentObject = selection[0][0].context.item;
 
                 this.hasComposition = Boolean(
                     parentObject && this.openmct.composition.get(parentObject)
                 );
-                this.isOverlayPlot = selection[0][0].context.item.type === 'telemetry.plot.overlay';
+                this.isOverlayPlot = parentObject?.type === OVERLAY_PLOT_TYPE;
             }
         },
         refreshTabs(selection) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6287 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

Adds optional chaining to handle the case where parentless objects such as shapes and lines would be selected in the displayLayout. Previously this was failing as a check to determine if the selected object was an Overlay Plot was expecting the parentObject to be defined.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
