### PR TITLE
cherry-pick(#6904): Check for null in DuplicateAction

### DIFF
--- a/src/plugins/duplicate/DuplicateTask.js
+++ b/src/plugins/duplicate/DuplicateTask.js
@@ -221,6 +221,8 @@ export default class DuplicateTask {
       // parse reviver to replace identifiers
       clonedParent = JSON.parse(clonedParent, (key, value) => {
         if (
+          value !== null &&
+          value !== undefined &&
           Object.prototype.hasOwnProperty.call(value, 'key') &&
           Object.prototype.hasOwnProperty.call(value, 'namespace') &&
           value.key === oldId.key &&


### PR DESCRIPTION
check for null before checking before hasOwnProperty

Issue #6900 