### PR TITLE
Handle aborted get requests and null domain objects when using ObjectAPI

### DIFF
--- a/e2e/tests/functional/search.e2e.spec.js
+++ b/e2e/tests/functional/search.e2e.spec.js
@@ -200,7 +200,7 @@ test.describe('Grand Search', () => {
 
   test('Slowly typing after search debounce will abort requests @couchdb', async ({ page }) => {
     let requestWasAborted = false;
-    //await createObjectsForSearch(page);
+    await createObjectsForSearch(page);
     page.on('requestfailed', (request) => {
       // check if the request was aborted
       if (request.failure().errorText === 'net::ERR_ABORTED') {

--- a/src/api/objects/ObjectAPI.js
+++ b/src/api/objects/ObjectAPI.js
@@ -232,6 +232,10 @@ export default class ObjectAPI {
       .get(identifier, abortSignal)
       .then((domainObject) => {
         delete this.cache[keystring];
+        if (!domainObject && abortSignal.aborted) {
+          // we've aborted the request
+          return;
+        }
         domainObject = this.applyGetInterceptors(identifier, domainObject);
 
         if (this.supportsMutation(identifier)) {
@@ -791,6 +795,9 @@ export default class ObjectAPI {
    */
   async getOriginalPath(identifier, path = [], abortSignal = null) {
     const domainObject = await this.get(identifier, abortSignal);
+    if (!domainObject) {
+      return [];
+    }
     path.push(domainObject);
     const { location } = domainObject;
     if (location && !this.#pathContainsDomainObject(location, path)) {

--- a/src/plugins/objectMigration/Migrations.js
+++ b/src/plugins/objectMigration/Migrations.js
@@ -180,7 +180,7 @@ define(['uuid'], function ({ v4: uuid }) {
       {
         check(domainObject) {
           return (
-            domainObject.type === 'layout' &&
+            domainObject?.type === 'layout' &&
             domainObject.configuration &&
             domainObject.configuration.layout
           );
@@ -201,7 +201,7 @@ define(['uuid'], function ({ v4: uuid }) {
       {
         check(domainObject) {
           return (
-            domainObject.type === 'telemetry.fixed' &&
+            domainObject?.type === 'telemetry.fixed' &&
             domainObject.configuration &&
             domainObject.configuration['fixed-display']
           );
@@ -246,7 +246,7 @@ define(['uuid'], function ({ v4: uuid }) {
       {
         check(domainObject) {
           return (
-            domainObject.type === 'table' &&
+            domainObject?.type === 'table' &&
             domainObject.configuration &&
             domainObject.configuration.table
           );


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7275 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

1. Check to see if request was aborted and the domain object is null before blindly applying get interceptors
2. Ensure migrations can handle a null returned domain object due to a request abort.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Command line build passes?
* [x] Has this been smoke tested?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
* [ ] Has associated issue been labelled unverified? (only applicable if this PR closes the issue)
* [x] Has associated issue been labelled bug? (only applicable if this PR is for a bug fix)
