### PR TITLE
docs: fix typos

### DIFF
--- a/API.md
+++ b/API.md
@@ -635,7 +635,7 @@ openmct.telemetry.addFormat({
 
 A single telemetry point is considered a Datum, and is represented by a standard
 javascript object.  Realtime subscriptions (obtained via **subscribe**) will
-invoke the supplied callback once for each telemetry datum recieved.  Telemetry
+invoke the supplied callback once for each telemetry datum received.  Telemetry
 requests (obtained via **request**) will return a promise for an array of
 telemetry datums.
 
@@ -660,7 +660,7 @@ section.
 Limit evaluators allow a telemetry integrator to define which limits exist for a
 telemetry endpoint and how limits should be applied to telemetry from a given domain object.
 
-A limit evaluator can implement the `evalute` method which is used to define how limits
+A limit evaluator can implement the `evaluate` method which is used to define how limits
 should be applied to telemetry and the `getLimits` method which is used to specify
 what the limit values are for different limit levels.
 
@@ -1018,7 +1018,7 @@ const ONE_MINUTE = 60 * 1000;
 
 openmct.install(openmct.plugins.Conductor({
     menuOptions: [
-        // 'Fixed' bounds mode configuation for the UTCTimeSystem
+        // 'Fixed' bounds mode configuration for the UTCTimeSystem
         {
             timeSystem: 'utc',
             bounds: {start: Date.now() - 30 * ONE_MINUTE, end: Date.now()},

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To run the performance tests:
 The test suite is configured to all tests localed in `e2e/tests/` ending in `*.e2e.spec.js`. For more about the e2e test suite, please see the [README](./e2e/README.md)
 
 ### Security Tests
-Each commit is analyzed for known security vulnerabilities using [CodeQL](https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-javascript/). The list of CWE coverage items is avaiable in the [CodeQL docs](https://codeql.github.com/codeql-query-help/javascript-cwe/). The CodeQL workflow is specified in the [CodeQL analysis file](./.github/workflows/codeql-analysis.yml) and the custom [CodeQL config](./.github/codeql/codeql-config.yml).
+Each commit is analyzed for known security vulnerabilities using [CodeQL](https://codeql.github.com/docs/codeql-language-guides/codeql-library-for-javascript/). The list of CWE coverage items is available in the [CodeQL docs](https://codeql.github.com/codeql-query-help/javascript-cwe/). The CodeQL workflow is specified in the [CodeQL analysis file](./.github/workflows/codeql-analysis.yml) and the custom [CodeQL config](./.github/codeql/codeql-config.yml).
 
 ### Test Reporting and Code Coverage
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -101,7 +101,7 @@ npx playwright test --config=e2e/playwright-ci.config.js --project=chrome --grep
 
 ### Updating Snapshots
 
-When the `@snapshot` tests fail, they will need to be evaluated to determine if the failure is an acceptable and desireable or an unintended regression.
+When the `@snapshot` tests fail, they will need to be evaluated to determine if the failure is an acceptable and desirable or an unintended regression.
 
 To compare a snapshot, run a test and open the html report with the 'Expected' vs 'Actual' screenshot. If the actual screenshot is preferred, then the source-controlled 'Expected' snapshots will need to be updated with the following scripts.
 
@@ -137,7 +137,7 @@ These tests are expected to become blocking and gating with assertions as we ext
 
 ### File Structure
 
-Our file structure follows the type of type of testing being excercised at the e2e layer and files containing test suites which matcher application behavior or our `src` and `example` layout. This area is not well refined as we figure out what works best for closed source and downstream projects. This may change altogether if we move `e2e` to it's own npm package.
+Our file structure follows the type of type of testing being exercised at the e2e layer and files containing test suites which matcher application behavior or our `src` and `example` layout. This area is not well refined as we figure out what works best for closed source and downstream projects. This may change altogether if we move `e2e` to it's own npm package.
 
 |File Path|Description|
 |:-:|-|


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

3 typos in `API.md`
1 typo in `README.md`
2 typos in `e2e/README.md`


Best!