### PR TITLE
[Build] Update package engine version range to block on node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "url": "https://github.com/nasa/openmct.git"
   },
   "engines": {
-    "node": ">=16.19.1"
+    "node": ">=16.19.1 <20"
   },
   "browserslist": [
     "Firefox ESR",


### PR DESCRIPTION
Buffer in place until we can formally support https://github.com/nasa/openmct/issues/6732

### Describe your changes:
`[node_modules/@achrinza/node-ipc](https://github.com/achrinza/node-ipc/issues/45)` has a version range up to 20 and is failing builds for folks using 20. We should be more explicit in our deps and tackle node20 holistically.

Until then, we should be preventing installs on node20.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
