### PR TITLE
fix: remove `pr:e2e:couchdb` label on run completion

### DIFF
--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -42,3 +42,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: html-test-results
+      - name: Remove 'e2e-couchdb' label if present
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e:couchdb') }}
+        run: |
+          curl --request DELETE \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/pr:e2e:couchdb \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -5,7 +5,6 @@ on:
     types:
       - labeled
       - opened
-      - synchronize
 jobs:
   e2e-couchdb:
     if: ${{ github.event.label.name == 'pr:e2e:couchdb' }} || ${{ github.event.action == 'opened' }}

--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -41,11 +41,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: html-test-results
-      - name: Remove e2e-couchdb label
+      - name: Remove pr:e2e:couchdb label (if present)
         if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e:couchdb') }}
         uses: octokit/request-action@v2.x
         with:
           route: DELETE /repos/{owner}/{repo}/issues/{pr_number}/labels/{name}
+          # These parameters will cause warnings due to
+          # a bug in the action runner. They can be ignored.
+          # https://github.com/octokit/request-action/issues/26
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -43,15 +43,14 @@ jobs:
           path: html-test-results
       - name: Remove pr:e2e:couchdb label (if present)
         if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e:couchdb') }}
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v6
         with:
-          route: DELETE /repos/{owner}/{repo}/issues/{pr_number}/labels/{name}
-          # These parameters will cause warnings due to
-          # a bug in the action runner. They can be ignored.
-          # https://github.com/octokit/request-action/issues/26
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          pr_number: ${{ github.event.pull_request.number }}
-          name: 'pr:e2e:couchdb'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const labelToRemove = 'pr:e2e:couchdb';
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: number,
+              name: labelToRemove
+            });

--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -41,9 +41,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: html-test-results
-      - name: Remove 'e2e-couchdb' label if present
+      - name: Remove e2e-couchdb label
         if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e:couchdb') }}
-        run: |
-          curl --request DELETE \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/pr:e2e:couchdb \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/{owner}/{repo}/issues/{pr_number}/labels/{name}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          pr_number: ${{ github.event.pull_request.number }}
+          name: 'pr:e2e:couchdb'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -5,6 +5,7 @@ on:
     types:
       - labeled
       - opened
+      - synchronize
 jobs:
   e2e-couchdb:
     if: ${{ github.event.label.name == 'pr:e2e:couchdb' }} || ${{ github.event.action == 'opened' }}

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -68,15 +68,14 @@ jobs:
             })
       - name: Remove pr:e2e label (if present)
         if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e') }}
-        uses: octokit/request-action@v2.x
+        uses: actions/github-script@v6
         with:
-          route: DELETE /repos/{owner}/{repo}/issues/{pr_number}/labels/{name}
-          # These parameters will cause warnings due to
-          # a bug in the action runner. They can be ignored.
-          # https://github.com/octokit/request-action/issues/26
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          pr_number: ${{ github.event.pull_request.number }}
-          name: 'pr:e2e'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const labelToRemove = 'pr:e2e';
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: number,
+              name: labelToRemove
+            });

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -66,3 +66,17 @@ jobs:
               repo: "openmct",
               body: 'Failure ❌ ! Build artifacts are here: https://github.com/nasa/openmct/actions/runs/' + context.runId
             })
+      - name: Remove pr:e2e label (if present)
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'pr:e2e') }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: DELETE /repos/{owner}/{repo}/issues/{pr_number}/labels/{name}
+          # These parameters will cause warnings due to
+          # a bug in the action runner. They can be ignored.
+          # https://github.com/octokit/request-action/issues/26
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          pr_number: ${{ github.event.pull_request.number }}
+          name: 'pr:e2e'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
No related issue.<!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

Updates the e2e-couchdb GHA to remove the `pr:e2e:couchdb` label on run completion (if label is present).

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
