### PR TITLE
cherry-pick(#6308): [TimeAPI] Fix independent time context check

### DIFF
--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -202,16 +202,10 @@ class IndependentTimeContext extends TimeContext {
     }
 
     getUpstreamContext() {
-        const objectKey = this.openmct.objects.makeKeyString(this.objectPath[this.objectPath.length - 1].identifier);
-        const doesObjectHaveTimeContext = this.globalTimeContext.independentContexts.get(objectKey);
-        if (doesObjectHaveTimeContext) {
-            return undefined;
-        }
-
         let timeContext = this.globalTimeContext;
         this.objectPath.some((item, index) => {
             const key = this.openmct.objects.makeKeyString(item.identifier);
-            //last index is the view object itself
+            //first index is the view object itself
             const itemContext = this.globalTimeContext.independentContexts.get(key);
             if (index > 0 && itemContext && itemContext.hasOwnContext()) {
                 //upstream time context

--- a/src/api/time/independentTimeAPISpec.js
+++ b/src/api/time/independentTimeAPISpec.js
@@ -93,18 +93,43 @@ describe("The Independent Time API", function () {
     });
 
     it("follows a parent time context given the objectPath", () => {
-        let timeContext = api.getContextForView([{
+        api.getContextForView([{
             identifier: {
                 namespace: '',
                 key: 'blah'
             }
-        }, {
+        }]);
+        let destroyTimeContext = api.addIndependentContext('blah', independentBounds);
+        let timeContext = api.getContextForView([{
             identifier: {
                 namespace: '',
                 key: domainObjectKey
             }
+        }, {
+            identifier: {
+                namespace: '',
+                key: 'blah'
+            }
         }]);
-        let destroyTimeContext = api.addIndependentContext('blah', independentBounds);
+        expect(timeContext.bounds()).toEqual(independentBounds);
+        destroyTimeContext();
+        expect(timeContext.bounds()).toEqual(bounds);
+    });
+
+    it("uses an object's independent time context if the parent doesn't have one", () => {
+        let timeContext = api.getContextForView([{
+            identifier: {
+                namespace: '',
+                key: domainObjectKey
+            }
+        }, {
+            identifier: {
+                namespace: '',
+                key: 'blah'
+            }
+        }]);
+        expect(timeContext.bounds()).toEqual(bounds);
+        let destroyTimeContext = api.addIndependentContext(domainObjectKey, independentBounds);
         expect(timeContext.bounds()).toEqual(independentBounds);
         destroyTimeContext();
         expect(timeContext.bounds()).toEqual(bounds);

--- a/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
+++ b/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
@@ -227,6 +227,10 @@ export default {
             if (this.isFixed) {
                 offsets = this.timeOptions.fixedOffsets;
             } else {
+                if (this.timeOptions.clockOffsets === undefined) {
+                    this.timeOptions.clockOffsets = this.openmct.time.clockOffsets();
+                }
+
                 offsets = this.timeOptions.clockOffsets;
             }
 


### PR DESCRIPTION
Issue https://github.com/nasa/openmct/issues/6107

* Fix independent time context to check first object in path (self) for upstream content instead of last object in path

* Revert changes that don't allow unregistering independent time context
