### PR TITLE
Allow specification of swimlanes via configuration

### DIFF
--- a/src/api/objects/MutableDomainObject.js
+++ b/src/api/objects/MutableDomainObject.js
@@ -129,7 +129,7 @@ class MutableDomainObject {
     this._globalEventEmitter.emit(qualifiedEventName(this, '$_synchronize_model'), model);
 
     //Emit wildcard event, with path so that callback knows what changed
-    this._globalEventEmitter.emit(qualifiedEventName(this, '*'), this);
+    this._globalEventEmitter.emit(qualifiedEventName(this, '*'), model);
   }
 
   $on(event, callback) {

--- a/src/api/objects/MutableDomainObject.js
+++ b/src/api/objects/MutableDomainObject.js
@@ -129,7 +129,7 @@ class MutableDomainObject {
     this._globalEventEmitter.emit(qualifiedEventName(this, '$_synchronize_model'), model);
 
     //Emit wildcard event, with path so that callback knows what changed
-    this._globalEventEmitter.emit(qualifiedEventName(this, '*'), model);
+    this._globalEventEmitter.emit(qualifiedEventName(this, '*'), this);
   }
 
   $on(event, callback) {

--- a/src/plugins/plan/components/PlanView.vue
+++ b/src/plugins/plan/components/PlanView.vue
@@ -430,6 +430,10 @@ export default {
         let currentRow = 0;
 
         const rawActivities = this.planData[groupName];
+        if (rawActivities === undefined) {
+          return;
+        }
+
         rawActivities.forEach((rawActivity) => {
           if (!this.isActivityInBounds(rawActivity)) {
             return;

--- a/src/plugins/plan/components/PlanView.vue
+++ b/src/plugins/plan/components/PlanView.vue
@@ -59,7 +59,7 @@ import SwimLane from '@/ui/components/swim-lane/SwimLane.vue';
 
 import TimelineAxis from '../../../ui/components/TimeSystemAxis.vue';
 import PlanViewConfiguration from '../PlanViewConfiguration';
-import { getContrastingColor, getValidatedData } from '../util';
+import { getContrastingColor, getValidatedData, getValidatedGroups } from '../util';
 import ActivityTimeline from './ActivityTimeline.vue';
 
 const PADDING = 1;
@@ -416,7 +416,7 @@ export default {
       return currentRow || SWIMLANE_PADDING;
     },
     generateActivities() {
-      const groupNames = Object.keys(this.planData);
+      const groupNames = getValidatedGroups(this.domainObject, this.planData);
 
       if (!groupNames.length) {
         return;

--- a/src/plugins/plan/components/PlanView.vue
+++ b/src/plugins/plan/components/PlanView.vue
@@ -259,7 +259,8 @@ export default {
 
       this.setScaleAndGenerateActivities();
     },
-    handleSelectFileChange() {
+    handleSelectFileChange(domainObject) {
+      this.domainObject = domainObject;
       this.planData = getValidatedData(this.domainObject);
       this.setScaleAndGenerateActivities();
     },

--- a/src/plugins/plan/components/PlanView.vue
+++ b/src/plugins/plan/components/PlanView.vue
@@ -259,8 +259,7 @@ export default {
 
       this.setScaleAndGenerateActivities();
     },
-    handleSelectFileChange(domainObject) {
-      this.domainObject = domainObject;
+    handleSelectFileChange() {
       this.planData = getValidatedData(this.domainObject);
       this.setScaleAndGenerateActivities();
     },

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -80,12 +80,17 @@ export function getValidatedGroups(domainObject, planData) {
   const sourceMap = domainObject.sourceMap;
   const json = getObjectJson(domainObject);
   if (sourceMap !== undefined && sourceMap.groupIds !== undefined) {
-    if (typeof sourceMap.groupIds === 'function') {
-      groupIds = sourceMap.groupIds(json);
+    const groups = json[sourceMap.groupIds];
+    if (groups.length && typeof groups[0] === 'object') {
+      const groupsWithNames = groups.filter(
+        (groupObj) => groupObj.name !== undefined && groupObj.name !== ''
+      );
+      groupIds = groupsWithNames.map((groupObj) => groupObj.name);
     } else {
-      groupIds = json[sourceMap.groupIds];
+      groupIds = groups;
     }
   }
+
   if (groupIds === undefined) {
     groupIds = Object.keys(planData);
   }

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -80,7 +80,7 @@ export function getValidatedGroups(domainObject, planData) {
   const sourceMap = domainObject.sourceMap;
   const json = getObjectJson(domainObject);
   if (sourceMap !== undefined && sourceMap.groupIds !== undefined) {
-    if (typeof groupIds === 'function') {
+    if (typeof sourceMap.groupIds === 'function') {
       groupIds = sourceMap.groupIds(json);
     } else {
       groupIds = json[sourceMap.groupIds];

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -80,7 +80,11 @@ export function getValidatedGroups(domainObject, planData) {
   const sourceMap = domainObject.sourceMap;
   const json = getObjectJson(domainObject);
   if (sourceMap !== undefined && sourceMap.groupIds !== undefined) {
-    groupIds = json[sourceMap.groupIds];
+    if (typeof groupIds === 'function') {
+      groupIds = sourceMap.groupIds(json);
+    } else {
+      groupIds = json[sourceMap.groupIds];
+    }
   }
   if (groupIds === undefined) {
     groupIds = Object.keys(planData);

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -22,17 +22,7 @@
 
 export function getValidatedData(domainObject) {
   const sourceMap = domainObject.sourceMap;
-  const body = domainObject.selectFile?.body;
-  let json = {};
-  if (typeof body === 'string') {
-    try {
-      json = JSON.parse(body);
-    } catch (e) {
-      return json;
-    }
-  } else if (body !== undefined) {
-    json = body;
-  }
+  const json = getObjectJson(domainObject);
 
   if (
     sourceMap !== undefined &&
@@ -67,6 +57,36 @@ export function getValidatedData(domainObject) {
   } else {
     return json;
   }
+}
+
+function getObjectJson(domainObject) {
+  const body = domainObject.selectFile?.body;
+  let json = {};
+  if (typeof body === 'string') {
+    try {
+      json = JSON.parse(body);
+    } catch (e) {
+      return json;
+    }
+  } else if (body !== undefined) {
+    json = body;
+  }
+
+  return json;
+}
+
+export function getValidatedGroups(domainObject, planData) {
+  let groupIds;
+  const sourceMap = domainObject.sourceMap;
+  const json = getObjectJson(domainObject);
+  if (sourceMap !== undefined && sourceMap.groupIds !== undefined) {
+    groupIds = json[sourceMap.groupIds];
+  }
+  if (groupIds === undefined) {
+    groupIds = Object.keys(planData);
+  }
+
+  return groupIds;
 }
 
 export function getContrastingColor(hexColor) {

--- a/src/plugins/timeline/TimelineViewLayout.vue
+++ b/src/plugins/timeline/TimelineViewLayout.vue
@@ -53,7 +53,7 @@ import _ from 'lodash';
 import SwimLane from '@/ui/components/swim-lane/SwimLane.vue';
 
 import TimelineAxis from '../../ui/components/TimeSystemAxis.vue';
-import { getValidatedData } from '../plan/util';
+import { getValidatedData, getValidatedGroups } from '../plan/util';
 import TimelineObjectView from './TimelineObjectView.vue';
 
 const unknownObjectType = {
@@ -108,7 +108,8 @@ export default {
       let objectPath = [domainObject].concat(this.objectPath.slice());
       let rowCount = 0;
       if (domainObject.type === 'plan') {
-        rowCount = Object.keys(getValidatedData(domainObject)).length;
+        const planData = getValidatedData(domainObject);
+        rowCount = getValidatedGroups(domainObject, planData).length;
       } else if (domainObject.type === 'gantt-chart') {
         rowCount = Object.keys(domainObject.configuration.swimlaneVisibility).length;
       }

--- a/src/plugins/timelist/TimelistComponent.vue
+++ b/src/plugins/timelist/TimelistComponent.vue
@@ -38,7 +38,7 @@ import { v4 as uuid } from 'uuid';
 import { TIME_CONTEXT_EVENTS } from '../../api/time/constants';
 import ListView from '../../ui/components/List/ListView.vue';
 import { getPreciseDuration } from '../../utils/duration';
-import { getValidatedData } from '../plan/util';
+import { getValidatedData, getValidatedGroups } from '../plan/util';
 import { SORT_ORDER_OPTIONS } from './constants';
 
 const SCROLL_TIMEOUT = 10000;
@@ -283,7 +283,7 @@ export default {
       this.planData = getValidatedData(domainObject);
     },
     listActivities() {
-      let groups = Object.keys(this.planData);
+      let groups = getValidatedGroups(this.domainObject, this.planData);
       let activities = [];
 
       groups.forEach((key) => {

--- a/src/plugins/timelist/TimelistComponent.vue
+++ b/src/plugins/timelist/TimelistComponent.vue
@@ -287,6 +287,9 @@ export default {
       let activities = [];
 
       groups.forEach((key) => {
+        if (this.planData[key] === undefined) {
+          return;
+        }
         // Create new objects so Vue 3 can detect any changes
         activities = activities.concat(JSON.parse(JSON.stringify(this.planData[key])));
       });


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7196 

### Describe your changes:
Read the groupIds (swimlanes) configuration and use it to order the plan view swimlanes. If there is no grouIds configuration, use the activities to get the groups like before.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Command line build passes?
* [ ] Has this been smoke tested?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
