### PR TITLE
Batch Couch DB create calls

### DIFF
--- a/src/plugins/persistence/couch/CouchObjectProvider.js
+++ b/src/plugins/persistence/couch/CouchObjectProvider.js
@@ -24,6 +24,7 @@ import CouchDocument from './CouchDocument';
 import CouchObjectQueue from './CouchObjectQueue';
 import { PENDING, CONNECTED, DISCONNECTED, UNKNOWN } from './CouchStatusIndicator';
 import { isNotebookOrAnnotationType } from '../../notebook/notebook-constants.js';
+import _ from 'lodash';
 
 const REV = '_rev';
 const ID = '_id';
@@ -42,6 +43,8 @@ class CouchObjectProvider {
     this.batchIds = [];
     this.onEventMessage = this.onEventMessage.bind(this);
     this.onEventError = this.onEventError.bind(this);
+    this.flushPersistenceQueue = _.debounce(this.flushPersistenceQueue.bind(this));
+    this.persistenceQueue = [];
   }
 
   /**
@@ -668,9 +671,12 @@ class CouchObjectProvider {
     if (!this.objectQueue[key].pending) {
       this.objectQueue[key].pending = true;
       const queued = this.objectQueue[key].dequeue();
-      let document = new CouchDocument(key, queued.model);
-      document.metadata.created = Date.now();
-      this.request(key, 'PUT', document)
+      let couchDocument = new CouchDocument(key, queued.model);
+      couchDocument.metadata.created = Date.now();
+      this.#enqueueForPersistence({
+        key,
+        document: couchDocument
+      })
         .then((response) => {
           this.#checkResponse(response, queued.intermediateResponse, key);
         })
@@ -681,6 +687,42 @@ class CouchObjectProvider {
     }
 
     return intermediateResponse.promise;
+  }
+
+  #enqueueForPersistence({ key, document }) {
+    return new Promise((resolve, reject) => {
+      this.persistenceQueue.push({
+        key,
+        document,
+        resolve,
+        reject
+      });
+      this.flushPersistenceQueue();
+    });
+  }
+
+  async flushPersistenceQueue() {
+    if (this.persistenceQueue.length > 1) {
+      const batch = {
+        docs: this.persistenceQueue.map((queued) => queued.document)
+      };
+      const response = await this.request('_bulk_docs', 'POST', batch);
+      response.forEach((responseMetadatum) => {
+        const queued = this.persistenceQueue.find(
+          (queuedMetadatum) => queuedMetadatum.key === responseMetadatum.id
+        );
+        if (responseMetadatum.ok) {
+          queued.resolve(responseMetadatum);
+        } else {
+          queued.reject(responseMetadatum);
+        }
+      });
+    } else if (this.persistenceQueue.length === 1) {
+      const { key, document, resolve, reject } = this.persistenceQueue[0];
+
+      this.request(key, 'PUT', document).then(resolve).catch(reject);
+    }
+    this.persistenceQueue = [];
   }
 
   /**


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes VIPEROMCT-345

### Describe your changes:

Implements persistence batching via debouncing for the Couch `create` action which in the case of Import From JSON can result in a very large number of POST requests to the Couch server.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
