### PR TITLE
Protect against prototype pollution in import action

### DIFF
--- a/src/plugins/importFromJSONAction/ImportFromJSONAction.js
+++ b/src/plugins/importFromJSONAction/ImportFromJSONAction.js
@@ -21,6 +21,7 @@
  *****************************************************************************/
 
 import objectUtils from 'objectUtils';
+import { filter__proto__ } from 'utils/sanitization';
 import { v4 as uuid } from 'uuid';
 
 export default class ImportAsJSONAction {
@@ -71,8 +72,10 @@ export default class ImportAsJSONAction {
 
   onSave(object, changes) {
     const selectFile = changes.selectFile;
-    const objectTree = selectFile.body;
-    this._importObjectTree(object, JSON.parse(objectTree));
+    const jsonTree = selectFile.body;
+    const objectTree = JSON.parse(jsonTree, filter__proto__);
+
+    this._importObjectTree(object, objectTree);
   }
 
   /**

--- a/src/plugins/localStorage/LocalStorageObjectProvider.js
+++ b/src/plugins/localStorage/LocalStorageObjectProvider.js
@@ -20,6 +20,8 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
+import { filter__proto__ } from '../../utils/sanitization';
+
 export default class LocalStorageObjectProvider {
   constructor(spaceKey = 'mct') {
     this.localStorage = window.localStorage;
@@ -83,7 +85,7 @@ export default class LocalStorageObjectProvider {
    * @private
    */
   getSpaceAsObject() {
-    return JSON.parse(this.getSpace());
+    return JSON.parse(this.getSpace(), filter__proto__);
   }
 
   /**

--- a/src/plugins/localStorage/pluginSpec.js
+++ b/src/plugins/localStorage/pluginSpec.js
@@ -73,7 +73,7 @@ describe('The local storage plugin', () => {
     expect(testObject.anotherProperty).toEqual(domainObject.anotherProperty);
   });
 
-  it('prevents prototype pollution when retrieving objects from localstorage', async () => {
+  it('prevents prototype pollution from manipulated localstorage', async () => {
     spyOn(console, 'warn');
 
     const identifier = {
@@ -82,7 +82,6 @@ describe('The local storage plugin', () => {
     };
 
     const pollutedSpaceString = `{"test-key":{"__proto__":{"toString":"foobar"},"type":"folder","name":"A test object","identifier":{"namespace":"","key":"test-key"}}}`;
-
     getLocalStorage()[space] = pollutedSpaceString;
 
     let testObject = await openmct.objects.get(identifier);

--- a/src/plugins/localStorage/pluginSpec.js
+++ b/src/plugins/localStorage/pluginSpec.js
@@ -73,6 +73,29 @@ describe('The local storage plugin', () => {
     expect(testObject.anotherProperty).toEqual(domainObject.anotherProperty);
   });
 
+  it('prevents prototype pollution when retrieving objects from localstorage', async () => {
+    spyOn(console, 'warn');
+
+    const identifier = {
+      namespace: '',
+      key: 'test-key'
+    };
+
+    const pollutedSpaceString = `{"test-key":{"__proto__":{"toString":"foobar"},"type":"folder","name":"A test object","identifier":{"namespace":"","key":"test-key"}}}`;
+
+    getLocalStorage()[space] = pollutedSpaceString;
+
+    let testObject = await openmct.objects.get(identifier);
+
+    const hasPollutedProto =
+      Object.prototype.hasOwnProperty.call(testObject, '__proto__') ||
+      Object.getPrototypeOf(testObject) !== Object.getPrototypeOf({});
+
+    // warning from openmct.objects.get
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(hasPollutedProto).toBeFalse();
+  });
+
   afterEach(() => {
     resetApplicationState(openmct);
     resetLocalStorage();

--- a/src/utils/sanitization.js
+++ b/src/utils/sanitization.js
@@ -1,0 +1,29 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+function filter__proto__(key, value) {
+  if (key !== '__proto__') {
+    return value;
+  }
+}
+
+export { filter__proto__ };


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7089

### Describe your changes:
remove `__proto__` when parsing JSON from import action

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
