### PR TITLE
[Build] Update to Node 20 and remove 16 (EOL)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,8 +237,8 @@ workflows:
   overall-circleci-commit-status: #These jobs run on every commit
     jobs:
       - lint:
-          name: node16-lint
-          node-version: lts/gallium
+          name: node20-lint
+          node-version: lts/iron
       - unit-test:
           name: node18-chrome
           node-version: lts/hydrogen
@@ -256,8 +256,8 @@ workflows:
   the-nightly: #These jobs do not run on PRs, but against master at night
     jobs:
       - unit-test:
-          name: node16-chrome-nightly
-          node-version: lts/gallium
+          name: node20-chrome-nightly
+          node-version: lts/iron
       - unit-test:
           name: node18-chrome
           node-version: lts/hydrogen

--- a/.github/workflows/pr-platform.yml
+++ b/.github/workflows/pr-platform.yml
@@ -22,7 +22,7 @@ jobs:
           - macos-latest
           - windows-latest
         node_version:
-          - lts/gallium
+          - lts/iron
           - lts/hydrogen
         architecture:
           - x64

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "url": "https://github.com/nasa/openmct.git"
   },
   "engines": {
-    "node": ">=16.19.1 <20"
+    "node": ">=18.14.2 <22"
   },
   "browserslist": [
     "Firefox ESR",


### PR DESCRIPTION
Closes: #6732 

### Describe your changes:
Adds node20 to our support matrix
Removes node16 from our support matrix (EOL last september)
Ensures node 18 is the default (per @akhenry )

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
