### PR TITLE
fix: Gantt Chart displays draft status of Plan in composition

### DIFF
--- a/e2e/tests/functional/planning/ganttChart.e2e.spec.js
+++ b/e2e/tests/functional/planning/ganttChart.e2e.spec.js
@@ -99,5 +99,5 @@ test.describe("Gantt Chart", () => {
 
         // Assert that the Plan's status is displayed as draft
         expect(await page.locator('.u-contents.c-swimlane.is-status--draft').count()).toBe(Object.keys(testPlan1).length);
-    }); 
+    });
 });

--- a/e2e/tests/visual/planning.visual.spec.js
+++ b/e2e/tests/visual/planning.visual.spec.js
@@ -26,14 +26,16 @@ const { createDomainObjectWithDefaults, createPlanFromJSON } = require('../../ap
 const percySnapshot = require('@percy/playwright');
 const examplePlanSmall = require('../../test-data/examplePlans/ExamplePlan_Small2.json');
 
-const snapshotScope = '.c-object-view';
+const snapshotScope = '.l-shell__pane-main .l-pane__contents';
 
 test.describe('Visual - Planning', () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto('./', { waitUntil: 'networkidle' });
+        await page.goto('./', { waitUntil: 'domcontentloaded' });
     });
+
     test('Plan View', async ({ page, theme }) => {
         const plan = await createPlanFromJSON(page, {
+            name: 'Plan Visual Test',
             json: examplePlanSmall
         });
 
@@ -42,9 +44,26 @@ test.describe('Visual - Planning', () => {
             scope: snapshotScope
         });
     });
+
+    test('Plan View w/ draft status', async ({ page, theme }) => {
+        const plan = await createPlanFromJSON(page, {
+            name: 'Plan Visual Test (Draft)',
+            json: examplePlanSmall
+        });
+        await page.goto('./#/browse/mine');
+
+        await setDraftStatusForPlan(page, plan);
+
+        await setBoundsToSpanAllActivities(page, examplePlanSmall, plan.url);
+        await percySnapshot(page, `Plan View w/ draft status (theme: ${theme})`, {
+            scope: snapshotScope
+        });
+    });
+
     test('Gantt Chart View', async ({ page, theme }) => {
         const ganttChart = await createDomainObjectWithDefaults(page, {
-            type: 'Gantt Chart'
+            type: 'Gantt Chart',
+            name: 'Gantt Chart Visual Test'
         });
         await createPlanFromJSON(page, {
             json: examplePlanSmall,
@@ -55,4 +74,35 @@ test.describe('Visual - Planning', () => {
             scope: snapshotScope
         });
     });
+
+    test('Gantt Chart View w/ draft status', async ({ page, theme }) => {
+        const ganttChart = await createDomainObjectWithDefaults(page, {
+            type: 'Gantt Chart',
+            name: 'Gantt Chart Visual Test (Draft)'
+        });
+        const plan = await createPlanFromJSON(page, {
+            json: examplePlanSmall,
+            parent: ganttChart.uuid
+        });
+
+        await setDraftStatusForPlan(page, plan);
+
+        await page.goto('./#/browse/mine');
+
+        await setBoundsToSpanAllActivities(page, examplePlanSmall, ganttChart.url);
+        await percySnapshot(page, `Gantt Chart View w/ draft status (theme: ${theme})`, {
+            scope: snapshotScope
+        });
+    });
 });
+
+/**
+ * Uses the Open MCT API to set the status of a plan to 'draft'.
+ * @param {import('@playwright/test').Page} page
+ * @param {import('../../appActions').CreatedObjectInfo} plan
+ */
+async function setDraftStatusForPlan(page, plan) {
+    await page.evaluate(async (planObject) => {
+        await window.openmct.status.set(planObject.uuid, 'draft');
+    }, plan);
+}

--- a/src/plugins/plan/components/Plan.vue
+++ b/src/plugins/plan/components/Plan.vue
@@ -211,6 +211,7 @@ export default {
                             this.removeFromComposition(this.planObject);
                             this.planObject = domainObject;
                             this.planData = getValidatedData(domainObject);
+                            this.setStatus(this.openmct.status.get(domainObject.identifier));
                             this.setScaleAndGenerateActivities();
                             dialog.dismiss();
                         }
@@ -232,6 +233,7 @@ export default {
                 this.planObject = domainObject;
                 this.swimlaneVisibility = this.configuration.swimlaneVisibility;
                 this.planData = getValidatedData(domainObject);
+                this.setStatus(this.openmct.status.get(domainObject.identifier));
                 this.setScaleAndGenerateActivities();
             }
         },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6641 VIPEROMCT-303 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
The Gantt Chart view was not respecting / displaying the draft status of a Plan if it was in its composition. This updates the logic to set the status when a domainObject is added in composition.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
