### PR TITLE
Prevent infinite loop when updating a table row in place

### DIFF
--- a/src/plugins/telemetryTable/collections/TableRowCollection.js
+++ b/src/plugins/telemetryTable/collections/TableRowCollection.js
@@ -153,40 +153,41 @@ define(['lodash', 'EventEmitter'], function (_, EventEmitter) {
       });
     }
 
-    mergeSortedRows(rows) {
+    mergeSortedRows(incomingRows) {
       const mergedRows = [];
-      let i = 0;
-      let j = 0;
+      let existingRowIndex = 0;
+      let incomingRowIndex = 0;
 
-      while (i < this.rows.length && j < rows.length) {
-        const existingRow = this.rows[i];
-        const incomingRow = rows[j];
+      while (existingRowIndex < this.rows.length && incomingRowIndex < incomingRows.length) {
+        const existingRow = this.rows[existingRowIndex];
+        const incomingRow = incomingRows[incomingRowIndex];
 
-        const index = this.getInPlaceUpdateIndex(incomingRow);
-        if (index > -1) {
-          this.updateRowInPlace(incomingRow, index);
+        const inPlaceIndex = this.getInPlaceUpdateIndex(incomingRow);
+        if (inPlaceIndex > -1) {
+          this.updateRowInPlace(incomingRow, inPlaceIndex);
+          incomingRowIndex++;
         } else {
           if (this.firstRowInSortOrder(existingRow, incomingRow) === existingRow) {
             mergedRows.push(existingRow);
-            i++;
+            existingRowIndex++;
           } else {
             mergedRows.push(incomingRow);
-            j++;
+            incomingRowIndex++;
           }
         }
       }
 
       // tail of existing rows is all that is left to merge
-      if (i < this.rows.length) {
-        for (i; i < this.rows.length; i++) {
-          mergedRows.push(this.rows[i]);
+      if (existingRowIndex < this.rows.length) {
+        for (existingRowIndex; existingRowIndex < this.rows.length; existingRowIndex++) {
+          mergedRows.push(this.rows[existingRowIndex]);
         }
       }
 
       // tail of incoming rows is all that is left to merge
-      if (j < rows.length) {
-        for (j; j < rows.length; j++) {
-          mergedRows.push(rows[j]);
+      if (incomingRowIndex < incomingRows.length) {
+        for (incomingRowIndex; incomingRowIndex < incomingRows.length; incomingRowIndex++) {
+          mergedRows.push(incomingRows[incomingRowIndex]);
         }
       }
 

--- a/src/plugins/telemetryTable/pluginSpec.js
+++ b/src/plugins/telemetryTable/pluginSpec.js
@@ -279,7 +279,7 @@ describe('the plugin', () => {
       const newTelemetry = {
         utc: 2,
         'some-key': 'some-value 2',
-        'some-other-key': 'duuuude'
+        'some-other-key': 'spacecraft'
       };
       spyOn(tableInstance.tableRows, 'getInPlaceUpdateIndex').and.returnValue(1);
       spyOn(tableInstance.tableRows, 'updateRowInPlace').and.callThrough();

--- a/src/plugins/telemetryTable/pluginSpec.js
+++ b/src/plugins/telemetryTable/pluginSpec.js
@@ -271,39 +271,6 @@ describe('the plugin', () => {
       expect(rows.length).toBe(3);
     });
 
-    it('Adds a row when updating with new telemetry', async () => {
-      let rows = element.querySelectorAll('table.c-telemetry-table__body tr');
-      await nextTick();
-      expect(rows.length).toBe(3);
-      // fire some telemetry
-      const newTelemetry = {
-        utc: 6,
-        'some-key': 'some-value 6',
-        'some-other-key': 'some-other-value 6'
-      };
-
-      // Create a spy on the addRows function.
-      spyOn(tableInstance.tableRows, 'addRows').and.callThrough();
-
-      telemetryCallback(newTelemetry);
-
-      await nextTick();
-
-      await new Promise((resolve) => {
-        // Wait for rows to render
-        const checkInterval = setInterval(() => {
-          const foundRows = element.querySelectorAll('table.c-telemetry-table__body tr');
-          if (foundRows.length === 4) {
-            clearInterval(checkInterval);
-            resolve();
-          }
-        }, 100);
-      });
-
-      rows = element.querySelectorAll('table.c-telemetry-table__body tr');
-      expect(rows.length).toBe(4);
-    });
-
     it('Adds a row in place when updating with existing telemetry', async () => {
       let rows = element.querySelectorAll('table.c-telemetry-table__body tr');
       await nextTick();

--- a/src/plugins/telemetryTable/pluginSpec.js
+++ b/src/plugins/telemetryTable/pluginSpec.js
@@ -49,7 +49,7 @@ describe('the plugin', () => {
   let tablePlugin;
   let element;
   let child;
-  let historicalProvider;
+  let historicalTelemetryProvider;
   let originalRouterPath;
   let unlistenConfigMutation;
 
@@ -61,12 +61,12 @@ describe('the plugin', () => {
     tablePlugin = new TablePlugin();
     openmct.install(tablePlugin);
 
-    historicalProvider = {
+    historicalTelemetryProvider = {
       request: () => {
         return Promise.resolve([]);
       }
     };
-    spyOn(openmct.telemetry, 'findRequestProvider').and.returnValue(historicalProvider);
+    spyOn(openmct.telemetry, 'findRequestProvider').and.returnValue(historicalTelemetryProvider);
 
     element = document.createElement('div');
     child = document.createElement('div');
@@ -137,11 +137,12 @@ describe('the plugin', () => {
     let tableView;
     let tableInstance;
     let mockClock;
+    let telemetryCallback;
 
     beforeEach(async () => {
       openmct.time.timeSystem('utc', {
         start: 0,
-        end: 4
+        end: 10
       });
 
       mockClock = jasmine.createSpyObj('clock', ['on', 'off', 'currentValue']);
@@ -151,7 +152,7 @@ describe('the plugin', () => {
       openmct.time.addClock(mockClock);
       openmct.time.clock('mockClock', {
         start: 0,
-        end: 4
+        end: 10
       });
 
       testTelemetryObject = {
@@ -214,7 +215,21 @@ describe('the plugin', () => {
         }
       ];
 
-      historicalProvider.request = () => Promise.resolve(testTelemetry);
+      historicalTelemetryProvider.request = () => {
+        return Promise.resolve(testTelemetry);
+      };
+
+      const realtimeTelemetryProvider = {
+        supportsSubscribe: () => true,
+        subscribe: (domainObject, passedCallback) => {
+          telemetryCallback = passedCallback;
+          return Promise.resolve(() => {});
+        }
+      };
+
+      spyOn(openmct.telemetry, 'findSubscriptionProvider').and.returnValue(
+        realtimeTelemetryProvider
+      );
 
       openmct.router.path = [testTelemetryObject];
 
@@ -254,6 +269,56 @@ describe('the plugin', () => {
       let rows = element.querySelectorAll('table.c-telemetry-table__body tr');
       await nextTick();
       expect(rows.length).toBe(3);
+    });
+
+    it('Adds a row when updating with new telemetry', async () => {
+      let rows = element.querySelectorAll('table.c-telemetry-table__body tr');
+      await nextTick();
+      expect(rows.length).toBe(3);
+      // fire some telemetry
+      const newTelemetry = {
+        utc: 6,
+        'some-key': 'some-value 6',
+        'some-other-key': 'some-other-value 6'
+      };
+
+      // Create a spy on the addRows function.
+      spyOn(tableInstance.tableRows, 'addRows').and.callThrough();
+
+      telemetryCallback(newTelemetry);
+
+      await nextTick();
+
+      await new Promise((resolve) => {
+        // Wait for rows to render
+        const checkInterval = setInterval(() => {
+          const foundRows = element.querySelectorAll('table.c-telemetry-table__body tr');
+          if (foundRows.length === 4) {
+            clearInterval(checkInterval);
+            resolve();
+          }
+        }, 100);
+      });
+
+      rows = element.querySelectorAll('table.c-telemetry-table__body tr');
+      expect(rows.length).toBe(4);
+    });
+
+    it('Adds a row in place when updating with existing telemetry', async () => {
+      let rows = element.querySelectorAll('table.c-telemetry-table__body tr');
+      await nextTick();
+      expect(rows.length).toBe(3);
+      // fire some telemetry
+      const newTelemetry = {
+        utc: 2,
+        'some-key': 'some-value 2',
+        'some-other-key': 'duuuude'
+      };
+      spyOn(tableInstance.tableRows, 'getInPlaceUpdateIndex').and.returnValue(1);
+      spyOn(tableInstance.tableRows, 'updateRowInPlace').and.callThrough();
+      telemetryCallback(newTelemetry);
+
+      expect(tableInstance.tableRows.updateRowInPlace.calls.count()).toBeGreaterThan(0);
     });
 
     it('Renders a column for every item in telemetry metadata', () => {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/akhenry/openmct-yamcs/issues/384

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
When updating a row in place, we need to be sure to bump the `incomingRowIndex` so we don't have an infinite loop.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
