### PR TITLE
chore: bump version to `2.2.4-SNAPSHOT`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "2.2.3-SNAPSHOT",
+  "version": "2.2.4-SNAPSHOT",
   "description": "The Open MCT core platform",
   "devDependencies": {
     "@babel/eslint-parser": "7.19.1",


### PR DESCRIPTION
Title says all