### PR TITLE
Plan rendering inside a timestrip

### DIFF
--- a/src/plugins/plan/components/Plan.vue
+++ b/src/plugins/plan/components/Plan.vue
@@ -281,7 +281,7 @@ export default {
 
       if (!clientWidth) {
         //this is a hack - need a better way to find the parent of this component
-        let parent = this.openmct.layout.$refs.browseObject.$el;
+        let parent = this.getParent();
         if (parent) {
           clientWidth = parent.getBoundingClientRect().width;
         }
@@ -289,12 +289,15 @@ export default {
 
       return clientWidth - 200;
     },
+    getParent() {
+      //this is a hack - need a better way to find the parent of this component
+      return this.$el.closest('.c-so-view__object-view');
+    },
     getClientHeight() {
       let clientHeight = this.$refs.plan.clientHeight;
 
       if (!clientHeight) {
-        //this is a hack - need a better way to find the parent of this component
-        let parent = this.openmct.layout.$refs.browseObject.$el;
+        let parent = this.getParent();
         if (parent) {
           clientHeight = parent.getBoundingClientRect().height;
         }

--- a/src/plugins/plan/components/Plan.vue
+++ b/src/plugins/plan/components/Plan.vue
@@ -291,7 +291,7 @@ export default {
     },
     getParent() {
       //this is a hack - need a better way to find the parent of this component
-      return this.$el.closest('.c-so-view__object-view');
+      return this.$el.closest('.is-object-type-time-strip');
     },
     getClientHeight() {
       let clientHeight = this.$refs.plan.clientHeight;

--- a/src/ui/components/TimeSystemAxis.vue
+++ b/src/ui/components/TimeSystemAxis.vue
@@ -78,6 +78,9 @@ export default {
     },
     timeSystem(newTimeSystem) {
       this.drawAxis(this.bounds, newTimeSystem);
+    },
+    contentHeight() {
+      this.updateNowMarker();
     }
   },
   mounted() {
@@ -110,20 +113,13 @@ export default {
       }
     },
     updateNowMarker() {
-      if (this.openmct.time.getClock() === undefined) {
-        let nowMarker = document.querySelector('.nowMarker');
-        if (nowMarker) {
-          nowMarker.classList.add('hidden');
-        }
-      } else {
-        let nowMarker = document.querySelector('.nowMarker');
-        if (nowMarker) {
-          nowMarker.classList.remove('hidden');
-          nowMarker.style.height = this.contentHeight + 'px';
-          const nowTimeStamp = this.openmct.time.getClock().currentValue();
-          const now = this.xScale(nowTimeStamp);
-          nowMarker.style.left = now + this.offset + 'px';
-        }
+      let nowMarker = this.$el.querySelector('.nowMarker');
+      if (nowMarker) {
+        nowMarker.classList.remove('hidden');
+        nowMarker.style.height = this.contentHeight + 'px';
+        const nowTimeStamp = this.openmct.time.now();
+        const now = this.xScale(nowTimeStamp);
+        nowMarker.style.left = now + this.offset + 'px';
       }
     },
     setDimensions() {


### PR DESCRIPTION
Closes #6296 

### Describe your changes:
Use the width and height of the container of the plan to set the activity widths and now markers
TimeSystemAxis always uses the value of global clock now()

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
