### PR TITLE
Destroy canvas in plots if not visible

### DIFF
--- a/e2e/tests/functional/plugins/tabs/tabs.e2e.spec.js
+++ b/e2e/tests/functional/plugins/tabs/tabs.e2e.spec.js
@@ -54,21 +54,35 @@ test.describe('Tabs View', () => {
     // ensure table header visible
     await expect(page.getByRole('searchbox', { name: 'message filter input' })).toBeVisible();
 
+    // no canvas (i.e., sine wave generator) in the document should be visible
+    await expect(page.locator('canvas')).toBeHidden();
+
     // select second tab
     await page.getByLabel(`${notebook.name} tab`).click();
 
     // ensure notebook visible
     await expect(page.locator('.c-notebook__drag-area')).toBeVisible();
 
+    // no canvas (i.e., sine wave generator) in the document should be visible
+    await expect(page.locator('canvas')).toBeHidden();
+
     // select third tab
     await page.getByLabel(`${sineWaveGenerator.name} tab`).click();
 
     // expect sine wave generator visible
-    expect(await page.locator('.c-plot').isVisible()).toBe(true);
+    await expect(page.locator('.c-plot')).toBeVisible();
+
+    // expect two canvases (i.e., overlay & main canvas for sine wave generator) to be visible
+    await expect(page.locator('canvas')).toHaveCount(2);
+    await expect(page.locator('canvas').nth(0)).toBeVisible();
+    await expect(page.locator('canvas').nth(1)).toBeVisible();
 
     // now try to select the first tab again
     await page.getByLabel(`${table.name} tab`).click();
     // ensure table header visible
     await expect(page.getByRole('searchbox', { name: 'message filter input' })).toBeVisible();
+
+    // no canvas (i.e., sine wave generator) in the document should be visible
+    await expect(page.locator('canvas')).toBeHidden();
   });
 });

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -22,10 +22,8 @@
 
 <template>
   <div ref="chart" class="gl-plot-chart-area">
-    <!-- overlay canvas -->
-    <canvas :style="canvasStyle"></canvas>
-    <!-- main canvas -->
-    <canvas :style="canvasStyle"></canvas>
+    <canvas :style="canvasStyle" class="js-overlay-canvas"></canvas>
+    <canvas :style="canvasStyle" class="js-main-canvas"></canvas>
     <div ref="limitArea" class="js-limit-area">
       <limit-label
         v-for="(limitLabel, index) in visibleLimitLabels"
@@ -530,8 +528,8 @@ export default {
     buildCanvasElements() {
       const div = document.createElement('div');
       div.innerHTML = `
-      <canvas style="position: absolute; background: none; width: 100%; height: 100%;"></canvas>
-      <canvas style="position: absolute; background: none; width: 100%; height: 100%;"></canvas>
+      <canvas style="position: absolute; background: none; width: 100%; height: 100%;" class="js-overlay-canvas"></canvas>
+      <canvas style="position: absolute; background: none; width: 100%; height: 100%;" class="js-main-canvas"></canvas>
       `;
       const mainCanvas = div.querySelectorAll('canvas')[1];
       const overlayCanvas = div.querySelectorAll('canvas')[0];

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -297,20 +297,6 @@ export default {
         }
       }
     },
