### PR TITLE
fix(readme): indent correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Building and running Open MCT in your local dev environment is very easy. Be sur
 (These instructions assume you are installing as a non-root user; developers have [reported issues](https://github.com/nasa/openmct/issues/1151) running these steps with root privileges.)
 
 1. Clone the source code 
-````
+```
 git clone https://github.com/nasa/openmct.git
 ```
 2. (Optionally) Install the correct node version using [nvm](https://github.com/nvm-sh/nvm) 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,29 @@ Once you've created something amazing with Open MCT, showcase your work in our G
 Building and running Open MCT in your local dev environment is very easy. Be sure you have [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/) installed, then follow the directions below. Need additional information? Check out the [Getting Started](https://nasa.github.io/openmct/getting-started/) page on our website.
 (These instructions assume you are installing as a non-root user; developers have [reported issues](https://github.com/nasa/openmct/issues/1151) running these steps with root privileges.)
 
-1. Clone the source code `git clone https://github.com/nasa/openmct.git`
+1. Clone the source code 
+````
+git clone https://github.com/nasa/openmct.git
+```
+2. (Optionally) Install the correct node version using [nvm](https://github.com/nvm-sh/nvm) 
 
-2. (Optionally) Install the correct node version using [nvm](https://github.com/nvm-sh/nvm) (`nvm install`)
-3. Install development dependencies. Note: Check the package.json engine for our tested and supported node versions. `npm install`
+```
+nvm install
+```
 
-4. Run a local development server `npm start`
+3. Install development dependencies. Note: Check the package.json engine for our tested and supported node versions. 
 
-Open MCT is now running, and can be accessed by pointing a web browser at [http://localhost:8080/](http://localhost:8080/)
+```
+npm install
+```
+
+4. Run a local development server 
+```
+npm start
+```
+
+> [!IMPORTANT]
+> Open MCT is now running, and can be accessed by pointing a web browser at [http://localhost:8080/](http://localhost:8080/)
 
 Open MCT is built using [`npm`](http://npmjs.com/) and [`webpack`](https://webpack.js.org/).
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,12 @@ Once you've created something amazing with Open MCT, showcase your work in our G
 Building and running Open MCT in your local dev environment is very easy. Be sure you have [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/) installed, then follow the directions below. Need additional information? Check out the [Getting Started](https://nasa.github.io/openmct/getting-started/) page on our website.
 (These instructions assume you are installing as a non-root user; developers have [reported issues](https://github.com/nasa/openmct/issues/1151) running these steps with root privileges.)
 
-1. Clone the source code
-
- `git clone https://github.com/nasa/openmct.git`
+1. Clone the source code `git clone https://github.com/nasa/openmct.git`
 
 2. (Optionally) Install the correct node version using [nvm](https://github.com/nvm-sh/nvm) (`nvm install`)
-3. Install development dependencies. Note: Check the package.json engine for our tested and supported node versions.
+3. Install development dependencies. Note: Check the package.json engine for our tested and supported node versions. `npm install`
 
- `npm install`
-
-4. Run a local development server
-
- `npm start`
+4. Run a local development server `npm start`
 
 Open MCT is now running, and can be accessed by pointing a web browser at [http://localhost:8080/](http://localhost:8080/)
 

--- a/README.md
+++ b/README.md
@@ -14,23 +14,26 @@ Once you've created something amazing with Open MCT, showcase your work in our G
 Building and running Open MCT in your local dev environment is very easy. Be sure you have [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/) installed, then follow the directions below. Need additional information? Check out the [Getting Started](https://nasa.github.io/openmct/getting-started/) page on our website.
 (These instructions assume you are installing as a non-root user; developers have [reported issues](https://github.com/nasa/openmct/issues/1151) running these steps with root privileges.)
 
-1. Clone the source code 
+1. Clone the source code:
+
 ```
 git clone https://github.com/nasa/openmct.git
 ```
-2. (Optionally) Install the correct node version using [nvm](https://github.com/nvm-sh/nvm) 
+
+2. (Optional) Install the correct node version using [nvm](https://github.com/nvm-sh/nvm):
 
 ```
 nvm install
 ```
 
-3. Install development dependencies (Note: Check the package.json engine for our tested and supported node versions): 
+3. Install development dependencies (Note: Check the `package.json` engine for our tested and supported node versions): 
 
 ```
 npm install
 ```
 
-4. Run a local development server 
+4. Run a local development server:
+
 ```
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone https://github.com/nasa/openmct.git
 nvm install
 ```
 
-3. Install development dependencies. Note: Check the package.json engine for our tested and supported node versions. 
+3. Install development dependencies (Note: Check the package.json engine for our tested and supported node versions): 
 
 ```
 npm install


### PR DESCRIPTION
### Describe your changes:
The padding in the get started section was weird.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
