### PR TITLE
fix(#6488): better determination of child tree items when collapsing a parent

### DIFF
--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -361,8 +361,8 @@ export default {
                 return;
             }
 
-            this.treeItems = this.treeItems.filter((treeItem) => {
-                const otherPath = treeItem.navigationPath;
+            this.treeItems = this.treeItems.filter((item) => {
+                const otherPath = item.navigationPath;
                 if (otherPath !== path
                     && this.isTreeItemAChildOf(otherPath, path)) {
                     this.destroyObserverByPath(otherPath);

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -965,7 +965,19 @@ export default {
             const childPathKeys = childNavigationPath.split('/');
             const parentPathKeys = parentNavigationPath.split('/');
 
-            return parentPathKeys.every((key) => childPathKeys.includes(key));
+            // If child path is shorter than the parent path,
+            // then it's not a child.
+            if (childPathKeys.length <= parentPathKeys.length) {
+                return false;
+            }
+
+            for (let i = 0; i < parentPathKeys.length; i++) {
+                if (childPathKeys[i] !== parentPathKeys[i]) {
+                    return false;
+                }
+            }
+
+            return true;
         },
         getElementStyleValue(el, style) {
             if (!el) {

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -965,8 +965,8 @@ export default {
             const childPathKeys = childNavigationPath.split('/');
             const parentPathKeys = parentNavigationPath.split('/');
 
-            // If child path is shorter than the parent path,
-            // then it's not a child.
+            // If child path is shorter than or same length as
+            // the parent path, then it's not a child.
             if (childPathKeys.length <= parentPathKeys.length) {
                 return false;
             }

--- a/src/ui/layout/mct-tree.vue
+++ b/src/ui/layout/mct-tree.vue
@@ -355,17 +355,18 @@ export default {
                 this.abortItemLoad(path);
             }
 
-            let pathIndex = this.openTreeItems.indexOf(path);
+            const pathIndex = this.openTreeItems.indexOf(path);
 
             if (pathIndex === -1) {
                 return;
             }
 
-            this.treeItems = this.treeItems.filter((checkItem) => {
-                if (checkItem.navigationPath !== path
-                    && checkItem.navigationPath.includes(path)) {
-                    this.destroyObserverByPath(checkItem.navigationPath);
-                    this.destroyMutableByPath(checkItem.navigationPath);
+            this.treeItems = this.treeItems.filter((treeItem) => {
+                const otherPath = treeItem.navigationPath;
+                if (otherPath !== path
+                    && this.isTreeItemAChildOf(otherPath, path)) {
+                    this.destroyObserverByPath(otherPath);
+                    this.destroyMutableByPath(otherPath);
 
                     return false;
                 }
@@ -959,6 +960,12 @@ export default {
         },
         isTreeItemPathOpen(path) {
             return this.openTreeItems.includes(path);
+        },
+        isTreeItemAChildOf(childNavigationPath, parentNavigationPath) {
+            const childPathKeys = childNavigationPath.split('/');
+            const parentPathKeys = parentNavigationPath.split('/');
+
+            return parentPathKeys.every((key) => childPathKeys.includes(key));
         },
         getElementStyleValue(el, style) {
             if (!el) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6488<!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
- Splits the parent and child navigationPaths into arrays of keystrings and then checks to ensure that every keystring in the parent path is included in the child path (is a subset)

- Array.includes is not only more performant than String.includes, but will do an exact match against array elements instead of checking for substrings.

This fixes the edge case of siblings being removed if their keystring includes a substring of the collapsing tree item's keystring (e.g.: collapsing `Science` folder removes sibling `ScienceSimData` folder)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
