### PR TITLE
Condition sets now provide the timeContext they're using when sending requests

### DIFF
--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -201,9 +201,11 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
   }
 
   requestLAD(telemetryObjects, requestOptions) {
+    //We pass in the global time context here
     let options = {
       strategy: 'latest',
-      size: 1
+      size: 1,
+      timeContext: this.openmct.time.getContextForView([])
     };
 
     if (requestOptions !== undefined) {

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -189,9 +189,11 @@ export default class TelemetryCriterion extends EventEmitter {
   }
 
   requestLAD(telemetryObjects, requestOptions) {
+    //We pass in the global time context here
     let options = {
       strategy: 'latest',
-      size: 1
+      size: 1,
+      timeContext: this.openmct.time.getContextForView([])
     };
 
     if (requestOptions !== undefined) {

--- a/src/plugins/condition/criterion/TelemetryCriterionSpec.js
+++ b/src/plugins/condition/criterion/TelemetryCriterionSpec.js
@@ -83,13 +83,19 @@ describe('The telemetry criterion', function () {
     });
     openmct.telemetry.getMetadata.and.returnValue(testTelemetryObject.telemetry);
 
-    openmct.time = jasmine.createSpyObj('timeAPI', ['timeSystem', 'bounds', 'getAllTimeSystems']);
+    openmct.time = jasmine.createSpyObj('timeAPI', [
+      'timeSystem',
+      'bounds',
+      'getAllTimeSystems',
+      'getContextForView'
+    ]);
     openmct.time.timeSystem.and.returnValue({ key: 'system' });
     openmct.time.bounds.and.returnValue({
       start: 0,
       end: 1
     });
     openmct.time.getAllTimeSystems.and.returnValue([{ key: 'system' }]);
+    openmct.time.getContextForView.and.returnValue({});
 
     testCriterionDefinition = {
       id: 'test-criterion-id',


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6928

### Describe your changes:
Send in the timeContext as request options for lad requests from condition sets. Some providers (like Yamcs) use the information from the timeContext (realtime vs fixed timespan mode etc.).

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
