### PR TITLE
fix: cleanup from #7029

### DIFF
--- a/src/api/objects/object-utils.js
+++ b/src/api/objects/object-utils.js
@@ -100,7 +100,7 @@ function makeKeyString(identifier) {
   }
 
   return [
-    identifier.namespace.replaceAll(/:/g, '\\:').replaceAll(/\\/g, '\\\\'),
+    identifier.namespace.replace(/:/g, '\\:').replace(/\\/g, '\\\\'),
     identifier.key
   ].join(':');
 }

--- a/src/api/objects/object-utils.js
+++ b/src/api/objects/object-utils.js
@@ -100,7 +100,7 @@ function makeKeyString(identifier) {
   }
 
   return [
-    identifier.namespace.replace(/:/g, '\\:').replace(/\\/g, '\\\\'),
+    identifier.namespace.replace(/\\/g, '\\\\').replace(/:/g, '\\:'),
     identifier.key
   ].join(':');
 }

--- a/src/api/objects/object-utils.js
+++ b/src/api/objects/object-utils.js
@@ -99,10 +99,9 @@ function makeKeyString(identifier) {
     return identifier.key;
   }
 
-  return [
-    identifier.namespace.replace(/\\/g, '\\\\').replace(/:/g, '\\:'),
-    identifier.key
-  ].join(':');
+  return [identifier.namespace.replace(/\\/g, '\\\\').replace(/:/g, '\\:'), identifier.key].join(
+    ':'
+  );
 }
 
 /**

--- a/src/api/objects/object-utils.js
+++ b/src/api/objects/object-utils.js
@@ -99,7 +99,10 @@ function makeKeyString(identifier) {
     return identifier.key;
   }
 
-  return [identifier.namespace.replace(/:/g, '\\:'), identifier.key].join(':');
+  return [
+    identifier.namespace.replaceAll(/:/g, '\\:').replaceAll(/\\/g, '\\\\'),
+    identifier.key
+  ].join(':');
 }
 
 /**

--- a/src/plugins/autoflow/AutoflowTabularPlugin.js
+++ b/src/plugins/autoflow/AutoflowTabularPlugin.js
@@ -35,7 +35,7 @@ export default function (options) {
         return !options || options.type === d.type;
       },
       view: function (domainObject) {
-        return new AutoflowTabularView(domainObject, openmct, document);
+        return new AutoflowTabularView(domainObject, openmct);
       }
     });
   };

--- a/src/plugins/conditionWidget/components/ConditionWidget.vue
+++ b/src/plugins/conditionWidget/components/ConditionWidget.vue
@@ -34,8 +34,9 @@
 </template>
 
 <script>
+import { sanitizeUrl } from '@braintree/sanitize-url';
+
 import tooltipHelpers from '../../../api/tooltips/tooltipMixins';
-const sanitizeUrl = require('@braintree/sanitize-url').sanitizeUrl;
 
 export default {
   mixins: [tooltipHelpers],

--- a/src/plugins/hyperlink/HyperlinkLayout.vue
+++ b/src/plugins/hyperlink/HyperlinkLayout.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script>
-const sanitizeUrl = require('@braintree/sanitize-url').sanitizeUrl;
+import { sanitizeUrl } from '@braintree/sanitize-url';
 
 export default {
   inject: ['domainObject'],

--- a/src/plugins/timer/components/TimerComponent.vue
+++ b/src/plugins/timer/components/TimerComponent.vue
@@ -44,12 +44,11 @@
 </template>
 
 <script>
+import momentDurationFormatSetup from 'moment-duration-format';
+import moment from 'moment-timezone';
 import raf from 'utils/raf';
 
 import throttle from '../../../utils/throttle';
-
-const moment = require('moment-timezone');
-const momentDurationFormatSetup = require('moment-duration-format');
 const refreshRateSeconds = 2;
 
 momentDurationFormatSetup(moment);

--- a/src/plugins/webPage/components/WebPage.vue
+++ b/src/plugins/webPage/components/WebPage.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script>
-const sanitizeUrl = require('@braintree/sanitize-url').sanitizeUrl;
+import { sanitizeUrl } from '@braintree/sanitize-url';
 
 export default {
   inject: ['openmct', 'domainObject'],

--- a/src/ui/router/ApplicationRouter.js
+++ b/src/ui/router/ApplicationRouter.js
@@ -19,11 +19,10 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-/*global module*/
 
-const LocationBar = require('location-bar');
-const EventEmitter = require('EventEmitter');
-const _ = require('lodash');
+import EventEmitter from 'EventEmitter';
+import LocationBar from 'location-bar';
+import _ from 'lodash';
 
 class ApplicationRouter extends EventEmitter {
   /**
@@ -430,4 +429,4 @@ function paramsToObject(searchParams) {
   return params;
 }
 
-module.exports = ApplicationRouter;
+export default ApplicationRouter;


### PR DESCRIPTION
### Describe your changes:

Cleanup PR from #7029 to convert a few more modules to ESM, and to stop using `require`.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Is this a breaking change to be called out in the release notes?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
