### PR TITLE
Move Dependabot to weekly to reduce frequency of changes and reduce CI Bill

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"  
+      interval: "weekly"  
     open-pull-requests-limit: 10
     labels:
+      - "pr:daveit"
       - "pr:e2e"
       - "type:maintenance"
       - "dependencies"
-      - "pr:daveit"
       - "pr:platform"
     ignore:
       #We have to source the playwright container which is not detected by Dependabot
@@ -32,6 +32,6 @@ updates:
     schedule:
       interval: "daily"    
     labels:
+      - "pr:daveit"
       - "type:maintenance"
       - "dependencies"
-      - "pr:daveit"


### PR DESCRIPTION
### Describe your changes:
Runs dependabot weekly instead of hourly so that we can reduce the PRs which are using up our CI minutes

Driveby: Move the order of `pr:daveit` to see if the order affects whether PRCop is skipped

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
