### PR TITLE
Only decrement and save if there is composition but no child object reference

### DIFF
--- a/src/plugins/exportAsJSONAction/ExportAsJSONAction.js
+++ b/src/plugins/exportAsJSONAction/ExportAsJSONAction.js
@@ -238,7 +238,9 @@ export default class ExportAsJSONAction {
                             }
                         }
                     });
-                    this._decrementCallsAndSave();
+                    if (!childObjectReferenceId) {
+                        this._decrementCallsAndSave();
+                    }
                 });
         } else if (!childObjectReferenceId) {
             this._decrementCallsAndSave();


### PR DESCRIPTION
Closes #6566

### Describe your changes:
Ensure that exporting works when: 
Exported objects have composition only
Exported objects have object references only
Exported objects have composition OR object references
Exported objects have composition AND object references
Exported objects have no composition and no object references

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
