### PR TITLE
cherry-pick(#6281): [Staleness] Handle Overlay Plots in Stacked Plots and removing LAD Tables from LAD Table Sets

### DIFF
--- a/example/generator/SinewaveStalenessProvider.js
+++ b/example/generator/SinewaveStalenessProvider.js
@@ -43,10 +43,7 @@ export default class SinewaveLimitProvider extends EventEmitter {
 
     isStale(domainObject, options) {
         if (!this.#providingStaleness(domainObject)) {
-            return Promise.resolve({
-                isStale: false,
-                utc: 0
-            });
+            return;
         }
 
         const id = this.#getObjectKeyString(domainObject);
@@ -55,7 +52,10 @@ export default class SinewaveLimitProvider extends EventEmitter {
             this.#createObserver(id);
         }
 
-        return Promise.resolve(this.#observingStaleness[id].isStale);
+        return Promise.resolve({
+            isStale: this.#observingStaleness[id].isStale,
+            utc: Date.now()
+        });
     }
 
     subscribeToStaleness(domainObject, callback) {

--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -48,11 +48,11 @@
                 </tr>
                 <lad-row
                     v-for="ladRow in ladTelemetryObjects[ladTable.key]"
-                    :key="ladRow.key"
+                    :key="combineKeys(ladTable.key, ladRow.key)"
                     :domain-object="ladRow.domainObject"
                     :path-to-table="ladTable.objectPath"
                     :has-units="hasUnits"
-                    :is-stale="staleObjects.includes(ladRow.key)"
+                    :is-stale="staleObjects.includes(combineKeys(ladTable.key, ladRow.key))"
                     @rowContextClick="updateViewContext"
                 />
             </template>
@@ -160,9 +160,17 @@ export default {
                 removeCallback
             });
         },
+        combineKeys(ladKey, telemetryObjectKey) {
+            return `${ladKey}-${telemetryObjectKey}`;
+        },
         removeLadTable(identifier) {
             let index = this.ladTableObjects.findIndex(ladTable => this.openmct.objects.makeKeyString(identifier) === ladTable.key);
             let ladTable = this.ladTableObjects[index];
+
+            this.ladTelemetryObjects[ladTable.key].forEach(telemetryObject => {
+                let combinedKey = this.combineKeys(ladTable.key, telemetryObject.key);
+                this.unwatchStaleness(combinedKey);
+            });
 
             this.$delete(this.ladTelemetryObjects, ladTable.key);
             this.ladTableObjects.splice(index, 1);
@@ -178,60 +186,58 @@ export default {
                 let telemetryObject = {};
                 telemetryObject.key = this.openmct.objects.makeKeyString(domainObject.identifier);
                 telemetryObject.domainObject = domainObject;
+                const combinedKey = this.combineKeys(ladTable.key, telemetryObject.key);
 
-                let telemetryObjects = this.ladTelemetryObjects[ladTable.key];
+                const telemetryObjects = this.ladTelemetryObjects[ladTable.key];
                 telemetryObjects.push(telemetryObject);
 
                 this.$set(this.ladTelemetryObjects, ladTable.key, telemetryObjects);
 
-                // if tracking already, possibly in another table, return
-                if (this.stalenessSubscription[telemetryObject.key]) {
-                    return;
-                } else {
-                    this.stalenessSubscription[telemetryObject.key] = {};
-                    this.stalenessSubscription[telemetryObject.key].stalenessUtils = new StalenessUtils(this.openmct, domainObject);
-                }
+                this.stalenessSubscription[combinedKey] = {};
+                this.stalenessSubscription[combinedKey].stalenessUtils = new StalenessUtils(this.openmct, domainObject);
 
                 this.openmct.telemetry.isStale(domainObject).then((stalenessResponse) => {
                     if (stalenessResponse !== undefined) {
-                        this.handleStaleness(telemetryObject.key, stalenessResponse);
+                        this.handleStaleness(combinedKey, stalenessResponse);
                     }
                 });
                 const stalenessSubscription = this.openmct.telemetry.subscribeToStaleness(domainObject, (stalenessResponse) => {
-                    this.handleStaleness(telemetryObject.key, stalenessResponse);
+                    this.handleStaleness(combinedKey, stalenessResponse);
                 });
 
-                this.stalenessSubscription[telemetryObject.key].unsubscribe = stalenessSubscription;
+                this.stalenessSubscription[combinedKey].unsubscribe = stalenessSubscription;
             };
         },
         removeTelemetryObject(ladTable) {
             return (identifier) => {
-                const SKIP_CHECK = true;
                 const keystring = this.openmct.objects.makeKeyString(identifier);
-                let telemetryObjects = this.ladTelemetryObjects[ladTable.key];
+                const telemetryObjects = this.ladTelemetryObjects[ladTable.key];
+                const combinedKey = this.combineKeys(ladTable.key, keystring);
                 let index = telemetryObjects.findIndex(telemetryObject => keystring === telemetryObject.key);
 
+                this.unwatchStaleness(combinedKey);
+
                 telemetryObjects.splice(index, 1);
-
                 this.$set(this.ladTelemetryObjects, ladTable.key, telemetryObjects);
-
-                this.stalenessSubscription[keystring].unsubscribe();
-                this.stalenessSubscription[keystring].stalenessUtils.destroy();
-                this.handleStaleness(keystring, { isStale: false }, SKIP_CHECK);
-                delete this.stalenessSubscription[keystring];
             };
         },
-        handleStaleness(id, stalenessResponse, skipCheck = false) {
-            if (skipCheck || this.stalenessSubscription[id].stalenessUtils.shouldUpdateStaleness(stalenessResponse)) {
-                const index = this.staleObjects.indexOf(id);
-                if (stalenessResponse.isStale) {
-                    if (index === -1) {
-                        this.staleObjects.push(id);
-                    }
-                } else {
-                    if (index !== -1) {
-                        this.staleObjects.splice(index, 1);
-                    }
+        unwatchStaleness(combinedKey) {
+            const SKIP_CHECK = true;
+
+            this.stalenessSubscription[combinedKey].unsubscribe();
+            this.stalenessSubscription[combinedKey].stalenessUtils.destroy();
+            this.handleStaleness(combinedKey, { isStale: false }, SKIP_CHECK);
+
+            delete this.stalenessSubscription[combinedKey];
+        },
+        handleStaleness(combinedKey, stalenessResponse, skipCheck = false) {
+            if (skipCheck || this.stalenessSubscription[combinedKey].stalenessUtils.shouldUpdateStaleness(stalenessResponse)) {
+                const index = this.staleObjects.indexOf(combinedKey);
+                const foundStaleObject = index > -1;
+                if (stalenessResponse.isStale && !foundStaleObject) {
+                    this.staleObjects.push(combinedKey);
+                } else if (!stalenessResponse.isStale && foundStaleObject) {
+                    this.staleObjects.splice(index, 1);
                 }
             }
         },

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -233,11 +233,11 @@ export default {
 
             this.openmct.telemetry.isStale(domainObject).then((stalenessResponse) => {
                 if (stalenessResponse !== undefined) {
-                    this.hanldeStaleness(keyString, stalenessResponse);
+                    this.handleStaleness(keyString, stalenessResponse);
                 }
             });
             const stalenessSubscription = this.openmct.telemetry.subscribeToStaleness(domainObject, (stalenessResponse) => {
-                this.hanldeStaleness(keyString, stalenessResponse);
+                this.handleStaleness(keyString, stalenessResponse);
             });
 
             this.stalenessSubscription[keyString].unsubscribe = stalenessSubscription;
@@ -264,7 +264,7 @@ export default {
                 delete this.stalenessSubscription[keyString];
             }
         },
-        hanldeStaleness(keyString, stalenessResponse) {
+        handleStaleness(keyString, stalenessResponse) {
             if (this.stalenessSubscription[keyString].stalenessUtils.shouldUpdateStaleness(stalenessResponse)) {
                 this.emitStaleness({
                     keyString,


### PR DESCRIPTION
* add handling for composition items (ex overlay plot) in stacked plots, fix swg staleness provider isStale method response

* typo

* removing staleness listeners when ladtable is remove

* addressing pr comments for this component

* address changes requested for lad table sets

* had to update is-stale for the row since we used combined keys in lad table sets now

Issue: #6265
