### PR TITLE
Add safari as well as iOS safari browserlist check

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
     "not IE 11",
     "last 2 Chrome versions",
     "unreleased Chrome versions",
-    "ios_saf > 15",
-    "Safari > 15"
+    "ios_saf >= 16",
+    "Safari >= 16"
   ],
   "author": "",
   "license": "Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "d3-scale": "3.3.0",
     "d3-selection": "3.0.0",
     "eslint": "8.37.0",
-    "eslint-plugin-compat": "4.1.2",
+    "eslint-plugin-compat": "4.1.4",
     "eslint-plugin-playwright": "0.12.0",
     "eslint-plugin-vue": "9.10.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "6.12.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "not IE 11",
     "last 2 Chrome versions",
     "unreleased Chrome versions",
-    "ios_saf > 15"
+    "ios_saf > 15",
+    "Safari > 15"
   ],
   "author": "",
   "license": "Apache-2.0"


### PR DESCRIPTION
### Describe your changes:
We're not detecting Safari version in our es-plugin-compat package. Let's explicitly add Safari as well as iOS.
Fix logic to be >=16

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
