### PR TITLE
Wait for bounds change to reset telemetry collection data

### DIFF
--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -204,7 +204,8 @@ export default class TelemetryAPI {
    */
   standardizeRequestOptions(options = {}) {
     if (!Object.hasOwn(options, 'start')) {
-      if (options.timeContext?.getBounds()) {
+      const bounds = options.timeContext?.getBounds();
+      if (bounds?.start) {
         options.start = options.timeContext.getBounds().start;
       } else {
         options.start = this.openmct.time.getBounds().start;
@@ -212,7 +213,8 @@ export default class TelemetryAPI {
     }
 
     if (!Object.hasOwn(options, 'end')) {
-      if (options.timeContext?.getBounds()) {
+      const bounds = options.timeContext?.getBounds();
+      if (bounds?.end) {
         options.end = options.timeContext.getBounds().end;
       } else {
         options.end = this.openmct.time.getBounds().end;

--- a/src/api/telemetry/TelemetryCollection.js
+++ b/src/api/telemetry/TelemetryCollection.js
@@ -71,6 +71,7 @@ export default class TelemetryCollection extends EventEmitter {
     this.requestAbort = undefined;
     this.isStrategyLatest = this.options.strategy === 'latest';
     this.dataOutsideTimeBounds = false;
+    this.modeChanged = false;
   }
 
   /**
@@ -306,6 +307,12 @@ export default class TelemetryCollection extends EventEmitter {
    * @private
    */
   _bounds(bounds, isTick) {
+    if (this.modeChanged && !isTick) {
+      this.modeChanged = false;
+      this._reset();
+      return;
+    }
+
     let startChanged = this.lastBounds.start !== bounds.start;
     let endChanged = this.lastBounds.end !== bounds.end;
 
@@ -439,7 +446,8 @@ export default class TelemetryCollection extends EventEmitter {
   }
 
   _timeModeChanged() {
-    this._reset();
+    //We're need this so that when the bounds change comes in after this mode change, we can reset and request historic telemetry
+    this.modeChanged = true;
   }
 
   /**

--- a/src/api/telemetry/TelemetryCollection.js
+++ b/src/api/telemetry/TelemetryCollection.js
@@ -307,7 +307,7 @@ export default class TelemetryCollection extends EventEmitter {
    * @private
    */
   _bounds(bounds, isTick) {
-    if (this.modeChanged && !isTick) {
+    if (this.modeChanged) {
       this.modeChanged = false;
       this._reset();
       return;

--- a/src/plugins/imagery/components/RelatedTelemetry/RelatedTelemetry.js
+++ b/src/plugins/imagery/components/RelatedTelemetry/RelatedTelemetry.js
@@ -30,9 +30,10 @@ function copyRelatedMetadata(metadata) {
 
 import IndependentTimeContext from '@/api/time/IndependentTimeContext';
 export default class RelatedTelemetry {
-  constructor(openmct, domainObject, telemetryKeys) {
+  constructor(openmct, domainObject, telemetryKeys, timeContext) {
     this._openmct = openmct;
     this._domainObject = domainObject;
+    this.timeContext = timeContext;
 
     let metadata = this._openmct.telemetry.getMetadata(this._domainObject);
     let imageHints = metadata.valuesForHints(['image'])[0];
@@ -43,7 +44,7 @@ export default class RelatedTelemetry {
       this.keys = telemetryKeys;
 
       this._timeFormatter = undefined;
-      this._timeSystemChange(this._openmct.time.timeSystem());
+      this._timeSystemChange(this.timeContext.timeSystem());
 
       // grab related telemetry metadata
       for (let key of this.keys) {
@@ -57,7 +58,7 @@ export default class RelatedTelemetry {
       this._timeSystemChange = this._timeSystemChange.bind(this);
       this.destroy = this.destroy.bind(this);
 
-      this._openmct.time.on('timeSystem', this._timeSystemChange);
+      this.timeContext.on('timeSystem', this._timeSystemChange);
     }
   }
 
@@ -109,7 +110,7 @@ export default class RelatedTelemetry {
         // and set bounds.
         ephemeralContext.resetContext();
         const newBounds = {
-          start: this._openmct.time.bounds().start,
+          start: this.timeContext.bounds().start,
           end: this._parseTime(datum)
         };
         ephemeralContext.bounds(newBounds);
@@ -183,7 +184,7 @@ export default class RelatedTelemetry {
   }
 
   destroy() {
-    this._openmct.time.off('timeSystem', this._timeSystemChange);
+    this.timeContext.off('timeSystem', this._timeSystemChange);
     for (let key of this.keys) {
       if (this[key] && this[key].unsubscribe) {
         this[key].unsubscribe();


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6813

### Describe your changes:
Reset and re-request telemetry only after receiving bounds following a mode change

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
