### PR TITLE
fix(#6391): refresh object composition before expanding a tree item

### DIFF
--- a/e2e/tests/functional/tree.e2e.spec.js
+++ b/e2e/tests/functional/tree.e2e.spec.js
@@ -53,6 +53,52 @@ test.describe('Main Tree', () => {
 
     });
 
+    test('Creating a child object on one tab and expanding its parent on the other shows the correct composition @2p', async ({ page, openmctConfig }) => {
+        test.info().annotations.push({
+            type: 'issue',
+            description: 'https://github.com/nasa/openmct/issues/6391'
+        });
+
+        const { myItemsFolderName } = openmctConfig;
+        const page2 = await page.context().newPage();
+
+        // Both pages: Go to baseURL
+        await Promise.all([
+            page.goto('./', { waitUntil: 'networkidle' }),
+            page2.goto('./', { waitUntil: 'networkidle' })
+        ]);
+
+        const page1Folder = await createDomainObjectWithDefaults(page, {
+            type: 'Folder'
+        });
+
+        await expandTreePaneItemByName(page2, myItemsFolderName);
+        await assertTreeItemIsVisible(page2, page1Folder.name);
+    });
+
+    test('Creating a child object on one tab and expanding its parent on the other shows the correct composition @couchdb @2p', async ({ page, openmctConfig }) => {
+        test.info().annotations.push({
+            type: 'issue',
+            description: 'https://github.com/nasa/openmct/issues/6391'
+        });
+
+        const { myItemsFolderName } = openmctConfig;
+        const page2 = await page.context().newPage();
+
+        // Both pages: Go to baseURL
+        await Promise.all([
+            page.goto('./', { waitUntil: 'networkidle' }),
+            page2.goto('./', { waitUntil: 'networkidle' })
+        ]);
+
+        const page1Folder = await createDomainObjectWithDefaults(page, {
+            type: 'Folder'
+        });
+
+        await expandTreePaneItemByName(page2, myItemsFolderName);
+        await assertTreeItemIsVisible(page2, page1Folder.name);
+    });
+
     test('Renaming an object reorders the tree @unstable', async ({ page, openmctConfig }) => {
         const { myItemsFolderName } = openmctConfig;
 

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -304,8 +304,7 @@ export default {
             }
 
             // will need to listen for root composition changes as well
-
-            this.treeItems = await this.loadAndBuildTreeItemsFor(root, []);
+            this.treeItems = await this.loadAndBuildTreeItemsFor(root.identifier, []);
         },
         treeItemAction(parentItem, type) {
             if (type === 'close') {
@@ -322,12 +321,12 @@ export default {
             this.$emit('tree-item-selection', item);
         },
         async openTreeItem(parentItem) {
-            let parentPath = parentItem.navigationPath;
+            const parentPath = parentItem.navigationPath;
 
             this.startItemLoad(parentPath);
             // pass in abort signal when functional
-            let childrenItems = await this.loadAndBuildTreeItemsFor(parentItem.object, parentItem.objectPath);
-            let parentIndex = this.treeItems.indexOf(parentItem);
+            const childrenItems = await this.loadAndBuildTreeItemsFor(parentItem.object.identifier, parentItem.objectPath);
+            const parentIndex = this.treeItems.indexOf(parentItem);
 
             // if it's not loading, it was aborted
             if (!this.isItemLoading(parentPath) || parentIndex === -1) {
@@ -558,8 +557,10 @@ export default {
             // determine if any part of the parent's path includes a key value of mine; aka My Items
             return Boolean(parentObjectPath.find(path => path.identifier.key === 'mine'));
         },
-        async loadAndBuildTreeItemsFor(domainObject, parentObjectPath, abortSignal) {
-            let collection = this.openmct.composition.get(domainObject);
+        async loadAndBuildTreeItemsFor(identifier, parentObjectPath, abortSignal) {
+            const domainObject = await this.openmct.objects.get(identifier);
+
+            const collection = this.openmct.composition.get(domainObject);
             let composition = await collection.load(abortSignal);
 
             if (SORT_MY_ITEMS_ALPH_ASC && this.isSortable(parentObjectPath)) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6391 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Refreshes the domain object's composition before expanding an item in the tree. This ensures that changes to composition made in another tab (or other instance if using non-localStorage persistence) will be reflected in the tree on expanding the tree item.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
