### PR TITLE
Fix couchdbsearchfolder and allow clocky reports

### DIFF
--- a/src/plugins/CouchDBSearchFolder/plugin.js
+++ b/src/plugins/CouchDBSearchFolder/plugin.js
@@ -1,9 +1,10 @@
-import { v4 as uuid } from 'uuid';
-
 export default function (folderName, couchPlugin, searchFilter) {
+  const DEFAULT_NAME = 'CouchDB Documents';
+
   return function install(openmct) {
     const couchProvider = couchPlugin.couchProvider;
-    const couchSearchId = uuid();
+    //replace any non-letter/non-number with a hyphen
+    const couchSearchId = (folderName || DEFAULT_NAME).replace(/[^a-zA-Z0-9]/g, '-');
     const couchSearchName = `couch-search-${couchSearchId}`;
 
     openmct.objects.addRoot({
@@ -19,7 +20,7 @@ export default function (folderName, couchPlugin, searchFilter) {
           return Promise.resolve({
             identifier,
             type: 'folder',
-            name: folderName || 'CouchDB Documents',
+            name: folderName || DEFAULT_NAME,
             location: 'ROOT'
           });
         }

--- a/src/plugins/CouchDBSearchFolder/plugin.js
+++ b/src/plugins/CouchDBSearchFolder/plugin.js
@@ -1,15 +1,19 @@
+import { v4 as uuid } from 'uuid';
+
 export default function (folderName, couchPlugin, searchFilter) {
   return function install(openmct) {
     const couchProvider = couchPlugin.couchProvider;
+    const couchSearchId = uuid();
+    const couchSearchName = `couch-search-${couchSearchId}`;
 
     openmct.objects.addRoot({
-      namespace: 'couch-search',
-      key: 'couch-search'
+      namespace: couchSearchName,
+      key: couchSearchName
     });
 
-    openmct.objects.addProvider('couch-search', {
+    openmct.objects.addProvider(couchSearchName, {
       get(identifier) {
-        if (identifier.key !== 'couch-search') {
+        if (identifier.key !== couchSearchName) {
           return undefined;
         } else {
           return Promise.resolve({
@@ -25,8 +29,8 @@ export default function (folderName, couchPlugin, searchFilter) {
     openmct.composition.addProvider({
       appliesTo(domainObject) {
         return (
-          domainObject.identifier.namespace === 'couch-search' &&
-          domainObject.identifier.key === 'couch-search'
+          domainObject.identifier.namespace === couchSearchName &&
+          domainObject.identifier.key === couchSearchName
         );
       },
       load() {

--- a/src/plugins/CouchDBSearchFolder/pluginSpec.js
+++ b/src/plugins/CouchDBSearchFolder/pluginSpec.js
@@ -23,10 +23,10 @@
 import { createOpenMct, resetApplicationState } from 'utils/testing';
 import CouchDBSearchFolderPlugin from './plugin';
 
-describe('the plugin', function () {
+fdescribe('the plugin', function () {
   let identifier = {
-    namespace: 'couch-search',
-    key: 'couch-search'
+    namespace: 'couch-search-CouchDB-Documents',
+    key: 'couch-search-CouchDB-Documents'
   };
   let testPath = '/test/db';
   let openmct;

--- a/src/plugins/CouchDBSearchFolder/pluginSpec.js
+++ b/src/plugins/CouchDBSearchFolder/pluginSpec.js
@@ -23,7 +23,7 @@
 import { createOpenMct, resetApplicationState } from 'utils/testing';
 import CouchDBSearchFolderPlugin from './plugin';
 
-fdescribe('the plugin', function () {
+describe('the plugin', function () {
   let identifier = {
     namespace: 'couch-search-CouchDB-Documents',
     key: 'couch-search-CouchDB-Documents'

--- a/src/plugins/viewLargeAction/viewLargeAction.js
+++ b/src/plugins/viewLargeAction/viewLargeAction.js
@@ -54,7 +54,7 @@ export default class ViewLargeAction {
 
     return (
       childElement &&
-      !childElement.classList.contains('js-main-container') &&
+      !childElement?.classList.contains('js-main-container') &&
       !this.openmct.router.isNavigatedObject(objectPath)
     );
   }

--- a/src/plugins/webPage/WebPageViewProvider.js
+++ b/src/plugins/webPage/WebPageViewProvider.js
@@ -29,7 +29,7 @@ export default function WebPage(openmct) {
     name: 'Web Page',
     cssClass: 'icon-page',
     canView: function (domainObject) {
-      return domainObject.type === 'webPage';
+      return domainObject.type === 'webPage' || domainObject.type === 'ttt-report';
     },
     view: function (domainObject) {
       let component;

--- a/src/plugins/webPage/WebPageViewProvider.js
+++ b/src/plugins/webPage/WebPageViewProvider.js
@@ -29,7 +29,7 @@ export default function WebPage(openmct) {
     name: 'Web Page',
     cssClass: 'icon-page',
     canView: function (domainObject) {
-      return domainObject.type === 'webPage' || domainObject.type === 'ttt-report';
+      return domainObject.type === 'webPage';
     },
     view: function (domainObject) {
       let component;

--- a/src/ui/components/components.js
+++ b/src/ui/components/components.js
@@ -23,9 +23,11 @@
 import ObjectView from './ObjectView.vue';
 import StackedPlot from '../../plugins/plot/stackedPlot/StackedPlot.vue';
 import Plot from '../../plugins/plot/Plot.vue';
+import WebPage from '../../plugins/webPage/components/WebPage.vue';
 
 export default {
   ObjectView,
   StackedPlot,
-  Plot
+  Plot,
+  WebPage
 };


### PR DESCRIPTION
Closes VIPEROMCT-62 and #6794

### Describe your changes:
Adds unique identifiers for couchdbsearchfolder since multiple instances of the folders was overwriting the original with a hardcoded name

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
