### PR TITLE
cherry-pick(#6334): Decouple removal of independent time context for a view from refreshing context for other views

### DIFF
--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -149,7 +149,7 @@ class TimeAPI extends GlobalTimeContext {
 
         return () => {
             //follow any upstream time context
-            this.emit('refreshContext');
+            this.emit('removeOwnContext', key);
         };
     }
 

--- a/src/api/time/independentTimeAPISpec.js
+++ b/src/api/time/independentTimeAPISpec.js
@@ -117,22 +117,58 @@ describe("The Independent Time API", function () {
     });
 
     it("uses an object's independent time context if the parent doesn't have one", () => {
+        const domainObjectKey2 = `${domainObjectKey}-2`;
+        const domainObjectKey3 = `${domainObjectKey}-3`;
         let timeContext = api.getContextForView([{
             identifier: {
                 namespace: '',
                 key: domainObjectKey
             }
-        }, {
+        }]);
+        let timeContext2 = api.getContextForView([{
             identifier: {
                 namespace: '',
-                key: 'blah'
+                key: domainObjectKey2
             }
         }]);
+        let timeContext3 = api.getContextForView([{
+            identifier: {
+                namespace: '',
+                key: domainObjectKey3
+            }
+        }]);
+        // all bounds follow global time context
         expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
+        // only first item has own context
         let destroyTimeContext = api.addIndependentContext(domainObjectKey, independentBounds);
         expect(timeContext.bounds()).toEqual(independentBounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
+        // first and second item have own context
+        let destroyTimeContext2 = api.addIndependentContext(domainObjectKey2, independentBounds);
+        expect(timeContext.bounds()).toEqual(independentBounds);
+        expect(timeContext2.bounds()).toEqual(independentBounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
+        // all items have own time context
+        let destroyTimeContext3 = api.addIndependentContext(domainObjectKey3, independentBounds);
+        expect(timeContext.bounds()).toEqual(independentBounds);
+        expect(timeContext2.bounds()).toEqual(independentBounds);
+        expect(timeContext3.bounds()).toEqual(independentBounds);
+        //remove own contexts one at a time - should revert to global time context
         destroyTimeContext();
         expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(independentBounds);
+        expect(timeContext3.bounds()).toEqual(independentBounds);
+        destroyTimeContext2();
+        expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(independentBounds);
+        destroyTimeContext3();
+        expect(timeContext.bounds()).toEqual(bounds);
+        expect(timeContext2.bounds()).toEqual(bounds);
+        expect(timeContext3.bounds()).toEqual(bounds);
     });
 
     it("Allows setting of valid bounds", function () {


### PR DESCRIPTION
Issue #6107 

* Decouple removing the context for a view from refreshing the context of views to get their upstream contexts

* Add test for clicking on an item in the elements pool for a preview

* Add test to ensure independent time context for items with no parents works as expected
