### PR TITLE
fix(#6854): [LADTableSet] prevent compositions from becoming reactive

### DIFF
--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -70,9 +70,6 @@ export default {
       required: true
     }
   },
-  created() {
-    this.compositions = [];
-  },
   data() {
     return {
       ladTableObjects: [],
@@ -116,6 +113,9 @@ export default {
 
       return '';
     }
+  },
+  created() {
+    this.compositions = [];
   },
   mounted() {
     this.ladTableConfiguration.on('change', this.handleConfigurationChange);

--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -70,11 +70,13 @@ export default {
       required: true
     }
   },
+  created() {
+    this.compositions = [];
+  },
   data() {
     return {
       ladTableObjects: [],
       ladTelemetryObjects: {},
-      compositions: [],
       viewContext: {},
       staleObjects: [],
       configuration: this.ladTableConfiguration.getConfiguration()


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6854 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Declare and initialize `this.compositions` in the `created()` hook rather than `data()` so that objects added to it do not become reactive, and thus can access their own private class methods.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
