### PR TITLE
Prevent tabbing into Notebook entries

### DIFF
--- a/src/plugins/notebook/components/NotebookEntry.vue
+++ b/src/plugins/notebook/components/NotebookEntry.vue
@@ -75,7 +75,7 @@
                     :id="entry.id"
                     class="c-ne__text c-ne__input"
                     aria-label="Notebook Entry Input"
-                    tabindex="0"
+                    tabindex="-1"
                     :contenteditable="canEdit"
                     v-bind.prop="formattedText"
                     @mouseover="checkEditability($event)"


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6312

### Describe your changes:
- Set entry inputs to `tabindex="-1"` to prevent tabbing into them.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [X] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? Unclear if updated tests are needed.
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
