### PR TITLE
Set table to fixed layout and ellipted overflowing cells

### DIFF
--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -199,8 +199,11 @@ div.c-table {
 }
 
 .c-lad-table {
+    table-layout: fixed;
     th, td {
         width: 33%; // Needed to prevent size jumping as values dynamically update
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     td {


### PR DESCRIPTION
Closes VIPERGC-87

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Constrained the LAD tables to behave more like telemetry tables by fixing the table layout and by hiding overflows. This will prevent unwanted jiggling of columns with large character counts like those that return stringified arrays. 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
