### PR TITLE
Handle negative height & width in image annotations

### DIFF
--- a/e2e/tests/functional/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/functional/plugins/imagery/exampleImagery.e2e.spec.js
@@ -239,6 +239,10 @@ test.describe('Example Imagery Object', () => {
     await expect(page.getByText('Driving')).toBeHidden();
     await expect(page.getByText('Science')).toBeHidden();
 
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/7083'
+    });
     // click on annotation again and expect tags to appear
     await page.mouse.click(canvasCenterX - 50, canvasCenterY - 50);
     await expect(page.getByText('Driving')).toBeVisible();

--- a/e2e/tests/functional/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/functional/plugins/imagery/exampleImagery.e2e.spec.js
@@ -235,12 +235,12 @@ test.describe('Example Imagery Object', () => {
     await page.getByText('Science').click();
 
     // click on a separate part of the canvas to ensure no tags appear
-    await page.mouse.click(canvasCenterX + 100, canvasCenterY + 100);
+    await page.mouse.click(canvasCenterX + 10, canvasCenterY + 10);
     await expect(page.getByText('Driving')).toBeHidden();
     await expect(page.getByText('Science')).toBeHidden();
 
     // click on annotation again and expect tags to appear
-    await page.mouse.click(canvasCenterX - 80, canvasCenterY - 80);
+    await page.mouse.click(canvasCenterX - 50, canvasCenterY - 50);
     await expect(page.getByText('Driving')).toBeVisible();
     await expect(page.getByText('Science')).toBeVisible();
   });

--- a/e2e/tests/functional/plugins/imagery/exampleImagery.e2e.spec.js
+++ b/e2e/tests/functional/plugins/imagery/exampleImagery.e2e.spec.js
@@ -209,7 +209,6 @@ test.describe('Example Imagery Object', () => {
     const canvasBoundingBox = await canvas.boundingBox();
     const canvasCenterX = canvasBoundingBox.x + canvasBoundingBox.width / 2;
     const canvasCenterY = canvasBoundingBox.y + canvasBoundingBox.height / 2;
-
     await Promise.all(tagHotkey.map((x) => page.keyboard.down(x)));
     await page.mouse.down();
     // steps not working for me here
@@ -222,7 +221,7 @@ test.describe('Example Imagery Object', () => {
     await expect(page.locator('[role="toolbar"][aria-label="Image controls"]')).toBeVisible();
     await Promise.all(tagHotkey.map((x) => page.keyboard.up(x)));
 
-    //Wait for canvas to stabilize.
+    // Wait for canvas to stabilize.
     await canvas.hover({ trial: true });
 
     // add some tags
@@ -234,6 +233,16 @@ test.describe('Example Imagery Object', () => {
     await page.getByRole('button', { name: /Add Tag/ }).click();
     await page.getByPlaceholder('Type to select tag').click();
     await page.getByText('Science').click();
+
+    // click on a separate part of the canvas to ensure no tags appear
+    await page.mouse.click(canvasCenterX + 100, canvasCenterY + 100);
+    await expect(page.getByText('Driving')).toBeHidden();
+    await expect(page.getByText('Science')).toBeHidden();
+
+    // click on annotation again and expect tags to appear
+    await page.mouse.click(canvasCenterX - 80, canvasCenterY - 80);
+    await expect(page.getByText('Driving')).toBeVisible();
+    await expect(page.getByText('Science')).toBeVisible();
   });
 
   test('Can use + - buttons to zoom on the image @unstable', async ({ page }) => {

--- a/src/plugins/imagery/components/AnnotationsCanvas.vue
+++ b/src/plugins/imagery/components/AnnotationsCanvas.vue
@@ -78,12 +78,21 @@ export default {
           )?.rectangle;
           const annotationRectangleForPixelDepth =
             this.transformRectangleToPixelDense(annotationRectangle);
-          const indexNumber = builtAnnotationsIndex.add(
-            annotationRectangleForPixelDepth.x,
-            annotationRectangleForPixelDepth.y,
-            annotationRectangleForPixelDepth.x + annotationRectangleForPixelDepth.width,
-            annotationRectangleForPixelDepth.y + annotationRectangleForPixelDepth.height
-          );
+          let { x, y, width, height } = annotationRectangleForPixelDepth;
+          let x2 = x + width;
+          let y2 = y + height;
+
+          // if height or width are negative, we need to adjust the x and y
+          if (width < 0) {
+            x2 = x;
+            x = x + width;
+          }
+          if (height < 0) {
+            y2 = y;
+            y = y + height;
+          }
+
+          const indexNumber = builtAnnotationsIndex.add(x, y, x2, y2);
           this.indexToAnnotationMap[indexNumber] = annotation;
         });
         builtAnnotationsIndex.finish();
@@ -103,6 +112,7 @@ export default {
     }
   },
   mounted() {
+    console.debug(`🍉 mounted`);
     this.canvas = this.$refs.canvas;
     this.context = this.canvas.getContext('2d');
 

--- a/src/plugins/imagery/components/AnnotationsCanvas.vue
+++ b/src/plugins/imagery/components/AnnotationsCanvas.vue
@@ -112,7 +112,6 @@ export default {
     }
   },
   mounted() {
-    console.debug(`🍉 mounted`);
     this.canvas = this.$refs.canvas;
     this.context = this.canvas.getContext('2d');
 

--- a/src/plugins/imagery/components/AnnotationsCanvas.vue
+++ b/src/plugins/imagery/components/AnnotationsCanvas.vue
@@ -78,20 +78,9 @@ export default {
           )?.rectangle;
           const annotationRectangleForPixelDepth =
             this.transformRectangleToPixelDense(annotationRectangle);
-          let { x, y, width, height } = annotationRectangleForPixelDepth;
-          let x2 = x + width;
-          let y2 = y + height;
-
-          // if height or width are negative, we need to adjust the x and y
-          if (width < 0) {
-            x2 = x;
-            x = x + width;
-          }
-          if (height < 0) {
-            y2 = y;
-            y = y + height;
-          }
-
+          const { x, y, x2, y2 } = this.transformAnnotationRectangleToFlatbushRectangle(
+            annotationRectangleForPixelDepth
+          );
           const indexNumber = builtAnnotationsIndex.add(x, y, x2, y2);
           this.indexToAnnotationMap[indexNumber] = annotation;
         });
@@ -132,6 +121,23 @@ export default {
     onAnnotationChange(annotations) {
       this.selectedAnnotations = annotations;
       this.$emit('annotations-changed', annotations);
+    },
+    transformAnnotationRectangleToFlatbushRectangle(annotationRectangle) {
+      let { x, y, width, height } = annotationRectangle;
+      let x2 = x + width;
+      let y2 = y + height;
+
+      // if height or width are negative, we need to adjust the x and y
+      if (width < 0) {
+        x2 = x;
+        x = x + width;
+      }
+      if (height < 0) {
+        y2 = y;
+        y = y + height;
+      }
+
+      return { x, y, x2, y2 };
     },
     updateSelection(selection) {
       const selectionContext = selection?.[0]?.[0]?.context?.item;


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7083 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

If the height or width are negative due the user dragging back and to the left, or forward and up, handle this properly when adding to the flatbush index.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
