### PR TITLE
Don't allow editing line more when not editing display layout

### DIFF
--- a/src/plugins/displayLayout/components/LineView.vue
+++ b/src/plugins/displayLayout/components/LineView.vue
@@ -101,7 +101,11 @@ export default {
       type: Number,
       required: true
     },
-    multiSelect: Boolean
+    multiSelect: Boolean,
+    isEditing: {
+      type: Boolean,
+      required: true
+    }
   },
   data() {
     return {
@@ -114,7 +118,7 @@ export default {
     showFrameEdit() {
       let layoutItem = this.selection.length > 0 && this.selection[0][0].context.layoutItem;
 
-      return !this.multiSelect && layoutItem && layoutItem.id === this.item.id;
+      return this.isEditing && !this.multiSelect && layoutItem && layoutItem.id === this.item.id;
     },
     position() {
       let { x, y, x2, y2 } = this.item;


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6846

### Describe your changes:
Check if we're in edit mode before showing frame edit for line view

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