-    countWebGLContexts() {
-      const canvases = document.getElementsByTagName('canvas');
-      let webGLContextCount = 0;
-
-      for (let i = 0; i < canvases.length; i++) {
-        const canvas = canvases[i];
-        const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-        if (gl && gl instanceof WebGLRenderingContext) {
-          webGLContextCount++;
-        }
-      }
-
-      return webGLContextCount;
-    },
     reDraw(newXKey, oldXKey, series) {
       this.changeInterpolate(newXKey, oldXKey, series);
       this.changeMarkers(newXKey, oldXKey, series);

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -442,15 +442,12 @@ export default {
       this.scheduleDraw();
     },
     destroy() {
+      this.destroyCanvas();
       this.isDestroyed = true;
-      this.stopListening();
       this.lines.forEach((line) => line.destroy());
       this.limitLines.forEach((line) => line.destroy());
       this.pointSets.forEach((pointSet) => pointSet.destroy());
       this.alarmSets.forEach((alarmSet) => alarmSet.destroy());
-      if (this.chartVisible) {
-        DrawLoader.releaseDrawAPI(this.drawAPI);
-      }
     },
     resetYOffsetAndSeriesDataForYAxis(yAxisId) {
       delete this.offset[yAxisId].y;

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -201,7 +201,7 @@ export default {
   mounted() {
     this.chartVisible = true;
     this.chartContainer = this.$parent.$refs.chartContainer;
-    this.visibilityObserver = new IntersectionObserver(this.observerCallback);
+    this.visibilityObserver = new IntersectionObserver(this.visibilityChanged);
     this.visibilityObserver.observe(this.chartContainer);
     eventHelpers.extend(this);
     this.seriesModels = [];
@@ -260,6 +260,7 @@ export default {
   },
   beforeUnmount() {
     this.destroy();
+    this.visibilityObserver.unobserve(this.chartContainer);
   },
   methods: {
     getConfig() {
@@ -276,7 +277,7 @@ export default {
 
       return config;
     },
-    observerCallback([entry]) {
+    visibilityChanged([entry]) {
       if (entry.target === this.chartContainer) {
         const wasVisible = this.chartVisible;
         this.chartVisible = entry.isIntersecting;
@@ -298,6 +299,21 @@ export default {
           console.debug(`🔄 chart was already visible ${this.domainObject.name}`);
         }
       }
+      console.debug(`👁️ current webgl context count ${this.countWebGLContexts()}`);
+    },
+    countWebGLContexts() {
+      const canvases = document.getElementsByTagName('canvas');
+      let webGLContextCount = 0;
+
+      for (let i = 0; i < canvases.length; i++) {
+        const canvas = canvases[i];
+        const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+        if (gl && gl instanceof WebGLRenderingContext) {
+          webGLContextCount++;
+        }
+      }
+
+      return webGLContextCount;
     },
     reDraw(newXKey, oldXKey, series) {
       this.changeInterpolate(newXKey, oldXKey, series);

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -200,7 +200,7 @@ export default {
   },
   mounted() {
     this.chartVisible = true;
-    this.chartContainer = this.$parent.$refs.chartContainer;
+    this.chartContainer = this.$refs.chart;
     this.visibilityObserver = new IntersectionObserver(this.visibilityChanged);
     this.visibilityObserver.observe(this.chartContainer);
     eventHelpers.extend(this);
@@ -284,10 +284,8 @@ export default {
         if (!this.chartVisible) {
           // destroy the chart
           this.destroyCanvas();
-          console.debug(`🛑 chart is not visible ${this.domainObject.name}`);
         } else if (!wasVisible && this.chartVisible) {
           // rebuild the chart
-          console.debug(`🪞 chart is visible ${this.domainObject.name}`);
           this.buildCanvasElements();
           const canvasInitialized = this.readyCanvasForDrawing();
           if (canvasInitialized) {
@@ -296,10 +294,8 @@ export default {
           this.$emit('plot-reinitialize-canvas');
         } else if (wasVisible && this.chartVisible) {
           // ignore, moving on
-          console.debug(`🔄 chart was already visible ${this.domainObject.name}`);
         }
       }
-      console.debug(`👁️ current webgl context count ${this.countWebGLContexts()}`);
     },
     countWebGLContexts() {
       const canvases = document.getElementsByTagName('canvas');
@@ -524,10 +520,8 @@ export default {
     },
     destroyCanvas() {
       if (this.isDestroyed) {
-        console.debug(`🛑 canvas already destroyed ${this.domainObject.name}`);
         return;
       }
-      console.debug(`🛑 destroying canvas ${this.domainObject.name}`);
       this.stopListening(this.drawAPI);
       DrawLoader.releaseDrawAPI(this.drawAPI);
       if (this.chartContainer) {
@@ -551,7 +545,6 @@ export default {
       return Boolean(this.drawAPI);
     },
     buildCanvasElements() {
-      console.debug(`⚙️ build canvas elements ${this.domainObject.name}`);
       const div = document.createElement('div');
       div.innerHTML = `
       <canvas style="position: absolute; background: none; width: 100%; height: 100%;"></canvas>
@@ -718,7 +711,6 @@ export default {
     draw() {
       this.drawScheduled = false;
       if (this.isDestroyed || !this.chartVisible) {
-        console.debug(`🛑 not doing draw ${this.domainObject.name}`);
         return;
       }
 
@@ -747,7 +739,6 @@ export default {
     },
     updateViewport(yAxisId) {
       if (!this.chartVisible) {
-        console.debug(`🛑 not updating viewport ${this.domainObject.name}`);
         return;
       }
       const mainYAxisId = this.config.yAxis.get('id');

--- a/src/plugins/plot/draw/DrawWebGL.js
+++ b/src/plugins/plot/draw/DrawWebGL.js
@@ -154,7 +154,7 @@ DrawWebGL.prototype.initContext = function () {
 DrawWebGL.prototype.destroy = function () {
   // Lose the context and delete all associated resources
   // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#lose_contexts_eagerly
-  this.gl.getExtension('WEBGL_lose_context').loseContext();
+  this.gl.getExtension('WEBGL_lose_context')?.loseContext();
   this.gl.deleteBuffer(this.buffer);
   this.buffer = undefined;
   this.gl.deleteProgram(this.program);

--- a/src/plugins/plot/draw/DrawWebGL.js
+++ b/src/plugins/plot/draw/DrawWebGL.js
@@ -154,7 +154,7 @@ DrawWebGL.prototype.initContext = function () {
 DrawWebGL.prototype.destroy = function () {
   // Lose the context and delete all associated resources
   // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#lose_contexts_eagerly
-  this.gl?.getExtension('WEBGL_lose_context').loseContext();
+  this.gl?.getExtension('WEBGL_lose_context')?.loseContext();
   this.gl?.deleteBuffer(this.buffer);
   this.buffer = undefined;
   this.gl?.deleteProgram(this.program);

--- a/src/plugins/plot/draw/DrawWebGL.js
+++ b/src/plugins/plot/draw/DrawWebGL.js
@@ -154,14 +154,14 @@ DrawWebGL.prototype.initContext = function () {
 DrawWebGL.prototype.destroy = function () {
   // Lose the context and delete all associated resources
   // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#lose_contexts_eagerly
-  this.gl.getExtension('WEBGL_lose_context')?.loseContext();
-  this.gl.deleteBuffer(this.buffer);
+  this.gl?.getExtension('WEBGL_lose_context').loseContext();
+  this.gl?.deleteBuffer(this.buffer);
   this.buffer = undefined;
-  this.gl.deleteProgram(this.program);
+  this.gl?.deleteProgram(this.program);
   this.program = undefined;
-  this.gl.deleteShader(this.vertexShader);
+  this.gl?.deleteShader(this.vertexShader);
   this.vertexShader = undefined;
-  this.gl.deleteShader(this.fragmentShader);
+  this.gl?.deleteShader(this.fragmentShader);
   this.fragmentShader = undefined;
   this.gl = undefined;
 

--- a/src/utils/visibility/VisibilityObserver.js
+++ b/src/utils/visibility/VisibilityObserver.js
@@ -38,8 +38,6 @@ export default class VisibilityObserver {
     if (!element) {
       throw new Error(`VisibilityObserver must be created with an element`);
     }
-    // set the id to some random 4 letters
-    this.id = Math.random().toString(36).substring(2, 6);
     this.#element = element;
     this.isIntersecting = true;
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7202 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Add an intersection observer to destroy the canvas when we've detected we're not visible.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
