### PR TITLE
[build] temporarily ignore typescript dependabot until we address it in #6483

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       - "pr:daveit"
       - "pr:platform"
     ignore:
+      #Temporarily Ignore until we address https://github.com/nasa/openmct/issues/6483
+      - dependency-name: "typescript"
       #We have to source the playwright container which is not detected by Dependabot
       - dependency-name: "@playwright/test"
       - dependency-name: "playwright-core"


### PR DESCRIPTION
Related to #6483 

### Describe your changes:
Typescript had a major 5.0 release and we should ignore it until we try to leverage the `satisfies` example in this ticket https://github.com/nasa/openmct/issues/6483

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
