### PR TITLE
Use the current timestamp from the global clock

### DIFF
--- a/e2e/tests/functional/planning/timelist.e2e.spec.js
+++ b/e2e/tests/functional/planning/timelist.e2e.spec.js
@@ -98,6 +98,8 @@ test.describe('Time List', () => {
       const startBound = testPlan.TEST_GROUP[0].start;
       const endBound = testPlan.TEST_GROUP[testPlan.TEST_GROUP.length - 1].end;
 
+      await page.goto(timelist.url);
+
       // Switch to fixed time mode with all plan events within the bounds
       await page.goto(
         `${timelist.url}?tc.mode=fixed&tc.startBound=${startBound}&tc.endBound=${endBound}&tc.timeSystem=utc&view=timelist.view`

--- a/src/plugins/timelist/Timelist.vue
+++ b/src/plugins/timelist/Timelist.vue
@@ -38,6 +38,7 @@ import { getPreciseDuration } from '../../utils/duration';
 import { SORT_ORDER_OPTIONS } from './constants';
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
+import { TIME_CONTEXT_EVENTS } from '../../api/time/constants';
 
 const SCROLL_TIMEOUT = 10000;
 
@@ -114,10 +115,8 @@ export default {
   },
   mounted() {
     this.isEditing = this.openmct.editor.isEditing();
-    this.timestamp = this.openmct.time.isRealTime()
-      ? this.openmct.time.now()
-      : this.openmct.time.bounds().start;
-    this.openmct.time.on('clock', this.setViewFromClock);
+    this.timestamp = this.openmct.time.now();
+    this.openmct.time.on(TIME_CONTEXT_EVENTS.modeChanged, this.setFixedTime);
 
     this.getPlanDataAndSetConfig(this.domainObject);
 
@@ -138,7 +137,7 @@ export default {
     this.status = this.openmct.status.get(this.domainObject.identifier);
 
     this.updateTimestamp = _.throttle(this.updateTimestamp, 1000);
-    this.openmct.time.on('bounds', this.updateTimestamp);
+    this.openmct.time.on('tick', this.updateTimestamp);
     this.openmct.editor.on('isEditing', this.setEditState);
 
     this.deferAutoScroll = _.debounce(this.deferAutoScroll, 500);
@@ -150,7 +149,7 @@ export default {
       this.composition.load();
     }
 
-    this.setViewFromClock(this.openmct.time.getClock());
+    this.setFixedTime(this.openmct.time.getMode());
   },
   beforeUnmount() {
     if (this.unlisten) {
@@ -166,8 +165,8 @@ export default {
     }
 
     this.openmct.editor.off('isEditing', this.setEditState);
-    this.openmct.time.off('bounds', this.updateTimestamp);
-    this.openmct.time.off('clock', this.setViewFromClock);
+    this.openmct.time.off('tick', this.updateTimestamp);
+    this.openmct.time.off(TIME_CONTEXT_EVENTS.modeChanged, this.setFixedTime);
 
     this.$el.parentElement?.removeEventListener('scroll', this.deferAutoScroll, true);
     if (this.clearAutoScrollDisabledTimer) {
@@ -202,22 +201,15 @@ export default {
         this.listActivities();
       }
     },
-    updateTimestamp(bounds, isTick) {
-      if (isTick === true && this.openmct.time.isRealTime()) {
-        this.updateTimeStampAndListActivities(this.openmct.time.now());
-      } else if (isTick === false && !this.openmct.time.isRealTime()) {
-        // set the start time for fixed time using the selected bounds start
-        this.updateTimeStampAndListActivities(bounds.start);
-      }
+    updateTimestamp(timestamp) {
+      //The clock never stops ticking
+      this.updateTimeStampAndListActivities(timestamp);
     },
-    setViewFromClock(newClock) {
+    setFixedTime() {
       this.filterValue = this.domainObject.configuration.filter;
       this.isFixedTime = !this.openmct.time.isRealTime();
       if (this.isFixedTime) {
         this.hideAll = false;
-        this.updateTimeStampAndListActivities(this.openmct.time.bounds()?.start);
-      } else {
-        this.updateTimeStampAndListActivities(this.openmct.time.now());
       }
     },
     addItem(domainObject) {


### PR DESCRIPTION
Closes #6797 

### Describe your changes:
Use the current timestamp from the global clock
Use mode changes to set if the view is fixed time or real time

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
