### PR TITLE
Allow Restricted Notebooks to export text

### DIFF
--- a/e2e/baseFixtures.js
+++ b/e2e/baseFixtures.js
@@ -170,5 +170,20 @@ exports.test = base.test.extend({
         }
     }
 });
+
+/**
+ * Takes a readable stream and returns a string.
+ * @param {ReadableStream} readable - the readable stream
+ * @return {Promise<String>} the stringified stream
+ */
+exports.streamToString = async function (readable) {
+    let result = '';
+    for await (const chunk of readable) {
+        result += chunk;
+    }
+
+    return result;
+};
+
 exports.expect = expect;
 exports.waitForAnimations = waitForAnimations;

--- a/e2e/baseFixtures.js
+++ b/e2e/baseFixtures.js
@@ -171,19 +171,5 @@ exports.test = base.test.extend({
     }
 });
 
-/**
- * Takes a readable stream and returns a string.
- * @param {ReadableStream} readable - the readable stream
- * @return {Promise<String>} the stringified stream
- */
-exports.streamToString = async function (readable) {
-    let result = '';
-    for await (const chunk of readable) {
-        result += chunk;
-    }
-
-    return result;
-};
-
 exports.expect = expect;
 exports.waitForAnimations = waitForAnimations;

--- a/e2e/pluginFixtures.js
+++ b/e2e/pluginFixtures.js
@@ -150,3 +150,17 @@ exports.test = test.extend({
     }
 });
 exports.expect = expect;
+
+/**
+ * Takes a readable stream and returns a string.
+ * @param {ReadableStream} readable - the readable stream
+ * @return {Promise<String>} the stringified stream
+ */
+exports.streamToString = async function (readable) {
+    let result = '';
+    for await (const chunk of readable) {
+        result += chunk;
+    }
+
+    return result;
+};

--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -25,6 +25,7 @@ This test suite is dedicated to tests which verify the basic operations surround
 */
 
 const { test, expect } = require('../../../../pluginFixtures');
+const { streamToString } = require('../../../../baseFixtures');
 const { createDomainObjectWithDefaults } = require('../../../../appActions');
 const nbUtils = require('../../../../helper/notebookUtils');
 const path = require('path');
@@ -395,13 +396,4 @@ test.describe('Notebook entry tests', () => {
     test.fixme('can export all notebook entry metdata', async ({ page }) => {});
     test.fixme('can export all notebook tags', async ({ page }) => {});
     test.fixme('can export all notebook snapshots', async ({ page }) => {});
-
-    async function streamToString(readable) {
-        let result = '';
-        for await (const chunk of readable) {
-            result += chunk;
-        }
-
-        return result;
-    }
 });

--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -24,8 +24,7 @@
 This test suite is dedicated to tests which verify the basic operations surrounding Notebooks.
 */
 
-const { test, expect } = require('../../../../pluginFixtures');
-const { streamToString } = require('../../../../baseFixtures');
+const { test, expect, streamToString } = require('../../../../pluginFixtures');
 const { createDomainObjectWithDefaults } = require('../../../../appActions');
 const nbUtils = require('../../../../helper/notebookUtils');
 const path = require('path');

--- a/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
@@ -20,8 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-const { test, expect } = require('../../../../pluginFixtures');
-const { streamToString } = require('../../../../baseFixtures');
+const { test, expect, streamToString } = require('../../../../pluginFixtures');
 const { openObjectTreeContextMenu, createDomainObjectWithDefaults } = require('../../../../appActions');
 const path = require('path');
 const nbUtils = require('../../../../helper/notebookUtils');

--- a/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
@@ -21,6 +21,7 @@
  *****************************************************************************/
 
 const { test, expect } = require('../../../../pluginFixtures');
+const { streamToString } = require('../../../../baseFixtures');
 const { openObjectTreeContextMenu, createDomainObjectWithDefaults } = require('../../../../appActions');
 const path = require('path');
 const nbUtils = require('../../../../helper/notebookUtils');
@@ -167,6 +168,30 @@ test.describe('Restricted Notebook with a page locked and with an embed @addInit
         await expect(embedMenu).not.toContainText('Remove This Embed');
     });
 
