### PR TITLE
fix(#5158): StackedPlotItem reorders are reflected on the plot in real time

### DIFF
--- a/e2e/tests/functional/plugins/plot/stackedPlot.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/stackedPlot.e2e.spec.js
@@ -82,6 +82,56 @@ test.describe('Stacked Plot', () => {
         await expect(swgCElementsPoolItem).toHaveCount(1);
     });
 
+    test('Can reorder Stacked Plot items', async ({ page }) => {
+        const swgAElementsPoolItem = page.locator('#inspector-elements-tree').locator('.c-object-label', { hasText: swgA.name });
+        const swgBElementsPoolItem = page.locator('#inspector-elements-tree').locator('.c-object-label', { hasText: swgB.name });
+        const swgCElementsPoolItem = page.locator('#inspector-elements-tree').locator('.c-object-label', { hasText: swgC.name });
+
+        await page.goto(stackedPlot.url);
+
+        await page.click('button[title="Edit"]');
+
+        // Expand the elements pool vertically
+        await page.locator('.l-pane__handle').nth(2).hover({ trial: true });
+        await page.mouse.down();
+        await page.mouse.move(0, 100);
+        await page.mouse.up();
+
+        const stackedPlotItem1 = page.locator('.c-plot--stacked-container').nth(0);
+        const stackedPlotItem2 = page.locator('.c-plot--stacked-container').nth(1);
+        const stackedPlotItem3 = page.locator('.c-plot--stacked-container').nth(2);
+
+        // assert initial plot order
+        await expect(stackedPlotItem1).toHaveAttribute('aria-label', `Stacked Plot Item ${swgA.name}`);
+        await expect(stackedPlotItem2).toHaveAttribute('aria-label', `Stacked Plot Item ${swgB.name}`);
+        await expect(stackedPlotItem3).toHaveAttribute('aria-label', `Stacked Plot Item ${swgC.name}`);
+
+        // Drag and drop to reorder
+        await swgBElementsPoolItem.dragTo(swgAElementsPoolItem);
+
+        // assert plot order after reorder
+        await expect(stackedPlotItem1).toHaveAttribute('aria-label', `Stacked Plot Item ${swgB.name}`);
+        await expect(stackedPlotItem2).toHaveAttribute('aria-label', `Stacked Plot Item ${swgA.name}`);
+        await expect(stackedPlotItem3).toHaveAttribute('aria-label', `Stacked Plot Item ${swgC.name}`);
+
+        // Drag and drop to reorder
+        await swgCElementsPoolItem.dragTo(swgAElementsPoolItem);
+
+        // assert plot order after second reorder
+        await expect(stackedPlotItem1).toHaveAttribute('aria-label', `Stacked Plot Item ${swgB.name}`);
+        await expect(stackedPlotItem2).toHaveAttribute('aria-label', `Stacked Plot Item ${swgC.name}`);
+        await expect(stackedPlotItem3).toHaveAttribute('aria-label', `Stacked Plot Item ${swgA.name}`);
+
+        // Save (exit edit mode)
+        await page.locator('button[title="Save"]').click();
+        await page.locator('li[title="Save and Finish Editing"]').click();
+
+        // assert plot order persists after save
+        await expect(stackedPlotItem1).toHaveAttribute('aria-label', `Stacked Plot Item ${swgB.name}`);
+        await expect(stackedPlotItem2).toHaveAttribute('aria-label', `Stacked Plot Item ${swgC.name}`);
+        await expect(stackedPlotItem3).toHaveAttribute('aria-label', `Stacked Plot Item ${swgA.name}`);
+    });
+
     test('Selecting a child plot while in browse and edit modes shows its properties in the inspector', async ({ page }) => {
         await page.goto(stackedPlot.url);
 

--- a/src/plugins/plot/stackedPlot/StackedPlot.vue
+++ b/src/plugins/plot/stackedPlot/StackedPlot.vue
@@ -241,7 +241,7 @@ export default {
             let oldComposition = this.compositionObjects.slice();
 
             reorderPlan.forEach((reorder) => {
-                this.compositionObjects[reorder.newIndex] = oldComposition[reorder.oldIndex];
+                this.$set(this.compositionObjects, reorder.newIndex, oldComposition[reorder.oldIndex]);
             });
         },
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6158 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Fixes an issue where Vue wasn't detecting composition reorders on StackedPlots due to using Array assignment instead of `Vue.$set`. Adds an e2e test for Stacked Plot Item reorders.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
