### PR TITLE
fix: unlisten to annotation event beforeDestroy

### DIFF
--- a/src/plugins/inspectorViews/annotations/AnnotationsInspectorView.vue
+++ b/src/plugins/inspectorViews/annotations/AnnotationsInspectorView.vue
@@ -126,8 +126,9 @@ export default {
     this.openmct.annotation.on('targetDomainObjectAnnotated', this.loadAnnotationForTargetObject);
     this.openmct.selection.on('change', this.updateSelection);
     await this.updateSelection(this.openmct.selection.get());
-  },
-  beforeDestroy() {
+},
+beforeDestroy() {
+    this.openmct.annotation.off('targetDomainObjectAnnotated', this.loadAnnotationForTargetObject);
     this.openmct.selection.off('change', this.updateSelection);
     const unobserveEntryFunctions = Object.values(this.unobserveEntries);
     unobserveEntryFunctions.forEach((unobserveEntry) => {

--- a/src/plugins/inspectorViews/annotations/AnnotationsInspectorView.vue
+++ b/src/plugins/inspectorViews/annotations/AnnotationsInspectorView.vue
@@ -126,8 +126,8 @@ export default {
     this.openmct.annotation.on('targetDomainObjectAnnotated', this.loadAnnotationForTargetObject);
     this.openmct.selection.on('change', this.updateSelection);
     await this.updateSelection(this.openmct.selection.get());
-},
-beforeDestroy() {
+  },
+  beforeDestroy() {
     this.openmct.annotation.off('targetDomainObjectAnnotated', this.loadAnnotationForTargetObject);
     this.openmct.selection.off('change', this.updateSelection);
     const unobserveEntryFunctions = Object.values(this.unobserveEntries);


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6689 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Stops listeners from stacking up when clicking through to view multiple annotations.

TODO: CouchDB / YAMCS quickstart regression test 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
