### PR TITLE
Fix CouchDBSearchFolder plugin to have unique identifiers.

### DIFF
--- a/src/plugins/CouchDBSearchFolder/plugin.js
+++ b/src/plugins/CouchDBSearchFolder/plugin.js
@@ -1,15 +1,19 @@
+import { v4 as uuid } from 'uuid';
+
 export default function (folderName, couchPlugin, searchFilter) {
   return function install(openmct) {
     const couchProvider = couchPlugin.couchProvider;
+    const couchSearchId = uuid();
+    const couchSearchName = `couch-search-${couchSearchId}`;
 
     openmct.objects.addRoot({
-      namespace: 'couch-search',
-      key: 'couch-search'
+      namespace: couchSearchName,
+      key: couchSearchName
     });
 
-    openmct.objects.addProvider('couch-search', {
+    openmct.objects.addProvider(couchSearchName, {
       get(identifier) {
-        if (identifier.key !== 'couch-search') {
+        if (identifier.key !== couchSearchName) {
           return undefined;
         } else {
           return Promise.resolve({
@@ -25,8 +29,8 @@ export default function (folderName, couchPlugin, searchFilter) {
     openmct.composition.addProvider({
       appliesTo(domainObject) {
         return (
-          domainObject.identifier.namespace === 'couch-search' &&
-          domainObject.identifier.key === 'couch-search'
+          domainObject.identifier.namespace === couchSearchName &&
+          domainObject.identifier.key === couchSearchName
         );
       },
       load() {

--- a/src/plugins/webPage/WebPageViewProvider.js
+++ b/src/plugins/webPage/WebPageViewProvider.js
@@ -29,7 +29,7 @@ export default function WebPage(openmct) {
     name: 'Web Page',
     cssClass: 'icon-page',
     canView: function (domainObject) {
-      return domainObject.type === 'webPage';
+      return domainObject.type === 'webPage' || domainObject.type === 'ttt-report';
     },
     view: function (domainObject) {
       let component;


### PR DESCRIPTION
Closes VIPEROMCT-62

### Describe your changes:
When we need multiple CouchDBSearchFolders, a hardcoded root was being added and modified causing issues.
This change uses a unique key for each instance of the CouchDBSearchFolder.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