+});
+
+test.describe('can export restricted notebook as text', () => {
+    test('basic functionality ', async ({ page }) => {
+
+        await nbUtils.enterTextEntry(page, `Foo bar entry`);
+        // Click on 3 Dot Menu
+        await page.locator('button[title="More options"]').click();
+        const downloadPromise = page.waitForEvent('download');
+
+        await page.getByRole('menuitem', { name: /Export Notebook as Text/ }).click();
+
+        await page.getByRole('button', { name: 'Save' }).click();
+        const download = await downloadPromise;
+        const readStream = await download.createReadStream();
+        const exportedText = await streamToString(readStream);
+        expect(exportedText).toContain('Foo bar entry');
+
+    });
+
+    test.fixme('can export multiple notebook entries as text ', async ({ page }) => {});
+    test.fixme('can export all notebook entry metdata', async ({ page }) => {});
+    test.fixme('can export all notebook tags', async ({ page }) => {});
+    test.fixme('can export all notebook snapshots', async ({ page }) => {});
 });
 
 /**

--- a/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
@@ -176,7 +176,6 @@ test.describe('can export restricted notebook as text', () => {
     });
 
     test('basic functionality ', async ({ page }) => {
-
         await nbUtils.enterTextEntry(page, `Foo bar entry`);
         // Click on 3 Dot Menu
         await page.locator('button[title="More options"]').click();

--- a/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/restrictedNotebook.e2e.spec.js
@@ -171,6 +171,10 @@ test.describe('Restricted Notebook with a page locked and with an embed @addInit
 });
 
 test.describe('can export restricted notebook as text', () => {
+    test.beforeEach(async ({ page }) => {
+        await startAndAddRestrictedNotebookObject(page);
+    });
+
     test('basic functionality ', async ({ page }) => {
 
         await nbUtils.enterTextEntry(page, `Foo bar entry`);

--- a/src/api/actions/ActionsAPI.js
+++ b/src/api/actions/ActionsAPI.js
@@ -31,7 +31,7 @@ class ActionsAPI extends EventEmitter {
         this._actionCollections = new WeakMap();
         this._openmct = openmct;
 
-        this._groupOrder = ['windowing', 'undefined', 'view', 'action', 'json'];
+        this._groupOrder = ['windowing', 'undefined', 'view', 'action', 'export'];
 
         this.register = this.register.bind(this);
         this.getActionsCollection = this.getActionsCollection.bind(this);

--- a/src/api/actions/ActionsAPI.js
+++ b/src/api/actions/ActionsAPI.js
@@ -31,7 +31,7 @@ class ActionsAPI extends EventEmitter {
         this._actionCollections = new WeakMap();
         this._openmct = openmct;
 
-        this._groupOrder = ['windowing', 'undefined', 'view', 'action', 'export'];
+        this._groupOrder = ['windowing', 'undefined', 'view', 'action', 'export', 'import'];
 
         this.register = this.register.bind(this);
         this.getActionsCollection = this.getActionsCollection.bind(this);

--- a/src/plugins/exportAsJSONAction/ExportAsJSONAction.js
+++ b/src/plugins/exportAsJSONAction/ExportAsJSONAction.js
@@ -32,7 +32,7 @@ export default class ExportAsJSONAction {
         this.key = 'export.JSON';
         this.description = '';
         this.cssClass = "icon-export";
-        this.group = "json";
+        this.group = "export";
         this.priority = 1;
 
         this.externalIdentifiers = [];

--- a/src/plugins/importFromJSONAction/ImportFromJSONAction.js
+++ b/src/plugins/importFromJSONAction/ImportFromJSONAction.js
@@ -29,7 +29,7 @@ export default class ImportAsJSONAction {
         this.key = 'import.JSON';
         this.description = '';
         this.cssClass = "icon-import";
-        this.group = "json";
+        this.group = "import";
         this.priority = 2;
 
         this.openmct = openmct;

--- a/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
+++ b/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
@@ -93,6 +93,11 @@ export default class ExportNotebookAsTextAction {
                 notebookAsText += `### ${page.name}\n\n`;
 
                 const notebookPageEntries = notebookEntries[section.id]?.[page.id];
+                if (!notebookPageEntries) {
+                    // blank page
+                    return;
+                }
+
                 notebookPageEntries.forEach(entry => {
                     if (changes.exportMetaData) {
                         const createdTimestamp = entry.createdOn;

--- a/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
+++ b/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
@@ -1,8 +1,8 @@
 import {saveAs} from 'saveAs';
 import Moment from 'moment';
-
 const UNKNOWN_USER = 'Unknown';
 const UNKNOWN_TIME = 'Unknown';
+const allowedTypes = ['Notebook', 'Notebook Shift Log'];
 
 export default class ExportNotebookAsTextAction {
 
@@ -58,7 +58,7 @@ export default class ExportNotebookAsTextAction {
         const domainObject = objectPath[0];
         const type = this.openmct.types.get(domainObject.type);
 
-        return type?.definition?.name === 'Notebook';
+        return allowedTypes.includes(type?.definition?.name);
     }
 
     async onSave(changes, objectPath) {
@@ -75,8 +75,8 @@ export default class ExportNotebookAsTextAction {
 
         if (changes.exportMetaData) {
             const createdTimestamp = domainObject.created;
-            const createdBy = domainObject.createdBy ?? UNKNOWN_USER;
-            const modifiedBy = domainObject.modifiedBy ?? UNKNOWN_USER;
+            const createdBy = this.getUserName(domainObject.createdBy);
+            const modifiedBy = this.getUserName(domainObject.modifiedBy);
             const modifiedTimestamp = domainObject.modified ?? domainObject.created;
             notebookAsText += `Created on ${this.formatTimeStamp(createdTimestamp)} by user ${createdBy}\n\n`;
             notebookAsText += `Updated on ${this.formatTimeStamp(modifiedTimestamp)} by user ${modifiedBy}\n\n`;
@@ -97,8 +97,8 @@ export default class ExportNotebookAsTextAction {
                 notebookPageEntries.forEach(entry => {
                     if (changes.exportMetaData) {
                         const createdTimestamp = entry.createdOn;
-                        const createdBy = entry.createdBy ?? UNKNOWN_USER;
-                        const modifiedBy = entry.modifiedBy ?? UNKNOWN_USER;
+                        const createdBy = this.getUserName(entry.createdBy);
+                        const modifiedBy = this.getUserName(entry.modifiedBy);
                         const modifiedTimestamp = entry.modified ?? entry.created;
                         notebookAsText += `Created on ${this.formatTimeStamp(createdTimestamp)} by user ${createdBy}\n\n`;
                         notebookAsText += `Updated on ${this.formatTimeStamp(modifiedTimestamp)} by user ${modifiedBy}\n\n`;
@@ -121,6 +121,14 @@ export default class ExportNotebookAsTextAction {
         const blob = new Blob([notebookAsText], {type: "text/markdown"});
         const fileName = domainObject.name + '.md';
         saveAs(blob, fileName);
+    }
+
+    getUserName(userId) {
+        if (userId && userId.length) {
+            return userId;
+        }
+
+        return UNKNOWN_USER;
     }
 
     async showForm(objectPath) {

--- a/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
+++ b/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
@@ -1,8 +1,9 @@
 import {saveAs} from 'saveAs';
 import Moment from 'moment';
+import {NOTEBOOK_TYPE, RESTRICTED_NOTEBOOK_TYPE} from '../notebook-constants';
 const UNKNOWN_USER = 'Unknown';
 const UNKNOWN_TIME = 'Unknown';
-const allowedTypes = ['Notebook', 'Notebook Shift Log'];
+const ALLOWED_TYPES = [NOTEBOOK_TYPE, RESTRICTED_NOTEBOOK_TYPE];
 
 export default class ExportNotebookAsTextAction {
 
@@ -56,9 +57,8 @@ export default class ExportNotebookAsTextAction {
 
     appliesTo(objectPath) {
         const domainObject = objectPath[0];
-        const type = this.openmct.types.get(domainObject.type);
 
-        return allowedTypes.includes(type?.definition?.name);
+        return ALLOWED_TYPES.includes(domainObject.type);
     }
 
     async onSave(changes, objectPath) {

--- a/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
+++ b/src/plugins/notebook/actions/ExportNotebookAsTextAction.js
@@ -12,10 +12,9 @@ export default class ExportNotebookAsTextAction {
 
         this.cssClass = 'icon-export';
         this.description = 'Exports notebook contents as a text file';
-        this.group = "action";
+        this.group = "export";
         this.key = 'exportNotebookAsText';
         this.name = 'Export Notebook as Text';
-        this.priority = 1;
     }
 
     invoke(objectPath) {

--- a/src/plugins/notebook/utils/notebook-entries.js
+++ b/src/plugins/notebook/utils/notebook-entries.js
@@ -2,7 +2,7 @@ import objectLink from '../../../ui/mixins/object-link';
 import { v4 as uuid } from 'uuid';
 
 async function getUsername(openmct) {
-    let username = '';
+    let username = null;
 
     if (openmct.user.hasProvider()) {
         const user = await openmct.user.getCurrentUser();


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6534 #6535

### Describe your changes:
Add Restricted Notebook to allowed objects for the action. Change initialization of `user` in Notebook to null. Check for blank strings when exporting markdown of Notebook.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
