### PR TITLE
[Build]Remove Node14LTS from supported versions and update our pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,11 +175,11 @@ workflows:
   overall-circleci-commit-status: #These jobs run on every commit
     jobs:
       - lint:
-          name: node14-lint
-          node-version: lts/fermium
+          name: node16-lint
+          node-version: lts/gallium
       - unit-test:
           name: node18-chrome
-          node-version: "18"
+          node-version: lts/hydrogen
       - e2e-test:
           name: e2e-stable
           node-version: lts/gallium
@@ -192,14 +192,11 @@ workflows:
   the-nightly: #These jobs do not run on PRs, but against master at night
     jobs:
       - unit-test:
-          name: node14-chrome-nightly
-          node-version: lts/fermium
-      - unit-test:
           name: node16-chrome-nightly
           node-version: lts/gallium
       - unit-test:
           name: node18-chrome
-          node-version: "18"
+          node-version: lts/hydrogen
       - npm-audit:
           node-version: lts/gallium
       - e2e-test:

--- a/.github/workflows/pr-platform.yml
+++ b/.github/workflows/pr-platform.yml
@@ -16,7 +16,6 @@ jobs:
           - macos-latest
           - windows-latest
         node_version:
-          - 14
           - 16
           - 18
         architecture:

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "url": "https://github.com/nasa/openmct.git"
   },
   "engines": {
-    "node": ">=16.19.1"
+    "node": ">=16.20.0"
   },
   "browserslist": [
     "Firefox ESR",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "karma-sourcemap-loader": "0.3.8",
     "karma-spec-reporter": "0.0.36",
     "karma-webpack": "5.0.0",
-    "kdbush": "^3.0.0",
+    "kdbush": "3.0.0",
     "location-bar": "3.0.1",
     "lodash": "4.17.21",
     "mini-css-extract-plugin": "2.7.5",
@@ -59,7 +59,7 @@
     "sass": "1.59.3",
     "sass-loader": "13.2.1",
     "sinon": "15.0.1",
-    "style-loader": "^3.3.1",
+    "style-loader": "3.3.2",
     "typescript": "4.9.5",
     "uuid": "9.0.0",
     "vue": "2.6.14",
@@ -107,7 +107,7 @@
     "url": "https://github.com/nasa/openmct.git"
   },
   "engines": {
-    "node": ">=14.19.1"
+    "node": ">=16.19.1"
   },
   "browserslist": [
     "Firefox ESR",


### PR DESCRIPTION
Closes #6528

### Describe your changes:
- [x] Pin minimum supported version
- [x] Driveby:pin dependencies
- [x] Remove all references of node14
- [x] use lts name instead of "18" alias

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
