### PR TITLE
chore: bump version to `2.2.5-SNAPSHOT`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmct",
-  "version": "2.2.4-SNAPSHOT",
+  "version": "2.2.5-SNAPSHOT",
   "description": "The Open MCT core platform",
   "devDependencies": {
     "@babel/eslint-parser": "7.21.8",


### PR DESCRIPTION
Version bump, title says all