### PR TITLE
[TimeAPI] Fix independent time context check

### DIFF
--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -202,7 +202,7 @@ class IndependentTimeContext extends TimeContext {
     }
 
     getUpstreamContext() {
-        const objectKey = this.openmct.objects.makeKeyString(this.objectPath[this.objectPath.length - 1].identifier);
+        const objectKey = this.openmct.objects.makeKeyString(this.objectPath[0].identifier);
         const doesObjectHaveTimeContext = this.globalTimeContext.independentContexts.get(objectKey);
         if (doesObjectHaveTimeContext) {
             return undefined;

--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -202,16 +202,10 @@ class IndependentTimeContext extends TimeContext {
     }
 
     getUpstreamContext() {
-        const objectKey = this.openmct.objects.makeKeyString(this.objectPath[0].identifier);
-        const doesObjectHaveTimeContext = this.globalTimeContext.independentContexts.get(objectKey);
-        if (doesObjectHaveTimeContext) {
-            return undefined;
-        }
-
         let timeContext = this.globalTimeContext;
         this.objectPath.some((item, index) => {
             const key = this.openmct.objects.makeKeyString(item.identifier);
-            //last index is the view object itself
+            //first index is the view object itself
             const itemContext = this.globalTimeContext.independentContexts.get(key);
             if (index > 0 && itemContext && itemContext.hasOwnContext()) {
                 //upstream time context

--- a/src/api/time/independentTimeAPISpec.js
+++ b/src/api/time/independentTimeAPISpec.js
@@ -93,18 +93,43 @@ describe("The Independent Time API", function () {
     });
 
     it("follows a parent time context given the objectPath", () => {
-        let timeContext = api.getContextForView([{
+        api.getContextForView([{
             identifier: {
                 namespace: '',
                 key: 'blah'
             }
-        }, {
+        }]);
+        let destroyTimeContext = api.addIndependentContext('blah', independentBounds);
+        let timeContext = api.getContextForView([{
             identifier: {
                 namespace: '',
                 key: domainObjectKey
             }
+        }, {
+            identifier: {
+                namespace: '',
+                key: 'blah'
+            }
         }]);
-        let destroyTimeContext = api.addIndependentContext('blah', independentBounds);
+        expect(timeContext.bounds()).toEqual(independentBounds);
+        destroyTimeContext();
+        expect(timeContext.bounds()).toEqual(bounds);
+    });
+
+    it("uses an object's independent time context if the parent doesn't have one", () => {
+        let timeContext = api.getContextForView([{
+            identifier: {
+                namespace: '',
+                key: domainObjectKey
+            }
+        }, {
+            identifier: {
+                namespace: '',
+                key: 'blah'
+            }
+        }]);
+        expect(timeContext.bounds()).toEqual(bounds);
+        let destroyTimeContext = api.addIndependentContext(domainObjectKey, independentBounds);
         expect(timeContext.bounds()).toEqual(independentBounds);
         destroyTimeContext();
         expect(timeContext.bounds()).toEqual(bounds);

--- a/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
+++ b/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
@@ -227,6 +227,10 @@ export default {
             if (this.isFixed) {
                 offsets = this.timeOptions.fixedOffsets;
             } else {
+                if (this.timeOptions.clockOffsets === undefined) {
+                    this.timeOptions.clockOffsets = this.openmct.time.clockOffsets();
+                }
+
                 offsets = this.timeOptions.clockOffsets;
             }
 


### PR DESCRIPTION
Reverted a change where if a plot has it's own context, it would never be cleared out.
Closes #6107

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [X] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [X] Command line build passes?
* [X] Has this been smoke tested?
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)