### PR TITLE
fix: update MCT `start()` to use element with ID `openmct-app`

### DIFF
--- a/src/MCT.js
+++ b/src/MCT.js
@@ -342,7 +342,7 @@ define([
    *        MCT; if undefined, MCT will be run in the body of the document
    */
   MCT.prototype.start = function (
-    domElement = document.body.firstElementChild,
+    domElement = document.getElementById('openmct-app'),
     isHeadlessMode = false
   ) {
     // Create element to mount Layout if it doesn't exist


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7175 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Upon the upgrade to Vue 3, openmct is now required to be mounted to a child `<div>`. This was never intended to be a breaking change, but is due to some faulty startup logic.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
