### PR TITLE
test: add `@unstable` tag to tags test

### DIFF
--- a/e2e/tests/functional/plugins/plot/tagging.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/tagging.e2e.spec.js
@@ -190,7 +190,7 @@ test.describe('Plot Tagging', () => {
         await setFixedTimeMode(page);
     });
 
-    test('Tags work with Plot View of telemetry items', async ({ page }) => {
+    test('Tags work with Plot View of telemetry items @unstable', async ({ page }) => {
         await createDomainObjectWithDefaults(page, {
             type: "Sine Wave Generator"
         });


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Add unstable tag to tags test as it is flaky due to non-deterministic wait for plots to finish rendering

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
