### PR TITLE
[CI] Update github workflows to run nightly and on merge into master

### DIFF
--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   e2e-couchdb:
-    if: github.event.label.name == 'pr:e2e:couchdb' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
+    if: contains(github.event.pull_request.labels.*.name, 'pr:e2e:couchdb') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -1,13 +1,17 @@
 name: 'e2e-couchdb'
 on:
+  push:
+    branches: master
   workflow_dispatch:
   pull_request:
     types:
       - labeled
       - opened
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   e2e-couchdb:
-    if: github.event.label.name == 'pr:e2e:couchdb' || github.event.action == 'opened' && github.actor == 'dependabot[bot]'
+    if: github.event.label.name == 'pr:e2e:couchdb' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -1,13 +1,17 @@
 name: 'e2e-pr'
 on:
+  push:
+    branches: master
   workflow_dispatch:
   pull_request:
     types:
       - labeled
       - opened
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   e2e-full:
-    if: github.event.label.name == 'pr:e2e' || github.event.action == 'opened' && github.actor == 'dependabot[bot]'
+    if: github.event.label.name == 'pr:e2e' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   e2e-full:
-    if: github.event.label.name == 'pr:e2e' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
+    if: contains(github.event.pull_request.labels.*.name, 'pr:e2e') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/pr-platform.yml
+++ b/.github/workflows/pr-platform.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   pr-platform:
-    if: github.event.label.name == 'pr:platform' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
+    if: contains(github.event.pull_request.labels.*.name, 'pr:platform') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/pr-platform.yml
+++ b/.github/workflows/pr-platform.yml
@@ -1,14 +1,17 @@
 name: 'pr-platform'
 on:
+  push:
+    branches: master
   workflow_dispatch:
   pull_request:
     types:
       - labeled
       - opened
-
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   pr-platform:
-    if: github.event.label.name == 'pr:platform' || github.event.action == 'opened' && github.actor == 'dependabot[bot]'
+    if: github.event.label.name == 'pr:platform' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'opened'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/e2e/playwright-ci.config.js
+++ b/e2e/playwright-ci.config.js
@@ -77,7 +77,6 @@ const config = {
       }
     ],
     ['junit', { outputFile: '../test-results/results.xml' }],
-    ['github'],
     ['@deploysentinel/playwright']
   ]
 };


### PR DESCRIPTION
### Describe your changes:
Our couchdb tests have been failing and changes have been merged into master onto of the failures. This PR:
- Adds couchdb to nightly test
- Updates the trigger logic to run more consistently
- Run on merge into master

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
