### PR TITLE
Prevent rubber-banding in Telemetry Table filter input

### DIFF
--- a/e2e/tests/functional/plugins/telemetryTable/telemetryTable.e2e.spec.js
+++ b/e2e/tests/functional/plugins/telemetryTable/telemetryTable.e2e.spec.js
@@ -92,7 +92,7 @@ test.describe('Telemetry Table', () => {
     await page.goto(table.url);
 
     await page.getByRole('searchbox', { name: 'message filter input' }).click();
-    await page.getByRole('searchbox', { name: 'message filter input' }).fill('Roger');
+    await page.keyboard.type('Roger', { delay: 150 });
 
     let cells = await page.getByRole('cell', { name: /Roger/ }).all();
     // ensure we've got more than one cell

--- a/e2e/tests/functional/plugins/telemetryTable/telemetryTable.e2e.spec.js
+++ b/e2e/tests/functional/plugins/telemetryTable/telemetryTable.e2e.spec.js
@@ -92,7 +92,7 @@ test.describe('Telemetry Table', () => {
     await page.goto(table.url);
 
     await page.getByRole('searchbox', { name: 'message filter input' }).click();
-    await page.keyboard.type('Roger', { delay: 150 });
+    await page.getByRole('searchbox', { name: 'message filter input' }).fill('Roger');
 
     let cells = await page.getByRole('cell', { name: /Roger/ }).all();
     // ensure we've got more than one cell

--- a/src/plugins/telemetryTable/components/TableComponent.vue
+++ b/src/plugins/telemetryTable/components/TableComponent.vue
@@ -478,7 +478,7 @@ export default {
     }
   },
   created() {
-    this.filterChanged = _.debounce(this.filterChanged, 500);
+    this.filterTelemetry = _.debounce(this.filterTelemetry, 500);
   },
   mounted() {
     this.nicelyCalled = new NicelyCalled(this.$refs.root);
@@ -671,8 +671,7 @@ export default {
         this.headersHolderEl.scrollLeft = this.scrollable.scrollLeft;
       }
     },
-    filterChanged(columnKey, newFilterValue) {
-      this.filters[columnKey] = newFilterValue;
+    filterTelemetry(columnKey) {
       if (this.enableRegexSearch[columnKey]) {
         if (this.isCompleteRegex(this.filters[columnKey])) {
           this.table.tableRows.setColumnRegexFilter(
@@ -687,6 +686,10 @@ export default {
       }
 
       this.setHeight();
+    },
+    filterChanged(columnKey, newFilterValue) {
+      this.filters[columnKey] = newFilterValue;
+      this.filterTelemetry(columnKey);
     },
     clearFilter(columnKey) {
       this.filters[columnKey] = '';


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7239 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

Sets the debounce to affect the filtering of the telemetry table, not the setting of the input value.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
