### PR TITLE
chore: bump version to `2.1.6`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "2.1.6-SNAPSHOT",
+  "version": "2.1.6",
   "description": "The Open MCT core platform",
   "devDependencies": {
     "@babel/eslint-parser": "7.18.9",


### PR DESCRIPTION
Bump version to `2.1.6`