### PR TITLE
cherry-pick(#6289): fix: DisplayLayout shapes can be selected and manipulated again

### DIFF
--- a/src/ui/inspector/Inspector.vue
+++ b/src/ui/inspector/Inspector.vue
@@ -109,6 +109,8 @@ import StylesInspectorView from "@/ui/inspector/styles/StylesInspectorView.vue";
 import SavedStylesInspectorView from "@/ui/inspector/styles/SavedStylesInspectorView.vue";
 import AnnotationsInspectorView from "./annotations/AnnotationsInspectorView.vue";
 
+const OVERLAY_PLOT_TYPE = "telemetry.plot.overlay";
+
 export default {
     components: {
         StylesInspectorView,
@@ -189,12 +191,12 @@ export default {
         },
         refreshComposition(selection) {
             if (selection.length > 0 && selection[0].length > 0) {
-                let parentObject = selection[0][0].context.item;
+                const parentObject = selection[0][0].context.item;
 
                 this.hasComposition = Boolean(
                     parentObject && this.openmct.composition.get(parentObject)
                 );
-                this.isOverlayPlot = selection[0][0].context.item.type === 'telemetry.plot.overlay';
+                this.isOverlayPlot = parentObject?.type === OVERLAY_PLOT_TYPE;
             }
         },
         refreshTabs(selection) {


### PR DESCRIPTION
fix: handle case where parentObject is undefined

- Fixes manipulation of parentless display layout objects such as shapes and lines

<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Issue #6287 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->
