### PR TITLE
Decouple removal of independent time context for a view from refreshing context for other views

### DIFF
--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -32,14 +32,18 @@ class IndependentTimeContext extends TimeContext {
         this.openmct = openmct;
         this.unlisteners = [];
         this.globalTimeContext = globalTimeContext;
-        this.upstreamTimeContext = undefined;
+        // We always start with the global time context.
+        // This upstream context will be undefined when an independent time context is added later.
+        this.upstreamTimeContext = this.globalTimeContext;
         this.objectPath = objectPath;
         this.refreshContext = this.refreshContext.bind(this);
         this.resetContext = this.resetContext.bind(this);
+        this.removeIndependentContext = this.removeIndependentContext.bind(this);
 
         this.refreshContext();
 
         this.globalTimeContext.on('refreshContext', this.refreshContext);
+        this.globalTimeContext.on('removeContext', this.removeIndependentContext);
     }
 
     bounds(newBounds) {
@@ -202,10 +206,16 @@ class IndependentTimeContext extends TimeContext {
     }
 
     getUpstreamContext() {
+        // If a view has an independent context, don't return an upstream context
+        // Be aware that when a new independent time context is created, we assign the global context as default
+        if (this.hasOwnContext()) {
+            return undefined;
+        }
+
         let timeContext = this.globalTimeContext;
         this.objectPath.some((item, index) => {
             const key = this.openmct.objects.makeKeyString(item.identifier);
-            //first index is the view object itself
+            // we're only interested in parents, not self, so index > 0
             const itemContext = this.globalTimeContext.independentContexts.get(key);
             if (index > 0 && itemContext && itemContext.hasOwnContext()) {
                 //upstream time context
@@ -218,6 +228,43 @@ class IndependentTimeContext extends TimeContext {
         });
 
         return timeContext;
+    }
+
+    /**
+     * Set the time context of a view to follow any upstream time contexts as necessary (defaulting to the global context)
+     * This needs to be separate from refreshContext
+     */
+    removeIndependentContext(viewKey) {
+        const key = this.openmct.objects.makeKeyString(this.objectPath[0].identifier);
+        if (viewKey && key === viewKey) {
+            //this is necessary as the upstream context gets reassigned after this
+            this.stopFollowingTimeContext();
+
+            let timeContext = this.globalTimeContext;
+
+            this.objectPath.some((item, index) => {
+                const objectKey = this.openmct.objects.makeKeyString(item.identifier);
+                // we're only interested in any parents, not self, so index > 0
+                const itemContext = this.globalTimeContext.independentContexts.get(objectKey);
+                if (index > 0 && itemContext && itemContext.hasOwnContext()) {
+                    //upstream time context
+                    timeContext = itemContext;
+
+                    return true;
+                }
+
+                return false;
+            });
+
+            this.upstreamTimeContext = timeContext;
+
+            this.followTimeContext();
+
+            // Emit bounds so that views that are changing context get the upstream bounds
+            this.emit('bounds', this.bounds());
+            // now that the view's context is set, tell others to check theirs in case they were following this view's context.
+            this.emit('refreshContext', viewKey);
+        }
     }
 }
 

--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -43,7 +43,7 @@ class IndependentTimeContext extends TimeContext {
         this.refreshContext();
 
         this.globalTimeContext.on('refreshContext', this.refreshContext);
-        this.globalTimeContext.on('removeContext', this.removeIndependentContext);
+        this.globalTimeContext.on('removeOwnContext', this.removeIndependentContext);
     }
 
     bounds(newBounds) {
@@ -263,7 +263,7 @@ class IndependentTimeContext extends TimeContext {
             // Emit bounds so that views that are changing context get the upstream bounds
             this.emit('bounds', this.bounds());
             // now that the view's context is set, tell others to check theirs in case they were following this view's context.
-            this.emit('refreshContext', viewKey);
+            this.globalTimeContext.emit('refreshContext', viewKey);
         }
     }
 }

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -149,7 +149,7 @@ class TimeAPI extends GlobalTimeContext {
 
         return () => {
             //follow any upstream time context
-            this.emit('refreshContext');
+            this.emit('removeOwnContext', key);
         };
     }
 

--- a/src/api/time/independentTimeAPISpec.js
+++ b/src/api/time/independentTimeAPISpec.js
@@ -117,22 +117,58 @@ describe("The Independent Time API", function () {
     });
 
     it("uses an object's independent time context if the parent doesn't have one", () => {
+        const domainObjectKey2 = `${domainObjectKey}-2`;
+        const domainObjectKey3 = `${domainObjectKey}-3`;
         let timeContext = api.getContextForView([{
             identifier: {
                 namespace: '',
                 key: domainObjectKey
             }
-        }, {
+        }]);
+        let timeContext2 = api.getContextForView([{
             identifier: {
                 namespace: '',
-                key: 'blah'
+                key: domainObjectKey2
             }
         }]);
+        let timeContext3 = api.getContextForView([{
+            identifier: {
+                namespace: '',
+                key: domainObjectKey3
+            }
+        }]);
+        // all bounds follow global time context
         expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
+        // only first item has own context
         let destroyTimeContext = api.addIndependentContext(domainObjectKey, independentBounds);
         expect(timeContext.bounds()).toEqual(independentBounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
+        // first and second item have own context
+        let destroyTimeContext2 = api.addIndependentContext(domainObjectKey2, independentBounds);
+        expect(timeContext.bounds()).toEqual(independentBounds);
+        expect(timeContext2.bounds()).toEqual(independentBounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
+        // all items have own time context
+        let destroyTimeContext3 = api.addIndependentContext(domainObjectKey3, independentBounds);
+        expect(timeContext.bounds()).toEqual(independentBounds);
+        expect(timeContext2.bounds()).toEqual(independentBounds);
+        expect(timeContext3.bounds()).toEqual(independentBounds);
+        //remove own contexts one at a time - should revert to global time context
         destroyTimeContext();
         expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(independentBounds);
+        expect(timeContext3.bounds()).toEqual(independentBounds);
+        destroyTimeContext2();
+        expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(independentBounds);
+        destroyTimeContext3();
+        expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
     });
 
     it("Allows setting of valid bounds", function () {


### PR DESCRIPTION
Closes VIPEROMCT-259 and #6107

### Describe your changes:
When independent time context is enabled for a view, it sends a `refreshContext` event. In response to this event, any other the views bing displayed re-calculate their `upstreamContext`. 
When there are multiple views on the viewport, the `refreshContext` call resets the time context of all but the last view to the global time context if the `objectPath` of those views has only one item.
The fix for this is to check if the first item in the `objectPath` has it's own context and return `undefined` as the `upstreamContext`

This fix then breaks the logic to _remove_ the independent context for views, because we cannot set the upstream context for the view `this.hasOwnContext()` will cause a `undefined` return.

So we now need to decouple the removal of a view's context from refreshing contexts.
A new method `removeIndependentContext` solves this.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
