### PR TITLE
Don't initialize the selected condition style when a view is loaded

### DIFF
--- a/src/plugins/condition/StyleRuleManager.js
+++ b/src/plugins/condition/StyleRuleManager.js
@@ -62,9 +62,9 @@ export default class StyleRuleManager extends EventEmitter {
     }
 
     initialize(styleConfiguration) {
+        // We don't set the selectedConditionId here because we want condition set computation to happen before we apply any selected style
         this.conditionSetIdentifier = styleConfiguration.conditionSetIdentifier;
         this.staticStyle = styleConfiguration.staticStyle;
-        this.selectedConditionId = styleConfiguration.selectedConditionId;
         this.defaultConditionId = styleConfiguration.defaultConditionId;
         this.updateConditionStylesMap(styleConfiguration.styles || []);
     }

--- a/src/plugins/condition/StyleRuleManager.js
+++ b/src/plugins/condition/StyleRuleManager.js
@@ -35,7 +35,9 @@ export default class StyleRuleManager extends EventEmitter {
         }
 
         if (styleConfiguration) {
-            this.initialize(styleConfiguration);
+            // We don't set the selectedConditionId here because we want condition set computation to happen before we apply any selected style
+            const styleConfigurationWithNoSelection = Object.assign(styleConfiguration, {selectedConditionId: ''});
+            this.initialize(styleConfigurationWithNoSelection);
             if (styleConfiguration.conditionSetIdentifier) {
                 this.openmct.time.on("bounds", this.refreshData);
                 this.subscribeToConditionSet();
@@ -57,13 +59,17 @@ export default class StyleRuleManager extends EventEmitter {
                 this.applySelectedConditionStyle();
             }
         } else if (this.conditionSetIdentifier) {
+            //reset the selected style and let the condition set output determine what it should be
+            this.selectedConditionId = undefined;
+            this.currentStyle = undefined;
+            this.updateDomainObjectStyle();
             this.subscribeToConditionSet();
         }
     }
 
     initialize(styleConfiguration) {
-        // We don't set the selectedConditionId here because we want condition set computation to happen before we apply any selected style
         this.conditionSetIdentifier = styleConfiguration.conditionSetIdentifier;
+        this.selectedConditionId = styleConfiguration.selectedConditionId;
         this.staticStyle = styleConfiguration.staticStyle;
         this.defaultConditionId = styleConfiguration.defaultConditionId;
         this.updateConditionStylesMap(styleConfiguration.styles || []);

--- a/src/plugins/condition/components/inspector/StylesView.vue
+++ b/src/plugins/condition/components/inspector/StylesView.vue
@@ -307,6 +307,8 @@ export default {
                     delete this.stopProvidingTelemetry;
                 }
             } else {
+                //reset the selectedConditionID so that the condition set computation can drive it.
+                this.applySelectedConditionStyle('');
                 this.subscribeToConditionSet();
             }
         },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6444 #5925 

### Describe your changes:
When going from Edit mode to view only mode, reset the selection so that only the computed condition set styling is applied.
Don't initialize the selected condition style when a view is loaded. Allow the condition set computed output to determine what the selected style should be.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
