### PR TITLE
When searching, build the path objects asynchronously while returning the results

### DIFF
--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -786,16 +786,17 @@ export default class ObjectAPI {
    * Given an identifier, constructs the original path by walking up its parents
    * @param {module:openmct.ObjectAPI~Identifier} identifier
    * @param {Array<module:openmct.DomainObject>} path an array of path objects
+   * @param {AbortSignal} abortSignal (optional) signal to abort fetch requests
    * @returns {Promise<Array<module:openmct.DomainObject>>} a promise containing an array of domain objects
    */
-  async getOriginalPath(identifier, path = []) {
-    const domainObject = await this.get(identifier);
+  async getOriginalPath(identifier, path = [], abortSignal = null) {
+    const domainObject = await this.get(identifier, abortSignal);
     path.push(domainObject);
     const { location } = domainObject;
     if (location && !this.#pathContainsDomainObject(location, path)) {
       // if we have a location, and we don't already have this in our constructed path,
       // then keep walking up the path
-      return this.getOriginalPath(utils.parseKeyString(location), path);
+      return this.getOriginalPath(utils.parseKeyString(location), path, abortSignal);
     } else {
       return path;
     }

--- a/src/ui/layout/search/GrandSearch.vue
+++ b/src/ui/layout/search/GrandSearch.vue
@@ -125,17 +125,14 @@ export default {
       );
     },
     async getSearchResults() {
+      // an abort controller will be passed in that will be used
+      // to cancel an active searches if necessary
       this.searchLoading = true;
       this.$refs.searchResultsDropDown.showSearchStarted();
       this.abortSearchController = new AbortController();
       const abortSignal = this.abortSearchController.signal;
 
       try {
-        this.annotationSearchResults = await this.openmct.annotation.searchForTags(
-          this.searchValue,
-          abortSignal
-        );
-
         const objectSearchPromises = this.openmct.objects.search(this.searchValue, abortSignal);
         for await (const objectSearchResult of objectSearchPromises) {
           const objectsWithPaths = await this.getPathsForObjects(objectSearchResult);
@@ -152,6 +149,11 @@ export default {
           this.showSearchResults();
         }
 
+        this.annotationSearchResults = await this.openmct.annotation.searchForTags(
+          this.searchValue,
+          abortSignal
+        );
+
         this.searchLoading = false;
         this.showSearchResults();
       } catch (error) {
@@ -161,7 +163,8 @@ export default {
           delete this.abortSearchController;
         }
 
-        // Handle non-abort errors
+        // Is this coming from the AbortController?
+        // If so, we can swallow the error. If not, 🤮 it to console
         if (error.name !== 'AbortError') {
           console.error(`😞 Error searching`, error);
         }

--- a/src/ui/layout/search/GrandSearch.vue
+++ b/src/ui/layout/search/GrandSearch.vue
@@ -104,7 +104,7 @@ export default {
         });
       };
     },
-    getPathsForObjects(objectsNeedingPaths) {
+    getPathsForObjects(objectsNeedingPaths, abortSignal) {
       return Promise.all(
         objectsNeedingPaths.map(async (domainObject) => {
           if (!domainObject) {
@@ -114,7 +114,9 @@ export default {
 
           const keyStringForObject = this.openmct.objects.makeKeyString(domainObject.identifier);
           const originalPathObjects = await this.openmct.objects.getOriginalPath(
-            keyStringForObject
+            keyStringForObject,
+            [],
+            abortSignal
           );
 
           return {
@@ -130,45 +132,55 @@ export default {
       this.searchLoading = true;
       this.$refs.searchResultsDropDown.showSearchStarted();
       this.abortSearchController = new AbortController();
-      const abortSignal = this.abortSearchController.signal;
 
       try {
-        const objectSearchPromises = this.openmct.objects.search(this.searchValue, abortSignal);
-        for await (const objectSearchResult of objectSearchPromises) {
-          const objectsWithPaths = await this.getPathsForObjects(objectSearchResult);
-          this.objectSearchResults.push(
-            ...objectsWithPaths.filter((result) => {
-              // Check if the result is NOT an annotation and has a reachable path
-              return (
-                !this.openmct.annotation.isAnnotation(result) &&
-                this.openmct.objects.isReachable(result?.objectPath)
-              );
-            })
-          );
-          // Display the available results so far
-          this.showSearchResults();
-        }
+        const searchObjectsPromise = this.searchObjects(this.abortSearchController.signal);
+        const searchAnnotationsPromise = this.searchAnnotations(this.abortSearchController.signal);
 
-        this.annotationSearchResults = await this.openmct.annotation.searchForTags(
-          this.searchValue,
-          abortSignal
-        );
+        // Wait for all promises, but they process their results as they complete
+        await Promise.allSettled([searchObjectsPromise, searchAnnotationsPromise]);
 
         this.searchLoading = false;
         this.showSearchResults();
       } catch (error) {
         this.searchLoading = false;
 
-        if (this.abortSearchController) {
-          delete this.abortSearchController;
-        }
-
         // Is this coming from the AbortController?
         // If so, we can swallow the error. If not, 🤮 it to console
         if (error.name !== 'AbortError') {
           console.error(`😞 Error searching`, error);
         }
+      } finally {
+        if (this.abortSearchController) {
+          delete this.abortSearchController;
+        }
       }
+    },
+    async searchObjects(abortSignal) {
+      const objectSearchPromises = this.openmct.objects.search(this.searchValue, abortSignal);
+      for await (const objectSearchResult of objectSearchPromises) {
+        const objectsWithPaths = await this.getPathsForObjects(objectSearchResult, abortSignal);
+        this.objectSearchResults.push(
+          ...objectsWithPaths.filter((result) => {
+            // Check if the result is NOT an annotation and has a reachable path
+            return (
+              !this.openmct.annotation.isAnnotation(result) &&
+              this.openmct.objects.isReachable(result?.objectPath)
+            );
+          })
+        );
+        // Display the available results so far for objects
+        this.showSearchResults();
+      }
+    },
+    async searchAnnotations(abortSignal) {
+      const annotationSearchResults = await this.openmct.annotation.searchForTags(
+        this.searchValue,
+        abortSignal
+      );
+      this.annotationSearchResults = annotationSearchResults;
+      // Display the available results so far for annotations
+      this.showSearchResults();
     },
     showSearchResults() {
       const dropdownOptions = {

--- a/src/ui/layout/search/GrandSearchSpec.js
+++ b/src/ui/layout/search/GrandSearchSpec.js
@@ -247,7 +247,7 @@ describe('GrandSearch', () => {
     // eslint-disable-next-line require-await
     mockObjectProvider.search = async (query, abortSignal, searchType) => {
       if (searchType === openmct.objects.SEARCH_TYPES.OBJECTS) {
-        return mockNewObject;
+        return [mockNewObject];
       } else {
         return [];
       }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7264 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
- When building the search results, return them as soon as we can, and asynchronously build the paths incrementally as we receive them.
- Asynchronously search for tags
- Pass abort controllers to search for more details about objects. For ObjectPath, if we've been dismounted, abort the original path search.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [x] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [ ] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
