### PR TITLE
[lint] Eslint import rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -156,7 +156,6 @@ module.exports = {
     ],
     'import/no-amd': 'error',
     'import/no-commonjs': 'error',
-    'import/no-nodejs-modules': 'error',
     'import/named': 'error',
     'import/no-webpack-loader-syntax': 'error',
     'import/exports-last': 'warn',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,23 +1,21 @@
-const LEGACY_FILES = ['example/**'];
 module.exports = {
   env: {
     browser: true,
     es6: true,
     jasmine: true,
-    amd: true
+    amd: false
   },
   globals: {
     _: 'readonly'
   },
-  plugins: ['prettier', 'unicorn', 'simple-import-sort'],
+  plugins: ['prettier', 'unicorn', 'simple-import-sort', 'import'],
   extends: [
     'eslint:recommended',
     'plugin:compat/recommended',
     'plugin:vue/vue3-recommended',
     'plugin:you-dont-need-lodash-underscore/compatible',
     'plugin:prettier/recommended',
-    'plugin:no-unsanitized/DOM',
-    'plugin:import/recommended'
+    'plugin:no-unsanitized/DOM'
   ],
   parser: 'vue-eslint-parser',
   parserOptions: {
@@ -153,9 +151,19 @@ module.exports = {
         cases: {
           pascalCase: true
         },
-        ignore: ['^.*\\.js$']
+        ignore: ['^.*\\.js$', '.eslintrc\\.cjs']
       }
     ],
+    'import/no-amd': 'error',
+    'import/no-commonjs': 'error',
+    'import/no-nodejs-modules': 'error',
+    'import/named': 'error',
+    'import/no-webpack-loader-syntax': 'error',
+    'import/exports-last': 'warn',
+    'import/first': 'error',
+    'import/no-import-module-exports': 'error',
+    'import/no-mutable-exports': 'error',
+    'import/no-unused-modules': 'error',
     'vue/first-attribute-linebreak': 'error',
     'vue/multiline-html-element-content-newline': 'off',
     'vue/singleline-html-element-content-newline': 'off',
@@ -163,7 +171,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: LEGACY_FILES,
+      files: ['example/**'],
       rules: {
         'no-unused-vars': [
           'error',
@@ -176,6 +184,12 @@ module.exports = {
         'no-nested-ternary': 'off',
         'no-var': 'off',
         'one-var': 'off'
+      }
+    },
+    {
+      files: ['*.eslintrc.cjs'],
+      env: {
+        node: true
       }
     }
   ]

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,7 +16,8 @@ module.exports = {
     'plugin:vue/vue3-recommended',
     'plugin:you-dont-need-lodash-underscore/compatible',
     'plugin:prettier/recommended',
-    'plugin:no-unsanitized/DOM'
+    'plugin:no-unsanitized/DOM',
+    'plugin:import/recommended'
   ],
   parser: 'vue-eslint-parser',
   parserOptions: {

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,5 +14,6 @@ d80b6923541704ab925abf0047cbbc58735c27e2
 8040b275fcf2ba71b42cd72d4daa64bb25c19c2d
 # Apply `prettier` formatting
 caa7bc6faebc204f67aedae3e35fb0d0d3ce27a7
+ff0d46c9d8cce8cdc43413ea4b32f60431f4253f
 # ES6 conversion
 2e03bc394ce6fd877c138ed79518b4f97425c298

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,3 +14,5 @@ d80b6923541704ab925abf0047cbbc58735c27e2
 8040b275fcf2ba71b42cd72d4daa64bb25c19c2d
 # Apply `prettier` formatting
 caa7bc6faebc204f67aedae3e35fb0d0d3ce27a7
+# ES6 conversion
+2e03bc394ce6fd877c138ed79518b4f97425c298

--- a/e2e/helper/notebookUtils.js
+++ b/e2e/helper/notebookUtils.js
@@ -20,11 +20,12 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
+import { fileURLToPath } from 'url';
+
 import { createDomainObjectWithDefaults } from '../appActions.js';
 
 const NOTEBOOK_DROP_AREA = '.c-notebook__drag-area';
 const CUSTOM_NAME = 'CUSTOM_NAME';
-import { fileURLToPath } from 'url';
 
 /**
  * @param {import('@playwright/test').Page} page

--- a/e2e/helper/planningUtils.js
+++ b/e2e/helper/planningUtils.js
@@ -31,7 +31,7 @@ import { expect } from '../pluginFixtures.js';
  * @param {object} plan The raw plan json to assert against
  * @param {string} objectUrl The URL of the object to assert against (plan or gantt chart)
  */
-export async function assertPlanActivities(page, plan, objectUrl) {
+async function assertPlanActivities(page, plan, objectUrl) {
   const groups = Object.keys(plan);
   for (const group of groups) {
     for (let i = 0; i < plan[group].length; i++) {
@@ -88,7 +88,7 @@ function activitiesWithinTimeBounds(start1, end1, start2, end2) {
  * @param {object} plan The raw plan json to assert against
  * @param {string} objectUrl The URL of the object to assert against (plan or gantt chart)
  */
-export async function assertPlanOrderedSwimLanes(page, plan, objectUrl) {
+async function assertPlanOrderedSwimLanes(page, plan, objectUrl) {
   // Switch to the plan view
   await page.goto(`${objectUrl}?view=plan.view`);
   const planGroups = await page
@@ -112,7 +112,7 @@ export async function assertPlanOrderedSwimLanes(page, plan, objectUrl) {
  * @param {object} planJson
  * @param {string} planObjectUrl
  */
-export async function setBoundsToSpanAllActivities(page, planJson, planObjectUrl) {
+async function setBoundsToSpanAllActivities(page, planJson, planObjectUrl) {
   const activities = Object.values(planJson).flat();
   // Get the earliest start value
   const start = Math.min(...activities.map((activity) => activity.start));
@@ -129,13 +129,13 @@ export async function setBoundsToSpanAllActivities(page, planJson, planObjectUrl
  * @param {import('@playwright/test').Page} page
  * @param {import('../../appActions').CreatedObjectInfo} plan
  */
-export async function setDraftStatusForPlan(page, plan) {
+async function setDraftStatusForPlan(page, plan) {
   await page.evaluate(async (planObject) => {
     await window.openmct.status.set(planObject.uuid, 'draft');
   }, plan);
 }
 
-export async function addPlanGetInterceptor(page) {
+async function addPlanGetInterceptor(page) {
   await page.waitForLoadState('load');
   await page.evaluate(async () => {
     await window.openmct.objects.addGetInterceptor({
@@ -154,3 +154,11 @@ export async function addPlanGetInterceptor(page) {
     });
   });
 }
+
+export {
+  addPlanGetInterceptor,
+  assertPlanActivities,
+  assertPlanOrderedSwimLanes,
+  setBoundsToSpanAllActivities,
+  setDraftStatusForPlan
+};

--- a/example/generator/GeneratorMetadataProvider.js
+++ b/example/generator/GeneratorMetadataProvider.js
@@ -1,3 +1,25 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 const METADATA_BY_TYPE = {
   generator: {
     values: [
@@ -123,7 +145,7 @@ const METADATA_BY_TYPE = {
   }
 };
 
-export default function GeneratorMetadataProvider() {}
+function GeneratorMetadataProvider() {}
 
 GeneratorMetadataProvider.prototype.supportsMetadata = function (domainObject) {
   return Object.prototype.hasOwnProperty.call(METADATA_BY_TYPE, domainObject.type);
@@ -132,3 +154,5 @@ GeneratorMetadataProvider.prototype.supportsMetadata = function (domainObject) {
 GeneratorMetadataProvider.prototype.getMetadata = function (domainObject) {
   return Object.assign({}, domainObject.telemetry, METADATA_BY_TYPE[domainObject.type]);
 };
+
+export { GeneratorMetadataProvider };

--- a/example/generator/SinewaveLimitProvider.js
+++ b/example/generator/SinewaveLimitProvider.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-var PURPLE = {
+const PURPLE = {
     sin: 2.2,
     cos: 2.2
   },
@@ -67,96 +67,119 @@ var PURPLE = {
     }
   };
 
-export default function SinewaveLimitProvider() {}
+/**
+ * SinewaveLimitProvider class provides limit evaluation for sinewave data.
+ */
+class SinewaveLimitProvider {
+  /**
+   * Determines if the SinewaveLimitProvider supports limits for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to check.
+   * @returns {boolean} True if supports limits, false otherwise.
+   */
+  supportsLimits(domainObject) {
+    return domainObject.type === 'generator';
+  }
 
-SinewaveLimitProvider.prototype.supportsLimits = function (domainObject) {
-  return domainObject.type === 'generator';
-};
+  /**
+   * Provides a limit evaluator for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to get the limit evaluator for.
+   * @returns {Object} The limit evaluator.
+   */
+  getLimitEvaluator(domainObject) {
+    return {
+      evaluate: function evaluate(datum, valueMetadata) {
+        var range = valueMetadata && valueMetadata.key;
 
-SinewaveLimitProvider.prototype.getLimitEvaluator = function (domainObject) {
-  return {
-    evaluate: function (datum, valueMetadata) {
-      var range = valueMetadata && valueMetadata.key;
-
-      if (datum[range] > RED[range]) {
-        return LIMITS.rh;
-      }
-
-      if (datum[range] < -RED[range]) {
-        return LIMITS.rl;
-      }
-
-      if (datum[range] > YELLOW[range]) {
-        return LIMITS.yh;
-      }
-
-      if (datum[range] < -YELLOW[range]) {
-        return LIMITS.yl;
-      }
-    }
-  };
-};
-
-SinewaveLimitProvider.prototype.getLimits = function (domainObject) {
-  return {
-    limits: function () {
-      return Promise.resolve({
-        WATCH: {
-          low: {
-            color: 'cyan',
-            sin: -CYAN.sin,
-            cos: -CYAN.cos
-          },
-          high: {
-            color: 'cyan',
-            ...CYAN
-          }
-        },
-        WARNING: {
-          low: {
-            color: 'yellow',
-            sin: -YELLOW.sin,
-            cos: -YELLOW.cos
-          },
-          high: {
-            color: 'yellow',
-            ...YELLOW
-          }
-        },
-        DISTRESS: {
-          low: {
-            color: 'orange',
-            sin: -ORANGE.sin,
-            cos: -ORANGE.cos
-          },
-          high: {
-            color: 'orange',
-            ...ORANGE
-          }
-        },
-        CRITICAL: {
-          low: {
-            color: 'red',
-            sin: -RED.sin,
-            cos: -RED.cos
-          },
-          high: {
-            color: 'red',
-            ...RED
-          }
-        },
-        SEVERE: {
-          low: {
-            color: 'purple',
-            sin: -PURPLE.sin,
-            cos: -PURPLE.cos
-          },
-          high: {
-            color: 'purple',
-            ...PURPLE
-          }
+        if (datum[range] > RED[range]) {
+          return LIMITS.rh;
         }
-      });
-    }
-  };
-};
+
+        if (datum[range] < -RED[range]) {
+          return LIMITS.rl;
+        }
+
+        if (datum[range] > YELLOW[range]) {
+          return LIMITS.yh;
+        }
+
+        if (datum[range] < -YELLOW[range]) {
+          return LIMITS.yl;
+        }
+      }
+    };
+  }
+
+  /**
+   * Retrieves the limits for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to get limits for.
+   * @returns {Object} The limits.
+   */
+  getLimits(domainObject) {
+    return {
+      limits: function limits() {
+        return Promise.resolve({
+          WATCH: {
+            low: {
+              color: 'cyan',
+              sin: -CYAN.sin,
+              cos: -CYAN.cos
+            },
+            high: {
+              color: 'cyan',
+              ...CYAN
+            }
+          },
+          WARNING: {
+            low: {
+              color: 'yellow',
+              sin: -YELLOW.sin,
+              cos: -YELLOW.cos
+            },
+            high: {
+              color: 'yellow',
+              ...YELLOW
+            }
+          },
+          DISTRESS: {
+            low: {
+              color: 'orange',
+              sin: -ORANGE.sin,
+              cos: -ORANGE.cos
+            },
+            high: {
+              color: 'orange',
+              ...ORANGE
+            }
+          },
+          CRITICAL: {
+            low: {
+              color: 'red',
+              sin: -RED.sin,
+              cos: -RED.cos
+            },
+            high: {
+              color: 'red',
+              ...RED
+            }
+          },
+          SEVERE: {
+            low: {
+              color: 'purple',
+              sin: -PURPLE.sin,
+              cos: -PURPLE.cos
+            },
+            high: {
+              color: 'purple',
+              ...PURPLE
+            }
+          }
+        });
+      }
+    };
+  }
+}
+
+export default SinewaveLimitProvider;

--- a/example/generator/StateGeneratorProvider.js
+++ b/example/generator/StateGeneratorProvider.js
@@ -20,52 +20,91 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default function StateGeneratorProvider() {}
+/**
+ * StateGeneratorProvider class provides methods to support subscription and request for state generation.
+ */
+class StateGeneratorProvider {
+  /**
+   * Determines if the StateGeneratorProvider supports subscription for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to check.
+   * @returns {boolean} True if supports subscription, false otherwise.
+   */
+  supportsSubscribe(domainObject) {
+    return domainObject.type === 'example.state-generator';
+  }
 
+  /**
+   * Subscribes to updates for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to subscribe to.
+   * @param {Function} callback - The callback to invoke with new data.
+   * @returns {Function} A function to unsubscribe from updates.
+   */
+  subscribe(domainObject, callback) {
+    const duration = domainObject.telemetry.duration * 1000;
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const datum = pointForTimestamp(now, duration, domainObject.name);
+      datum.value = String(datum.value);
+      callback(datum);
+    }, duration);
+
+    return function unsubscribe() {
+      clearInterval(interval);
+    };
+  }
+
+  /**
+   * Determines if the StateGeneratorProvider supports request for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to check.
+   * @param {Object} options - Request options.
+   * @returns {boolean} True if supports request, false otherwise.
+   */
+  supportsRequest(domainObject, options) {
+    return domainObject.type === 'example.state-generator';
+  }
+
+  /**
+   * Handles data requests for the given domain object.
+   *
+   * @param {Object} domainObject - The domain object to request data for.
+   * @param {Object} options - Request options including start and end times.
+   * @returns {Promise<Array<Object>>} A promise that resolves to an array of data points.
+   */
+  request(domainObject, options) {
+    let start = options.start;
+    const end = Math.min(Date.now(), options.end); // no future values
+    const duration = domainObject.telemetry.duration * 1000;
+    if (options.strategy === 'latest' || options.size === 1) {
+      start = end;
+    }
+
+    const data = [];
+    while (start <= end && data.length < 5000) {
+      data.push(pointForTimestamp(start, duration, domainObject.name));
+      start += duration;
+    }
+
+    return Promise.resolve(data);
+  }
+}
+
+/**
+ * Generates a telemetry point for a given timestamp.
+ *
+ * @param {number} timestamp - The timestamp for generating the point.
+ * @param {number} duration - The duration between points.
+ * @param {string} name - The name of the telemetry point.
+ * @returns {Object} The telemetry data point.
+ */
 function pointForTimestamp(timestamp, duration, name) {
   return {
-    name: name,
+    name,
     utc: Math.floor(timestamp / duration) * duration,
     value: Math.floor(timestamp / duration) % 2
   };
 }
 
-StateGeneratorProvider.prototype.supportsSubscribe = function (domainObject) {
-  return domainObject.type === 'example.state-generator';
-};
-
-StateGeneratorProvider.prototype.subscribe = function (domainObject, callback) {
-  var duration = domainObject.telemetry.duration * 1000;
-
-  var interval = setInterval(function () {
-    var now = Date.now();
-    var datum = pointForTimestamp(now, duration, domainObject.name);
-    datum.value = String(datum.value);
-    callback(datum);
-  }, duration);
-
-  return function () {
-    clearInterval(interval);
-  };
-};
-
-StateGeneratorProvider.prototype.supportsRequest = function (domainObject, options) {
-  return domainObject.type === 'example.state-generator';
-};
-
-StateGeneratorProvider.prototype.request = function (domainObject, options) {
-  var start = options.start;
-  var end = Math.min(Date.now(), options.end); // no future values
-  var duration = domainObject.telemetry.duration * 1000;
-  if (options.strategy === 'latest' || options.size === 1) {
-    start = end;
-  }
-
-  var data = [];
-  while (start <= end && data.length < 5000) {
-    data.push(pointForTimestamp(start, duration, domainObject.name));
-    start += duration;
-  }
-
-  return Promise.resolve(data);
-};
+export default StateGeneratorProvider;

--- a/openmct.js
+++ b/openmct.js
@@ -20,15 +20,6 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-const matcher = /\/openmct.js$/;
-if (document.currentScript) {
-  let src = document.currentScript.src;
-  if (src && matcher.test(src)) {
-    // eslint-disable-next-line no-undef
-    __webpack_public_path__ = src.replace(matcher, '') + '/';
-  }
-}
-
 /**
  * @typedef {object} BuildInfo
  * @property {string} version
@@ -75,6 +66,15 @@ if (document.currentScript) {
  */
 
 import { MCT } from './src/MCT.js';
+
+const matcher = /\/openmct.js$/;
+if (document.currentScript) {
+  let src = document.currentScript.src;
+  if (src && matcher.test(src)) {
+    // eslint-disable-next-line no-undef
+    __webpack_public_path__ = src.replace(matcher, '') + '/';
+  }
+}
 
 /** @type {OpenMCT} */
 const openmct = new MCT();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "8.54.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-compat": "4.2.0",
+    "eslint-plugin-import":"2.29.1",
     "eslint-plugin-no-unsanitized": "4.0.2",
     "eslint-plugin-playwright": "0.12.0",
     "eslint-plugin-prettier": "4.2.1",

--- a/src/api/menu/menu.js
+++ b/src/api/menu/menu.js
@@ -26,7 +26,7 @@ import { h } from 'vue';
 import MenuComponent from './components/MenuComponent.vue';
 import SuperMenuComponent from './components/SuperMenu.vue';
 
-export const MENU_PLACEMENT = {
+const MENU_PLACEMENT = {
   TOP: 'top',
   TOP_LEFT: 'top-left',
   TOP_RIGHT: 'top-right',
@@ -37,7 +37,16 @@ export const MENU_PLACEMENT = {
   RIGHT: 'right'
 };
 
+/**
+ * Represents a Menu that extends EventEmitter functionality.
+ * This class provides methods to show and dismiss menus, and manages their lifecycle.
+ */
 class Menu extends EventEmitter {
+  /**
+   * Creates a Menu instance.
+   * @param {Object} options - Configuration options for the menu.
+   * @param {Function} [options.onDestroy] - Callback function for the 'destroy' event.
+   */
   constructor(options) {
     super();
 
@@ -46,12 +55,17 @@ class Menu extends EventEmitter {
       this.once('destroy', options.onDestroy);
     }
 
+    // Binding methods to ensure the correct 'this' context
     this.dismiss = this.dismiss.bind(this);
     this.show = this.show.bind(this);
     this.showMenu = this.showMenu.bind(this);
     this.showSuperMenu = this.showSuperMenu.bind(this);
   }
 
+  /**
+   * Dismisses the menu and removes the associated event listener.
+   * Emits a 'destroy' event on dismissal.
+   */
   dismiss() {
     if (this.destroy) {
       this.destroy();
@@ -61,6 +75,10 @@ class Menu extends EventEmitter {
     this.emit('destroy');
   }
 
+  /**
+   * Shows a menu using the MenuComponent.
+   * Renders the menu and sets up necessary destruction logic.
+   */
   showMenu() {
     if (this.destroy) {
       return;
@@ -80,6 +98,10 @@ class Menu extends EventEmitter {
     this.show();
   }
 
+  /**
+   * Shows a super menu using the SuperMenuComponent.
+   * Renders the super menu and sets up necessary destruction logic.
+   */
   showSuperMenu() {
     const { vNode, destroy } = mount({
       data() {
@@ -102,10 +124,13 @@ class Menu extends EventEmitter {
     this.show();
   }
 
+  /**
+   * Appends the menu element to the document body and adds an event listener for dismissal.
+   */
   show() {
     document.body.appendChild(this.el);
     document.addEventListener('click', this.dismiss);
   }
 }
 
-export default Menu;
+export { Menu, MENU_PLACEMENT };

--- a/src/exporters/ImageExporter.js
+++ b/src/exporters/ImageExporter.js
@@ -25,15 +25,15 @@
  * Originally created by hudsonfoo on 09/02/16
  */
 
+import html2canvas from 'html2canvas';
+import { saveAs } from 'saveAs';
+import { v4 as uuid } from 'uuid';
+
 function replaceDotsWithUnderscores(filename) {
   const regex = /\./gi;
 
   return filename.replace(regex, '_');
 }
-
-import html2canvas from 'html2canvas';
-import { saveAs } from 'saveAs';
-import { v4 as uuid } from 'uuid';
 
 class ImageExporter {
   constructor(openmct) {

--- a/src/plugins/LADTable/components/LadRow.vue
+++ b/src/plugins/LADTable/components/LadRow.vue
@@ -48,13 +48,13 @@
 </template>
 
 <script>
-const CONTEXT_MENU_ACTIONS = ['viewDatumAction', 'viewHistoricalData', 'remove'];
-const BLANK_VALUE = '---';
-
 import identifierToString from '/src/tools/url.js';
 import PreviewAction from '@/ui/preview/PreviewAction.js';
 
 import tooltipHelpers from '../../../api/tooltips/tooltipMixins.js';
+
+const CONTEXT_MENU_ACTIONS = ['viewDatumAction', 'viewHistoricalData', 'remove'];
+const BLANK_VALUE = '---';
 
 export default {
   mixins: [tooltipHelpers],

--- a/src/plugins/LADTable/pluginSpec.js
+++ b/src/plugins/LADTable/pluginSpec.js
@@ -273,7 +273,7 @@ describe('The LAD Table', () => {
       expect(rowName).toBe(expectedName);
     });
 
-    fit('should show the correct values for the datum based on domain and range hints', async () => {
+    it('should show the correct values for the datum based on domain and range hints', async () => {
       const range = mockObj.telemetry.telemetry.values.find((val) => {
         return val.hints && val.hints.range !== undefined;
       }).key;

--- a/src/plugins/LADTable/pluginSpec.js
+++ b/src/plugins/LADTable/pluginSpec.js
@@ -273,7 +273,7 @@ describe('The LAD Table', () => {
       expect(rowName).toBe(expectedName);
     });
 
-    it('should show the correct values for the datum based on domain and range hints', async () => {
+    fit('should show the correct values for the datum based on domain and range hints', async () => {
       const range = mockObj.telemetry.telemetry.values.find((val) => {
         return val.hints && val.hints.range !== undefined;
       }).key;

--- a/src/plugins/URLIndicatorPlugin/URLIndicator.js
+++ b/src/plugins/URLIndicatorPlugin/URLIndicator.js
@@ -19,12 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-
-// Set of connection states; changing among these states will be
-// reflected in the indicator's appearance.
-// CONNECTED: Everything nominal, expect to be able to read/write.
-// DISCONNECTED: HTTP failed; maybe misconfigured, disconnected.
-// PENDING: Still trying to connect, and haven't failed yet.
+// Set of connection states
 const CONNECTED = {
   statusClass: 's-status-on'
 };
@@ -34,78 +29,108 @@ const PENDING = {
 const DISCONNECTED = {
   statusClass: 's-status-warning-hi'
 };
-export default function URLIndicator(options, simpleIndicator) {
-  this.bindMethods();
-  this.count = 0;
 
-  this.indicator = simpleIndicator;
-  this.setDefaultsFromOptions(options);
-  this.setIndicatorToState(PENDING);
+/**
+ * URLIndicator class for monitoring and displaying the connection status of a URL.
+ */
+class URLIndicator {
+  /**
+   * Create a URLIndicator.
+   * @param {Object} options - Configuration options for the URLIndicator.
+   * @param {Object} simpleIndicator - The indicator object used for display.
+   */
+  constructor(options, simpleIndicator) {
+    this.bindMethods();
+    this.count = 0;
 
-  this.fetchUrl();
-  setInterval(this.fetchUrl, this.interval);
-}
+    this.indicator = simpleIndicator;
+    this.setDefaultsFromOptions(options);
+    this.setIndicatorToState(PENDING);
 
-URLIndicator.prototype.setIndicatorToState = function (state) {
-  switch (state) {
-    case CONNECTED: {
-      this.indicator.text(this.label + ' is connected');
-      this.indicator.description(
-        this.label + ' is online, checking status every ' + this.interval + ' milliseconds.'
-      );
-      break;
-    }
-
-    case PENDING: {
-      this.indicator.text('Checking status of ' + this.label + ' please stand by...');
-      this.indicator.description('Checking status of ' + this.label + ' please stand by...');
-      break;
-    }
-
-    case DISCONNECTED: {
-      this.indicator.text(this.label + ' is offline');
-      this.indicator.description(
-        this.label + ' is offline, checking status every ' + this.interval + ' milliseconds'
-      );
-      break;
-    }
+    this.fetchUrl();
+    setInterval(this.fetchUrl, this.interval);
   }
 
-  this.indicator.statusClass(state.statusClass);
-};
+  /**
+   * Binds methods to the instance context.
+   */
+  bindMethods() {
+    this.fetchUrl = this.fetchUrl.bind(this);
+    this.handleSuccess = this.handleSuccess.bind(this);
+    this.handleError = this.handleError.bind(this);
+    this.setIndicatorToState = this.setIndicatorToState.bind(this);
+  }
 
-URLIndicator.prototype.fetchUrl = function () {
-  fetch(this.URLpath)
-    .then((response) => {
-      if (response.ok) {
-        this.handleSuccess();
-      } else {
+  /**
+   * Sets the indicator to a specified state.
+   * @param {Object} state - The state to set the indicator to.
+   */
+  setIndicatorToState(state) {
+    switch (state) {
+      case CONNECTED:
+        this.indicator.text(this.label + ' is connected');
+        this.indicator.description(
+          this.label + ' is online, checking status every ' + this.interval + ' milliseconds.'
+        );
+        break;
+
+      case PENDING:
+        this.indicator.text('Checking status of ' + this.label + ' please stand by...');
+        this.indicator.description('Checking status of ' + this.label + ' please stand by...');
+        break;
+
+      case DISCONNECTED:
+        this.indicator.text(this.label + ' is offline');
+        this.indicator.description(
+          this.label + ' is offline, checking status every ' + this.interval + ' milliseconds'
+        );
+        break;
+    }
+
+    this.indicator.statusClass(state.statusClass);
+  }
+
+  /**
+   * Fetches the URL and sets the indicator state based on the response.
+   */
+  fetchUrl() {
+    fetch(this.URLpath)
+      .then((response) => {
+        if (response.ok) {
+          this.handleSuccess();
+        } else {
+          this.handleError();
+        }
+      })
+      .catch(() => {
         this.handleError();
-      }
-    })
-    .catch((error) => {
-      this.handleError();
-    });
-};
+      });
+  }
 
-URLIndicator.prototype.handleError = function (e) {
-  this.setIndicatorToState(DISCONNECTED);
-};
+  /**
+   * Handles errors in fetching the URL.
+   */
+  handleError() {
+    this.setIndicatorToState(DISCONNECTED);
+  }
 
-URLIndicator.prototype.handleSuccess = function () {
-  this.setIndicatorToState(CONNECTED);
-};
+  /**
+   * Handles successful fetching of the URL.
+   */
+  handleSuccess() {
+    this.setIndicatorToState(CONNECTED);
+  }
 
-URLIndicator.prototype.setDefaultsFromOptions = function (options) {
-  this.URLpath = options.url;
-  this.label = options.label || options.url;
-  this.interval = options.interval || 10000;
-  this.indicator.iconClass(options.iconClass || 'icon-chain-links');
-};
+  /**
+   * Sets default values from options.
+   * @param {Object} options - The options to set defaults from.
+   */
+  setDefaultsFromOptions(options) {
+    this.URLpath = options.url;
+    this.label = options.label || options.url;
+    this.interval = options.interval || 10000;
+    this.indicator.iconClass(options.iconClass || 'icon-chain-links');
+  }
+}
 
-URLIndicator.prototype.bindMethods = function () {
-  this.fetchUrl = this.fetchUrl.bind(this);
-  this.handleSuccess = this.handleSuccess.bind(this);
-  this.handleError = this.handleError.bind(this);
-  this.setIndicatorToState = this.setIndicatorToState.bind(this);
-};
+export default URLIndicator;

--- a/src/plugins/autoflow/AutoflowTabularRowController.js
+++ b/src/plugins/autoflow/AutoflowTabularRowController.js
@@ -29,7 +29,7 @@
  * @param openmct a reference to the openmct application
  * @param {Function} callback a callback to invoke with "last updated" timestamps
  */
-export default function AutoflowTabularRowController(domainObject, data, openmct, callback) {
+function AutoflowTabularRowController(domainObject, data, openmct, callback) {
   this.domainObject = domainObject;
   this.data = data;
   this.openmct = openmct;
@@ -89,3 +89,5 @@ AutoflowTabularRowController.prototype.destroy = function () {
     this.unsubscribe();
   }
 };
+
+export default AutoflowTabularRowController;

--- a/src/plugins/autoflow/dom-observer.js
+++ b/src/plugins/autoflow/dom-observer.js
@@ -20,25 +20,37 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default function DOMObserver(element) {
-  this.element = element;
-  this.observers = [];
-}
+/**
+ * DOMObserver class for observing changes in the DOM.
+ */
+class DOMObserver {
+  /**
+   * Create a DOMObserver instance.
+   * @param {Element} element - The DOM element to observe.
+   */
+  constructor(element) {
+    this.element = element;
+    this.observers = [];
+  }
 
-DOMObserver.prototype.when = function (latchFunction) {
-  return new Promise(
-    function (resolve, reject) {
-      //Test latch function at least once
+  /**
+   * Wait until the latch function returns true.
+   * @param {Function} latchFunction - The function to test for latch condition.
+   * @returns {Promise} A promise that resolves when the latch condition is true.
+   */
+  when(latchFunction) {
+    return new Promise((resolve, reject) => {
+      // Test latch function at least once
       if (latchFunction()) {
         resolve();
       } else {
-        //Latch condition not true yet, create observer on DOM and test again on change.
+        // Latch condition not true yet, create observer on DOM and test again on change.
         const config = {
           attributes: true,
           childList: true,
           subtree: true
         };
-        const observer = new MutationObserver(function () {
+        const observer = new MutationObserver(() => {
           if (latchFunction()) {
             resolve();
           }
@@ -46,14 +58,17 @@ DOMObserver.prototype.when = function (latchFunction) {
         observer.observe(this.element, config);
         this.observers.push(observer);
       }
-    }.bind(this)
-  );
-};
+    });
+  }
 
-DOMObserver.prototype.destroy = function () {
-  this.observers.forEach(
-    function (observer) {
+  /**
+   * Destroy all the observers.
+   */
+  destroy() {
+    this.observers.forEach((observer) => {
       observer.disconnect();
-    }.bind(this)
-  );
-};
+    });
+  }
+}
+
+export default DOMObserver;

--- a/src/plugins/charts/scatter/ScatterPlotWithUnderlay.vue
+++ b/src/plugins/charts/scatter/ScatterPlotWithUnderlay.vue
@@ -45,12 +45,12 @@
 <script>
 import Plotly from 'plotly-basic';
 
+import { getValidatedData } from '@/plugins/plan/util';
+
 const MULTI_AXES_X_PADDING_PERCENT = {
   LEFT: 8,
   RIGHT: 94
 };
-
-import { getValidatedData } from '@/plugins/plan/util';
 
 const PATH_COLORS = ['blue', 'red', 'green'];
 const MARKER_COLOR = 'white';

--- a/src/plugins/condition/utils/evaluator.js
+++ b/src/plugins/condition/utils/evaluator.js
@@ -21,7 +21,13 @@
  *****************************************************************************/
 import { TRIGGER } from './constants.js';
 
-export function evaluateResults(results, trigger) {
+/**
+ * Evaluates an array of results based on a specified trigger condition.
+ * @param {Array} results - The array of results to evaluate.
+ * @param {TRIGGER} trigger - The trigger condition to apply for evaluation.
+ * @returns {boolean} The result of the evaluation based on the trigger.
+ */
+function evaluateResults(results, trigger) {
   if (trigger && trigger === TRIGGER.XOR) {
     return matchExact(results, 1);
   } else if (trigger && trigger === TRIGGER.NOT) {
@@ -33,37 +39,51 @@ export function evaluateResults(results, trigger) {
   }
 }
 
+/**
+ * Checks if all elements in the results array are true.
+ * @param {Array} results - The array of results to evaluate.
+ * @returns {boolean} True if all elements are true, otherwise false.
+ */
 function matchAll(results) {
   for (let result of results) {
     if (result !== true) {
       return false;
     }
   }
-
   return true;
 }
 
+/**
+ * Checks if any element in the results array is true.
+ * @param {Array} results - The array of results to evaluate.
+ * @returns {boolean} True if any element is true, otherwise false.
+ */
 function matchAny(results) {
   for (let result of results) {
     if (result === true) {
       return true;
     }
   }
-
   return false;
 }
 
+/**
+ * Checks if the number of true elements in the results array matches the target.
+ * @param {Array} results - The array of results to evaluate.
+ * @param {number} target - The target number of true elements to match.
+ * @returns {boolean} True if the number of true elements matches the target, otherwise false.
+ */
 function matchExact(results, target) {
   let matches = 0;
   for (let result of results) {
     if (result === true) {
       matches++;
     }
-
     if (matches > target) {
       return false;
     }
   }
-
   return matches === target;
 }
+
+export { evaluateResults };

--- a/src/plugins/displayLayout/LayoutDrag.js
+++ b/src/plugins/displayLayout/LayoutDrag.js
@@ -47,36 +47,56 @@
  * @constructor
  * @memberof platform/features/layout
  */
-export default function LayoutDrag(rawPosition, posFactor, dimFactor, gridSize) {
+function LayoutDrag(rawPosition, posFactor, dimFactor, gridSize) {
   this.rawPosition = rawPosition;
   this.posFactor = posFactor;
   this.dimFactor = dimFactor;
   this.gridSize = gridSize;
 }
 
-// Convert a delta from pixel coordinates to grid coordinates,
-// rounding to whole-number grid coordinates.
+/**
+ * Convert a delta from pixel coordinates to grid coordinates,
+ * rounding to whole-number grid coordinates.
+ * @param {number[]} gridSize the size of each grid element, in pixels
+ * @param {number[]} pixelDelta the offset from the original position, in pixels
+ * @returns {number[]} the delta in grid coordinates
+ */
 function toGridDelta(gridSize, pixelDelta) {
   return pixelDelta.map(function (v, i) {
     return Math.round(v / gridSize[i]);
   });
 }
 
-// Utility function to perform element-by-element multiplication
+/**
+ * Utility function to perform element-by-element multiplication.
+ * @param {number[]} array the array to be multiplied
+ * @param {number[]} factors the factors to multiply with
+ * @returns {number[]} the resulting array after multiplication
+ */
 function multiply(array, factors) {
   return array.map(function (v, i) {
     return v * factors[i];
   });
 }
 
-// Utility function to perform element-by-element addition
+/**
+ * Utility function to perform element-by-element addition.
+ * @param {number[]} array the array to be added
+ * @param {number[]} other the array to be added with
+ * @returns {number[]} the resulting array after addition
+ */
 function add(array, other) {
   return array.map(function (v, i) {
     return v + other[i];
   });
 }
 
-// Utility function to perform element-by-element max-choosing
+/**
+ * Utility function to perform element-by-element max-choosing.
+ * @param {number[]} array the array to be compared
+ * @param {number[]} other the array to be compared with
+ * @returns {number[]} the resulting array after max-choosing
+ */
 function max(array, other) {
   return array.map(function (v, i) {
     return Math.max(v, other[i]);
@@ -106,3 +126,5 @@ LayoutDrag.prototype.getAdjustedPosition = function (pixelDelta) {
     position: max(add(this.rawPosition.position, multiply(gridDelta, this.posFactor)), [0, 0])
   };
 };
+
+export default LayoutDrag;

--- a/src/plugins/gauge/gauge-limit-util.js
+++ b/src/plugins/gauge/gauge-limit-util.js
@@ -5,11 +5,16 @@ const GAUGE_LIMITS = {
   q4: 270
 };
 
-export const DIAL_VALUE_DEG_OFFSET = 45;
+const DIAL_VALUE_DEG_OFFSET = 45;
 
-// type: low, high
-// quadrant: low, mid, high, max
-export function getLimitDegree(type, quadrant) {
+/**
+ * Retrieves the limit degree based on the type and quadrant.
+ *
+ * @param {string} type - The type of limit ('low' or 'high').
+ * @param {string} quadrant - The quadrant of the gauge ('low', 'mid', 'high', or 'max').
+ * @returns {number} - The limit degree based on the type and quadrant.
+ */
+function getLimitDegree(type, quadrant) {
   if (quadrant === 'max') {
     return GAUGE_LIMITS.q4 + DIAL_VALUE_DEG_OFFSET;
   }
@@ -34,3 +39,5 @@ function getHighLimitDegree(quadrant) {
     return GAUGE_LIMITS.q2 + DIAL_VALUE_DEG_OFFSET;
   }
 }
+
+export { DIAL_VALUE_DEG_OFFSET, getLimitDegree };

--- a/src/plugins/imagery/components/Compass/utils.js
+++ b/src/plugins/imagery/components/Compass/utils.js
@@ -1,19 +1,38 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2023, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
 /**
+ * Sums an arbitrary number of absolute rotations (rotations relative to one common direction 0) and normalizes the rotation to the range [0, 360).
  *
- * sums an arbitrary number of absolute rotations
- * (meaning rotations relative to one common direction 0)
- * normalizes the rotation to the range [0, 360)
- *
- * @param  {...number} rotations in degrees
- * @returns {number} normalized sum of all rotations - [0, 360) degrees
+ * @param {...number} rotations - Rotations in degrees.
+ * @returns {number} - Normalized sum of all rotations in the range [0, 360) degrees.
  */
-export function rotate(...rotations) {
+function rotate(...rotations) {
   const rotation = rotations.reduce((a, b) => a + b, 0);
 
   return normalizeCompassDirection(rotation);
 }
 
-export function inRange(degrees, [min, max]) {
+function inRange(degrees, [min, max]) {
   const point = rotate(degrees);
 
   return min > max
@@ -21,7 +40,7 @@ export function inRange(degrees, [min, max]) {
     : point >= min && point <= max;
 }
 
-export function percentOfRange(degrees, [min, max]) {
+function percentOfRange(degrees, [min, max]) {
   let distance = rotate(degrees);
   let minRange = min;
   let maxRange = max;
@@ -42,3 +61,5 @@ function normalizeCompassDirection(degrees) {
 
   return base >= 0 ? base : 360 + base;
 }
+
+export { inRange, percentOfRange, rotate };

--- a/src/plugins/imagery/components/RelatedTelemetry/RelatedTelemetry.js
+++ b/src/plugins/imagery/components/RelatedTelemetry/RelatedTelemetry.js
@@ -20,6 +20,8 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
+import IndependentTimeContext from '@/api/time/IndependentTimeContext';
+
 function copyRelatedMetadata(metadata) {
   let compare = metadata.comparisonFunction;
   let copiedMetadata = JSON.parse(JSON.stringify(metadata));
@@ -27,8 +29,6 @@ function copyRelatedMetadata(metadata) {
 
   return copiedMetadata;
 }
-
-import IndependentTimeContext from '@/api/time/IndependentTimeContext';
 export default class RelatedTelemetry {
   constructor(openmct, domainObject, telemetryKeys, timeContext) {
     this._openmct = openmct;

--- a/src/plugins/imagery/mixins/imageryData.js
+++ b/src/plugins/imagery/mixins/imageryData.js
@@ -20,11 +20,11 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
+import { TIME_CONTEXT_EVENTS } from '../../../api/time/constants.js';
 const DEFAULT_DURATION_FORMATTER = 'duration';
 const IMAGE_HINT_KEY = 'image';
 const IMAGE_THUMBNAIL_HINT_KEY = 'thumbnail';
 const IMAGE_DOWNLOAD_NAME_HINT_KEY = 'imageDownloadName';
-import { TIME_CONTEXT_EVENTS } from '../../../api/time/constants.js';
 
 export default {
   inject: ['openmct', 'domainObject', 'objectPath'],

--- a/src/plugins/localTimeSystem/LocalTimeFormat.js
+++ b/src/plugins/localTimeSystem/LocalTimeFormat.js
@@ -40,7 +40,7 @@ const DATE_FORMATS = [DATE_FORMAT, 'YYYY-MM-DD h:mm:ss a', 'YYYY-MM-DD h:mm a', 
  * @constructor
  * @memberof platform/commonUI/formats
  */
-export default function LocalTimeFormat() {
+function LocalTimeFormat() {
   this.key = 'local-format';
 }
 
@@ -64,3 +64,5 @@ LocalTimeFormat.prototype.parse = function (text) {
 LocalTimeFormat.prototype.validate = function (text) {
   return moment(text, DATE_FORMATS).isValid();
 };
+
+export default LocalTimeFormat;

--- a/src/plugins/notebook/monkeyPatchObjectAPIForNotebooks.js
+++ b/src/plugins/notebook/monkeyPatchObjectAPIForNotebooks.js
@@ -7,6 +7,13 @@ import {
   isNotebookType
 } from './notebook-constants.js';
 
+/**
+ * Monkey patch for the openmct.objects.save method.
+ *
+ * @param {Object} openmct - The openmct object.
+ * @returns {void}
+ */
+// eslint-disable-next-line import/exports-last
 export default function (openmct) {
   const apiSave = openmct.objects.save.bind(openmct.objects);
 

--- a/src/plugins/notebook/utils/notebook-entries.js
+++ b/src/plugins/notebook/utils/notebook-entries.js
@@ -7,6 +7,15 @@ import {
   saveNotebookImageDomainObject
 } from './notebook-image.js';
 
+const DEFAULT_CLASS = 'notebook-default';
+
+const TIME_BOUNDS = {
+  START_BOUND: 'tc.startBound',
+  END_BOUND: 'tc.endBound',
+  START_DELTA: 'tc.startDelta',
+  END_DELTA: 'tc.endDelta'
+};
+
 async function getUsername(openmct) {
   let username = null;
 
@@ -27,15 +36,7 @@ async function getActiveRole(openmct) {
   return role;
 }
 
-export const DEFAULT_CLASS = 'notebook-default';
-const TIME_BOUNDS = {
-  START_BOUND: 'tc.startBound',
-  END_BOUND: 'tc.endBound',
-  START_DELTA: 'tc.startDelta',
-  END_DELTA: 'tc.endDelta'
-};
-
-export function addEntryIntoPage(notebookStorage, entries, entry) {
+function addEntryIntoPage(notebookStorage, entries, entry) {
   const defaultSectionId = notebookStorage.defaultSectionId;
   const defaultPageId = notebookStorage.defaultPageId;
   if (!defaultSectionId || !defaultPageId) {
@@ -58,7 +59,17 @@ export function addEntryIntoPage(notebookStorage, entries, entry) {
   return newEntries;
 }
 
-export function selectEntry({
+/**
+ * Selects an entry in the notebook.
+ * @param {Object} options - The options for selecting the entry.
+ * @param {HTMLElement} options.element - The HTML element representing the entry.
+ * @param {string} options.entryId - The ID of the entry.
+ * @param {Object} options.domainObject - The domain object associated with the entry.
+ * @param {Object} options.openmct - The Open MCT object.
+ * @param {Function} options.onAnnotationChange - The callback function for annotation changes.
+ * @param {Object} options.notebookAnnotations - The annotations for the notebook.
+ */
+function selectEntry({
   element,
   entryId,
   domainObject,
@@ -93,7 +104,14 @@ export function selectEntry({
   );
 }
 
-export function getHistoricLinkInFixedMode(openmct, bounds, historicLink) {
+/**
+ * Retrieves the historic link in fixed mode based on the provided parameters.
+ * @param {Object} openmct - The Open MCT object.
+ * @param {Object} bounds - The time bounds.
+ * @param {string} historicLink - The historic link.
+ * @returns {string} The historic link in fixed mode.
+ */
+function getHistoricLinkInFixedMode(openmct, bounds, historicLink) {
   if (historicLink.includes('tc.mode=fixed')) {
     return historicLink;
   }
@@ -121,7 +139,14 @@ export function getHistoricLinkInFixedMode(openmct, bounds, historicLink) {
   return params.join('&');
 }
 
-export function createNewImageEmbed(image, openmct, imageName = '') {
+/**
+ * Creates a new image embed object based on the provided image and metadata.
+ * @param {File} image - The image file to embed.
+ * @param {Object} openmct - The Open MCT object.
+ * @param {string} [imageName=''] - The name of the image.
+ * @returns {Promise<Object>} A promise that resolves to the newly created image embed object.
+ */
+function createNewImageEmbed(image, openmct, imageName = '') {
   return new Promise((resolve) => {
     const reader = new FileReader();
     reader.onloadend = async () => {
@@ -160,7 +185,24 @@ export function createNewImageEmbed(image, openmct, imageName = '') {
   });
 }
 
-export async function createNewEmbed(snapshotMeta, snapshot = '') {
+/**
+ * Creates a new embed object based on the provided snapshot metadata.
+ * @param {Object} snapshotMeta - The snapshot metadata.
+ * @param {Object} [snapshot=''] - The snapshot data.
+ * @returns {Promise<Object>} A promise that resolves to the newly created embed object.
+ * The embed object has the following properties:
+ * - bounds: The bounds of the embed.
+ * - createdOn: The current date and time.
+ * - createdBy: The username obtained asynchronously.
+ * - cssClass: The CSS class for the embed.
+ * - domainObject: The domain object associated with the embed.
+ * - historicLink: The historic link for the embed.
+ * - id: A unique identifier for the embed.
+ * - name: The name of the embed.
+ * - snapshot: The snapshot data.
+ * - type: The type of the embed.
+ */
+async function createNewEmbed(snapshotMeta, snapshot = '') {
   const { bounds, link, objectPath, openmct, userImage } = snapshotMeta;
   let name = null;
   let type = null;
@@ -203,7 +245,16 @@ export async function createNewEmbed(snapshotMeta, snapshot = '') {
   };
 }
 
-export async function addNotebookEntry(
+/**
+ * Adds a notebook entry to the specified domain object.
+ * @param {OpenMCT} openmct - The OpenMCT instance.
+ * @param {DomainObject} domainObject - The domain object to add the entry to.
+ * @param {NotebookStorage} notebookStorage - The notebook storage.
+ * @param {Array} [passedEmbeds=[]] - Optional array of embeds.
+ * @param {string} [entryText=''] - Optional entry text.
+ * @returns {Promise<string>} The ID of the added entry.
+ */
+async function addNotebookEntry(
   openmct,
   domainObject,
   notebookStorage,
@@ -243,7 +294,14 @@ export async function addNotebookEntry(
   return id;
 }
 
-export function getNotebookEntries(domainObject, selectedSection, selectedPage) {
+/**
+ * Retrieves the notebook entries for the selected section and page.
+ * @param {object} domainObject - The domain object containing the notebook entries.
+ * @param {object} selectedSection - The selected section of the notebook.
+ * @param {object} selectedPage - The selected page of the notebook.
+ * @returns {array} - An array of notebook entries.
+ */
+function getNotebookEntries(domainObject, selectedSection, selectedPage) {
   if (!domainObject || !selectedSection || !selectedPage || !domainObject.configuration) {
     return;
   }
@@ -266,7 +324,7 @@ export function getNotebookEntries(domainObject, selectedSection, selectedPage) 
   return specificEntries;
 }
 
-export function getEntryPosById(entryId, domainObject, selectedSection, selectedPage) {
+function getEntryPosById(entryId, domainObject, selectedSection, selectedPage) {
   if (!domainObject || !selectedSection || !selectedPage) {
     return;
   }
@@ -284,7 +342,7 @@ export function getEntryPosById(entryId, domainObject, selectedSection, selected
   return foundId;
 }
 
-export function deleteNotebookEntries(openmct, domainObject, selectedSection, selectedPage) {
+function deleteNotebookEntries(openmct, domainObject, selectedSection, selectedPage) {
   if (!domainObject || !selectedSection) {
     return;
   }
@@ -309,10 +367,24 @@ export function deleteNotebookEntries(openmct, domainObject, selectedSection, se
   mutateObject(openmct, domainObject, 'configuration.entries', entries);
 }
 
-export function mutateObject(openmct, object, key, value) {
+function mutateObject(openmct, object, key, value) {
   openmct.objects.mutate(object, key, value);
 }
 
 function addDefaultClass(domainObject, openmct) {
   openmct.status.set(domainObject.identifier, DEFAULT_CLASS);
 }
+
+export {
+  addEntryIntoPage,
+  addNotebookEntry,
+  createNewEmbed,
+  createNewImageEmbed,
+  DEFAULT_CLASS,
+  deleteNotebookEntries,
+  getEntryPosById,
+  getHistoricLinkInFixedMode,
+  getNotebookEntries,
+  mutateObject,
+  selectEntry
+};

--- a/src/plugins/persistence/couch/scripts/deleteAnnotations.js
+++ b/src/plugins/persistence/couch/scripts/deleteAnnotations.js
@@ -21,7 +21,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
-const process = require('process');
+import process from 'process';
 
 async function main() {
   try {

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export function getValidatedData(domainObject) {
+function getValidatedData(domainObject) {
   const sourceMap = domainObject.sourceMap;
   const json = getObjectJson(domainObject);
 
@@ -123,3 +123,5 @@ export function getContrastingColor(hexColor) {
 
   return cBrightness > cThreshold ? '#000000' : '#ffffff';
 }
+
+export { getValidatedData };

--- a/src/plugins/summaryWidget/SummaryWidgetViewPolicy.js
+++ b/src/plugins/summaryWidget/SummaryWidgetViewPolicy.js
@@ -23,9 +23,16 @@
 /**
  * Policy determining which views can apply to summary widget.  Disables
  * any view other than normal summary widget view.
+ * @constructor
  */
-export default function SummaryWidgetViewPolicy() {}
+function SummaryWidgetViewPolicy() {}
 
+/**
+ * Determines whether a view is allowed for a given domain object.
+ * @param {View} view - The view to check.
+ * @param {DomainObject} domainObject - The domain object to check against.
+ * @returns {boolean} - True if the view is allowed, false otherwise.
+ */
 SummaryWidgetViewPolicy.prototype.allow = function (view, domainObject) {
   if (domainObject.getModel().type === 'summary-widget') {
     return view.key === 'summary-widget-viewer';
@@ -33,3 +40,5 @@ SummaryWidgetViewPolicy.prototype.allow = function (view, domainObject) {
 
   return true;
 };
+
+export default SummaryWidgetViewPolicy;

--- a/src/plugins/summaryWidget/SummaryWidgetsCompositionPolicy.js
+++ b/src/plugins/summaryWidget/SummaryWidgetsCompositionPolicy.js
@@ -20,10 +20,21 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default function SummaryWidgetsCompositionPolicy(openmct) {
+/**
+ * SummaryWidgetsCompositionPolicy constructor function.
+ * @param {Object} openmct - The Open MCT object.
+ * @constructor
+ */
+function SummaryWidgetsCompositionPolicy(openmct) {
   this.openmct = openmct;
 }
 
+/**
+ * Check if a child object is allowed to be added to a parent object.
+ * @param {Object} parent - The parent object.
+ * @param {Object} child - The child object.
+ * @returns {boolean} - True if the child is allowed, false otherwise.
+ */
 SummaryWidgetsCompositionPolicy.prototype.allow = function (parent, child) {
   const parentType = parent.type;
 
@@ -33,3 +44,5 @@ SummaryWidgetsCompositionPolicy.prototype.allow = function (parent, child) {
 
   return true;
 };
+
+export default SummaryWidgetsCompositionPolicy;

--- a/src/plugins/summaryWidget/src/Condition.js
+++ b/src/plugins/summaryWidget/src/Condition.js
@@ -30,16 +30,13 @@ import ObjectSelect from './input/ObjectSelect.js';
 import OperationSelect from './input/OperationSelect.js';
 
 /**
- * Represents an individual condition for a summary widget rule. Manages the
- * associated inputs and view.
- * @param {Object} conditionConfig The configuration for this condition, consisting
- *                                of object, key, operation, and values fields
- * @param {number} index the index of this Condition object in it's parent Rule's data model,
- *                        to be injected into callbacks for removes
- * @param {ConditionManager} conditionManager A ConditionManager instance for populating
- *                                            selects with configuration data
+ * Represents an individual condition for a summary widget rule. Manages the associated inputs and view.
+ * @param {Object} conditionConfig The configuration for this condition, consisting of object, key, operation, and values fields
+ * @param {number} index the index of this Condition object in it's parent Rule's data model to be injected into callbacks for removes
+ * @param {ConditionManager} conditionManager A ConditionManager instance for populating selects with configuration data
+ * @constructor
  */
-export default function Condition(conditionConfig, index, conditionManager) {
+function Condition(conditionConfig, index, conditionManager) {
   eventHelpers.extend(this);
   this.config = conditionConfig;
   this.index = index;
@@ -248,3 +245,5 @@ Condition.prototype.generateSelectOptions = function () {
 
   return fragment;
 };
+
+export default Condition;

--- a/src/plugins/summaryWidget/src/ConditionEvaluator.js
+++ b/src/plugins/summaryWidget/src/ConditionEvaluator.js
@@ -9,7 +9,7 @@
  * @param {Object} compositionObjs The current set of composition objects to
  *                                 evaluate for 'any' and 'all' conditions
  */
-export default function ConditionEvaluator(subscriptionCache, compositionObjs) {
+function ConditionEvaluator(subscriptionCache, compositionObjs) {
   this.subscriptionCache = subscriptionCache;
   this.compositionObjs = compositionObjs;
 
@@ -480,3 +480,5 @@ ConditionEvaluator.prototype.setTestDataCache = function (testCache) {
 ConditionEvaluator.prototype.useTestData = function (useTestCache) {
   this.useTestCache = useTestCache;
 };
+
+export default ConditionEvaluator;

--- a/src/plugins/summaryWidget/src/ConditionManager.js
+++ b/src/plugins/summaryWidget/src/ConditionManager.js
@@ -12,7 +12,7 @@ import ConditionEvaluator from './ConditionEvaluator.js';
  * @param {Object} domainObject the Summary Widget domain object
  * @param {MCT} openmct an MCT instance
  */
-export default function ConditionManager(domainObject, openmct) {
+function ConditionManager(domainObject, openmct) {
   this.domainObject = domainObject;
   this.openmct = openmct;
 
@@ -381,3 +381,5 @@ ConditionManager.prototype.destroy = function () {
   this.composition.off('remove', this.onCompositionRemove, this);
   this.composition.off('load', this.onCompositionLoad, this);
 };
+
+export default ConditionManager;

--- a/src/plugins/summaryWidget/src/Rule.js
+++ b/src/plugins/summaryWidget/src/Rule.js
@@ -20,14 +20,7 @@ import IconPalette from './input/IconPalette.js';
  * @param {WidgetDnD} widgetDnD A WidgetDnD instance to handle dragging and dropping rules
  * @param {element} container The DOM element which contains this summary widget
  */
-export default function Rule(
-  ruleConfig,
-  domainObject,
-  openmct,
-  conditionManager,
-  widgetDnD,
-  container
-) {
+function Rule(ruleConfig, domainObject, openmct, conditionManager, widgetDnD, container) {
   eventHelpers.extend(this);
   const self = this;
   const THUMB_ICON_CLASS = 'c-sw__icon js-sw__icon';
@@ -528,3 +521,5 @@ Rule.prototype.generateDescription = function () {
   this.description.innerText = self.config.description;
   this.config.description = description;
 };
+
+export default Rule;

--- a/src/plugins/summaryWidget/src/SummaryWidget.js
+++ b/src/plugins/summaryWidget/src/SummaryWidget.js
@@ -23,7 +23,7 @@ const DEFAULT_PROPS = {
  * @param {Object} domainObject The domain Object represented by this Widget
  * @param {MCT} openmct An MCT instance
  */
-export default function SummaryWidget(domainObject, openmct) {
+function SummaryWidget(domainObject, openmct) {
   eventHelpers.extend(this);
 
   this.domainObject = domainObject;
@@ -391,3 +391,5 @@ SummaryWidget.prototype.applyStyle = function (elem, style) {
 SummaryWidget.prototype.updateDomainObject = function () {
   this.openmct.objects.mutate(this.domainObject, 'configuration', this.domainObject.configuration);
 };
+
+export default SummaryWidget;

--- a/src/plugins/summaryWidget/src/TestDataItem.js
+++ b/src/plugins/summaryWidget/src/TestDataItem.js
@@ -17,7 +17,7 @@ import ObjectSelect from './input/ObjectSelect.js';
  *                           for populating selects with configuration data
  * @constructor
  */
-export default function TestDataItem(itemConfig, index, conditionManager) {
+function TestDataItem(itemConfig, index, conditionManager) {
   eventHelpers.extend(this);
   this.config = itemConfig;
   this.index = index;
@@ -188,3 +188,5 @@ TestDataItem.prototype.generateValueInput = function (key) {
     inputArea.append(this.valueInput);
   }
 };
+
+export default TestDataItem;

--- a/src/plugins/summaryWidget/src/TestDataManager.js
+++ b/src/plugins/summaryWidget/src/TestDataManager.js
@@ -12,7 +12,7 @@ import TestDataItem from './TestDataItem.js';
  * @param {ConditionManager} conditionManager A conditionManager instance
  * @param {MCT} openmct and MCT instance
  */
-export default function TestDataManager(domainObject, conditionManager, openmct) {
+function TestDataManager(domainObject, conditionManager, openmct) {
   eventHelpers.extend(this);
   const self = this;
 
@@ -196,3 +196,5 @@ TestDataManager.prototype.destroy = function () {
     item.remove();
   });
 };
+
+export default TestDataManager;

--- a/src/plugins/summaryWidget/src/WidgetDnD.js
+++ b/src/plugins/summaryWidget/src/WidgetDnD.js
@@ -9,7 +9,7 @@ import ruleImageTemplate from '../res/ruleImageTemplate.html';
  * @param {string[]} ruleOrder An array of rule IDs representing the current rule order
  * @param {Object} rulesById An object mapping rule IDs to rule configurations
  */
-export default function WidgetDnD(container, ruleOrder, rulesById) {
+function WidgetDnD(container, ruleOrder, rulesById) {
   this.container = container;
   this.ruleOrder = ruleOrder;
   this.rulesById = rulesById;
@@ -160,3 +160,5 @@ WidgetDnD.prototype.drop = function (event) {
     this.imageContainer.hide();
   }
 };
+
+export default WidgetDnD;

--- a/src/plugins/summaryWidget/src/input/KeySelect.js
+++ b/src/plugins/summaryWidget/src/input/KeySelect.js
@@ -1,5 +1,7 @@
 import Select from './Select.js';
 
+const NULLVALUE = '- Select Field -';
+
 /**
  * Create a {Select} element whose composition is dynamically updated with
  * the telemetry fields of a particular domain object
@@ -14,8 +16,6 @@ import Select from './Select.js';
  * @param {function} changeCallback A change event callback to register with this
  *                                  select on initialization
  */
-const NULLVALUE = '- Select Field -';
-
 function KeySelect(config, objectSelect, manager, changeCallback) {
   const self = this;
 

--- a/src/plugins/summaryWidget/src/input/KeySelect.js
+++ b/src/plugins/summaryWidget/src/input/KeySelect.js
@@ -16,7 +16,7 @@ import Select from './Select.js';
  */
 const NULLVALUE = '- Select Field -';
 
-export default function KeySelect(config, objectSelect, manager, changeCallback) {
+function KeySelect(config, objectSelect, manager, changeCallback) {
   const self = this;
 
   this.config = config;
@@ -91,3 +91,5 @@ KeySelect.prototype.generateOptions = function () {
 KeySelect.prototype.destroy = function () {
   this.objectSelect.destroy();
 };
+
+export default KeySelect;

--- a/src/plugins/summaryWidget/src/input/ObjectSelect.js
+++ b/src/plugins/summaryWidget/src/input/ObjectSelect.js
@@ -13,7 +13,7 @@ import Select from './Select.js';
  * @param {string[][]} baseOptions A set of [value, label] keyword pairs to
  *                                 display regardless of the composition state
  */
-export default function ObjectSelect(config, manager, baseOptions) {
+function ObjectSelect(config, manager, baseOptions) {
   const self = this;
 
   this.config = config;
@@ -84,3 +84,5 @@ ObjectSelect.prototype.generateOptions = function () {
   });
   this.select.setOptions(items);
 };
+
+export default ObjectSelect;

--- a/src/plugins/summaryWidget/src/input/OperationSelect.js
+++ b/src/plugins/summaryWidget/src/input/OperationSelect.js
@@ -17,7 +17,16 @@ import Select from './Select.js';
  */
 const NULLVALUE = '- Select Comparison -';
 
-export default function OperationSelect(config, keySelect, manager, changeCallback) {
+/**
+ * Represents a select element for operations in the OperationSelect component.
+ *
+ * @param {Object} config - The configuration object for the OperationSelect.
+ * @param {KeySelect} keySelect - The KeySelect instance linked to this OperationSelect.
+ * @param {ConditionManager} manager - The ConditionManager instance.
+ * @param {Function} changeCallback - The callback function to be called on change event.
+ * @constructor
+ */
+function OperationSelect(config, keySelect, manager, changeCallback) {
   eventHelpers.extend(this);
   const self = this;
 
@@ -37,10 +46,11 @@ export default function OperationSelect(config, keySelect, manager, changeCallba
   }
 
   /**
-   * Change event handler for the {KeySelect} to which this OperationSelect instance
+   * Change event handler for the KeySelect to which this OperationSelect instance
    * is linked. Loads the operations applicable to the given telemetry property and updates
-   * its select element's composition
-   * @param {Object} key The key identifying the newly selected property
+   * its select element's composition.
+   *
+   * @param {Object} key - The key identifying the newly selected property.
    * @private
    */
   function onKeyChange(key) {
@@ -54,8 +64,8 @@ export default function OperationSelect(config, keySelect, manager, changeCallba
 
   /**
    * Event handler for the initial metadata load event from the associated
-   * ConditionManager. Retrieves telemetry property types and updates the
-   * select
+   * ConditionManager. Retrieves telemetry property types and updates the select.
+   *
    * @private
    */
   function onMetadataLoad() {
@@ -117,3 +127,5 @@ OperationSelect.prototype.loadOptions = function (key) {
 OperationSelect.prototype.destroy = function () {
   this.stopListening();
 };
+
+export default OperationSelect;

--- a/src/plugins/summaryWidget/src/input/Palette.js
+++ b/src/plugins/summaryWidget/src/input/Palette.js
@@ -14,7 +14,7 @@ import eventHelpers from '../eventHelpers.js';
  *                         palette item in the view; how this data is represented is
  *                         up to the descendent class
  */
-export default function Palette(cssClass, container, items) {
+function Palette(cssClass, container, items) {
   eventHelpers.extend(this);
 
   const self = this;
@@ -179,3 +179,5 @@ Palette.prototype.toggleNullOption = function () {
     this.domElement.querySelector('.c-palette__item-none').style.display = 'none';
   }
 };
+
+export default Palette;

--- a/src/plugins/summaryWidget/src/input/Select.js
+++ b/src/plugins/summaryWidget/src/input/Select.js
@@ -9,7 +9,7 @@ import eventHelpers from '../eventHelpers.js';
  * its composition from the data model
  * @constructor
  */
-export default function Select() {
+function Select() {
   eventHelpers.extend(this);
 
   const self = this;
@@ -41,6 +41,7 @@ export default function Select() {
 /**
  * Get the DOM element representing this Select in the view
  * @return {Element}
+ * @memberof Select.prototype
  */
 Select.prototype.getDOM = function () {
   return this.domElement;
@@ -50,8 +51,8 @@ Select.prototype.getDOM = function () {
  * Register a callback with this select: supported callback is change
  * @param {string} event The key for the event to listen to
  * @param {function} callback The function that this rule will invoke on this event
- * @param {Object} context A reference to a scope to use as the context for
- *                         context for the callback function
+ * @param {Object} context A reference to a scope to use as the context for context for the callback function
+ * @memberof Select.prototype
  */
 Select.prototype.on = function (event, callback, context) {
   if (this.supportedCallbacks.includes(event)) {
@@ -66,6 +67,7 @@ Select.prototype.on = function (event, callback, context) {
  * @param {string} event The key for the event to stop listening to
  * @param {function} callback The function to unregister
  * @param {Object} context A reference to a scope to use as the context for the callback function
+ * @memberof Select.prototype
  */
 Select.prototype.off = function (event, callback, context) {
   if (this.supportedCallbacks.includes(event)) {
@@ -76,8 +78,9 @@ Select.prototype.off = function (event, callback, context) {
 };
 
 /**
- * Update the select element in the view from the current state of the data
- * model
+ * Update the select element in the view from the current state of the data model.
+ * @function
+ * @memberof Select.prototype
  */
 Select.prototype.populate = function () {
   const self = this;
@@ -102,6 +105,7 @@ Select.prototype.populate = function () {
  * Add a single option to this select
  * @param {string} value The value for the new option
  * @param {string} label The human-readable text for the new option
+ * @memberof Select.prototype
  */
 Select.prototype.addOption = function (value, label) {
   this.options.push([value, label]);
@@ -111,6 +115,7 @@ Select.prototype.addOption = function (value, label) {
 /**
  * Set the available options for this select. Replaces any existing options
  * @param {string[][]} options An array of [value, label] pairs to display
+ * @memberof Select.prototype
  */
 Select.prototype.setOptions = function (options) {
   this.options = options;
@@ -122,6 +127,7 @@ Select.prototype.setOptions = function (options) {
  * callbacks with the new value. If the value doesn't exist in this select's
  * model, its state will not change.
  * @param {string} value The value to set as the selected option
+ * @memberof Select.prototype
  */
 Select.prototype.setSelected = function (value) {
   let selectedIndex = 0;
@@ -141,11 +147,15 @@ Select.prototype.setSelected = function (value) {
 /**
  * Get the value of the currently selected item
  * @return {string}
+ * @memberof Select.prototype
  */
 Select.prototype.getSelected = function () {
   return this.domElement.querySelector('select').value;
 };
 
+/**
+ * @memberof Select.prototype
+ */
 Select.prototype.hide = function () {
   this.domElement.classList.add('hidden');
   if (this.domElement.querySelector('.equal-to')) {
@@ -153,6 +163,9 @@ Select.prototype.hide = function () {
   }
 };
 
+/**
+ * @memberof Select.prototype
+ */
 Select.prototype.show = function () {
   this.domElement.classList.remove('hidden');
   if (this.domElement.querySelector('.equal-to')) {
@@ -160,6 +173,11 @@ Select.prototype.show = function () {
   }
 };
 
+/**
+ * @memberof Select.prototype
+ */
 Select.prototype.destroy = function () {
   this.stopListening();
 };
+
+export default Select;

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
@@ -24,7 +24,13 @@ import objectUtils from 'objectUtils';
 
 import SummaryWidgetEvaluator from './SummaryWidgetEvaluator.js';
 
-export default function EvaluatorPool(openmct) {
+/**
+ * Represents a pool of evaluators for objects in Open MCT.
+ *
+ * @param {Object} openmct - The Open MCT object.
+ * @constructor
+ */
+function EvaluatorPool(openmct) {
   this.openmct = openmct;
   this.byObjectId = {};
   this.byEvaluator = new WeakMap();
@@ -57,3 +63,5 @@ EvaluatorPool.prototype.release = function (evaluator) {
     delete this.byObjectId[poolEntry.objectId];
   }
 };
+
+export default EvaluatorPool;

--- a/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
+++ b/src/plugins/summaryWidget/src/telemetry/EvaluatorPool.js
@@ -36,6 +36,13 @@ function EvaluatorPool(openmct) {
   this.byEvaluator = new WeakMap();
 }
 
+/**
+ * Get the evaluator for the given domain object.
+ * If the evaluator does not exist in the pool, create a new one.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @returns {SummaryWidgetEvaluator} The evaluator for the domain object.
+ */
 EvaluatorPool.prototype.get = function (domainObject) {
   const objectId = objectUtils.makeKeyString(domainObject.identifier);
   let poolEntry = this.byObjectId[objectId];
@@ -54,6 +61,11 @@ EvaluatorPool.prototype.get = function (domainObject) {
   return poolEntry.evaluator;
 };
 
+/**
+ * Release the evaluator and remove it from the pool if no longer in use.
+ *
+ * @param {SummaryWidgetEvaluator} evaluator - The evaluator to release.
+ */
 EvaluatorPool.prototype.release = function (evaluator) {
   const poolEntry = this.byEvaluator.get(evaluator);
   poolEntry.leases -= 1;

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetCondition.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetCondition.js
@@ -22,7 +22,16 @@
 
 import OPERATIONS from './operations.js';
 
-export default function SummaryWidgetCondition(definition) {
+/**
+ * Represents a condition for a summary widget.
+ *
+ * @param {Object} definition - The definition object for the condition.
+ * @param {string} definition.object - The object to evaluate the condition on.
+ * @param {string} definition.key - The key of the property to evaluate.
+ * @param {Array} definition.values - The values to compare against.
+ * @constructor
+ */
+function SummaryWidgetCondition(definition) {
   this.object = definition.object;
   this.key = definition.key;
   this.values = definition.values;
@@ -72,3 +81,5 @@ SummaryWidgetCondition.prototype.evaluateState = function (state) {
 
   return this.comparator(testValues);
 };
+
+export default SummaryWidgetCondition;

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetMetadataProvider.js
@@ -20,14 +20,36 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default function SummaryWidgetMetadataProvider(openmct) {
+/**
+ * Represents a SummaryWidgetMetadataProvider.
+ *
+ * @param {Object} openmct - The openmct object.
+ * @constructor
+ */
+function SummaryWidgetMetadataProvider(openmct) {
+  /**
+   * The openmct object.
+   * @type {Object}
+   */
   this.openmct = openmct;
 }
 
+/**
+ * Check if the metadata provider supports the given domain object.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @returns {boolean} - True if the metadata provider supports the domain object, false otherwise.
+ */
 SummaryWidgetMetadataProvider.prototype.supportsMetadata = function (domainObject) {
   return domainObject.type === 'summary-widget';
 };
 
+/**
+ * Get the domains for the given domain object.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @returns {Object[]} - An array of domain objects.
+ */
 SummaryWidgetMetadataProvider.prototype.getDomains = function (domainObject) {
   return this.openmct.time.getAllTimeSystems().map(function (ts, i) {
     return {
@@ -41,6 +63,12 @@ SummaryWidgetMetadataProvider.prototype.getDomains = function (domainObject) {
   });
 };
 
+/**
+ * Get the metadata for the given domain object.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @returns {Object} - The metadata object.
+ */
 SummaryWidgetMetadataProvider.prototype.getMetadata = function (domainObject) {
   const ruleOrder = domainObject.configuration.ruleOrder || [];
   const enumerations = ruleOrder
@@ -107,3 +135,5 @@ SummaryWidgetMetadataProvider.prototype.getMetadata = function (domainObject) {
 
   return metadata;
 };
+
+export default SummaryWidgetMetadataProvider;

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetRule.js
@@ -22,23 +22,75 @@
 
 import SummaryWidgetCondition from './SummaryWidgetCondition.js';
 
-export default function SummaryWidgetRule(definition) {
+/**
+ * Represents a SummaryWidgetRule.
+ *
+ * @param {Object} definition - The rule definition.
+ * @constructor
+ */
+function SummaryWidgetRule(definition) {
+  /**
+   * The name of the rule.
+   * @type {string}
+   */
   this.name = definition.name;
+
+  /**
+   * The label of the rule.
+   * @type {string}
+   */
   this.label = definition.label;
+
+  /**
+   * The ID of the rule.
+   * @type {string}
+   */
   this.id = definition.id;
+
+  /**
+   * The icon of the rule.
+   * @type {string}
+   */
   this.icon = definition.icon;
+
+  /**
+   * The style of the rule.
+   * @type {string}
+   */
   this.style = definition.style;
+
+  /**
+   * The message of the rule.
+   * @type {string}
+   */
   this.message = definition.message;
+
+  /**
+   * The description of the rule.
+   * @type {string}
+   */
   this.description = definition.description;
+
+  /**
+   * The conditions of the rule.
+   * @type {SummaryWidgetCondition[]}
+   */
   this.conditions = definition.conditions.map(function (cDefinition) {
     return new SummaryWidgetCondition(cDefinition);
   });
+
+  /**
+   * The trigger type of the rule.
+   * @type {string}
+   */
   this.trigger = definition.trigger;
 }
 
 /**
- * Evaluate the given rule against a telemetryState and return true if it
- * matches.
+ * Evaluate the given rule against a telemetryState and return true if it matches.
+ *
+ * @param {Object} telemetryState - The telemetry state.
+ * @returns {boolean} - True if the rule matches, false otherwise.
  */
 SummaryWidgetRule.prototype.evaluate = function (telemetryState) {
   let i;
@@ -66,3 +118,5 @@ SummaryWidgetRule.prototype.evaluate = function (telemetryState) {
     throw new Error('Invalid rule trigger: ' + this.trigger);
   }
 };
+
+export default SummaryWidgetRule;

--- a/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
+++ b/src/plugins/summaryWidget/src/telemetry/SummaryWidgetTelemetryProvider.js
@@ -22,14 +22,38 @@
 
 import EvaluatorPool from './EvaluatorPool.js';
 
-export default function SummaryWidgetTelemetryProvider(openmct) {
+/**
+ * Represents a SummaryWidgetTelemetryProvider.
+ *
+ * @param {Object} openmct - The OpenMCT object.
+ * @constructor
+ */
+function SummaryWidgetTelemetryProvider(openmct) {
+  /**
+   * The evaluator pool for managing evaluators.
+   * @type {EvaluatorPool}
+   */
   this.pool = new EvaluatorPool(openmct);
 }
 
+/**
+ * Checks if the telemetry provider supports the request for the given domain object and options.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @param {Object} options - The options for the request.
+ * @returns {boolean} - True if the request is supported, false otherwise.
+ */
 SummaryWidgetTelemetryProvider.prototype.supportsRequest = function (domainObject, options) {
   return domainObject.type === 'summary-widget';
 };
 
+/**
+ * Makes a request for telemetry data for the given domain object and options.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @param {Object} options - The options for the request.
+ * @returns {Promise} - A promise that resolves to an array of telemetry data.
+ */
 SummaryWidgetTelemetryProvider.prototype.request = function (domainObject, options) {
   if (options.strategy !== 'latest' && options.size !== 1) {
     return Promise.resolve([]);
@@ -46,10 +70,23 @@ SummaryWidgetTelemetryProvider.prototype.request = function (domainObject, optio
   );
 };
 
+/**
+ * Checks if the telemetry provider supports subscribing to telemetry updates for the given domain object.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @returns {boolean} - True if subscribing is supported, false otherwise.
+ */
 SummaryWidgetTelemetryProvider.prototype.supportsSubscribe = function (domainObject) {
   return domainObject.type === 'summary-widget';
 };
 
+/**
+ * Subscribes to telemetry updates for the given domain object.
+ *
+ * @param {Object} domainObject - The domain object.
+ * @param {Function} callback - The callback function to be called when telemetry updates occur.
+ * @returns {Function} - A function to unsubscribe from telemetry updates.
+ */
 SummaryWidgetTelemetryProvider.prototype.subscribe = function (domainObject, callback) {
   const evaluator = this.pool.get(domainObject);
   const unsubscribe = evaluator.subscribe(callback);
@@ -59,3 +96,5 @@ SummaryWidgetTelemetryProvider.prototype.subscribe = function (domainObject, cal
     unsubscribe();
   }.bind(this);
 };
+
+export default SummaryWidgetTelemetryProvider;

--- a/src/plugins/telemetryMean/src/MeanTelemetryProvider.js
+++ b/src/plugins/telemetryMean/src/MeanTelemetryProvider.js
@@ -24,11 +24,41 @@ import objectUtils from 'objectUtils';
 
 import TelemetryAverager from './TelemetryAverager.js';
 
-export default function MeanTelemetryProvider(openmct) {
+/**
+ * Represents a MeanTelemetryProvider.
+ *
+ * @param {Object} openmct - The OpenMCT object.
+ * @constructor
+ */
+function MeanTelemetryProvider(openmct) {
+  /**
+   * The OpenMCT object.
+   * @type {Object}
+   */
   this.openmct = openmct;
+
+  /**
+   * The telemetry API provided by OpenMCT.
+   * @type {Object}
+   */
   this.telemetryAPI = openmct.telemetry;
+
+  /**
+   * The time API provided by OpenMCT.
+   * @type {Object}
+   */
   this.timeAPI = openmct.time;
+
+  /**
+   * The object API provided by OpenMCT.
+   * @type {Object}
+   */
   this.objectAPI = openmct.objects;
+
+  /**
+   * The per-object providers.
+   * @type {Object}
+   */
   this.perObjectProviders = {};
 }
 
@@ -131,3 +161,5 @@ function logError(error) {
     console.error(error);
   }
 }
+
+export default MeanTelemetryProvider;

--- a/src/plugins/telemetryMean/src/MockTelemetryApi.js
+++ b/src/plugins/telemetryMean/src/MockTelemetryApi.js
@@ -20,7 +20,11 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default function MockTelemetryApi() {
+/**
+ * Represents a mock telemetry API.
+ * @constructor
+ */
+function MockTelemetryApi() {
   this.createSpy('subscribe');
   this.createSpy('getMetadata');
 
@@ -95,3 +99,5 @@ MockTelemetryApi.prototype.createSpy = function (functionName) {
   spyOn(this, functionName);
   this[functionName].and.callThrough();
 };
+
+export default MockTelemetryApi;

--- a/src/plugins/telemetryMean/src/TelemetryAverager.js
+++ b/src/plugins/telemetryMean/src/TelemetryAverager.js
@@ -20,13 +20,16 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default function TelemetryAverager(
-  telemetryAPI,
-  timeAPI,
-  domainObject,
-  samples,
-  averageDatumCallback
-) {
+/**
+ * Constructs a new TelemetryAverager instance.
+ * @param {TelemetryAPI} telemetryAPI - The telemetry API.
+ * @param {TimeAPI} timeAPI - The time API.
+ * @param {Object} domainObject - The domain object.
+ * @param {number} samples - The number of samples to average.
+ * @param {Function} averageDatumCallback - The callback function to handle the averaged datum.
+ * @constructor
+ */
+function TelemetryAverager(telemetryAPI, timeAPI, domainObject, samples, averageDatumCallback) {
   this.telemetryAPI = telemetryAPI;
   this.timeAPI = timeAPI;
 
@@ -119,3 +122,5 @@ TelemetryAverager.prototype.getFormatter = function (key) {
 
   return this.telemetryAPI.getValueFormatter(valueMetadata);
 };
+
+export default TelemetryAverager;

--- a/src/plugins/telemetryTable/TelemetryTableRow.js
+++ b/src/plugins/telemetryTable/TelemetryTableRow.js
@@ -20,10 +20,21 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export default class TelemetryTableRow {
+/**
+ * Represents a telemetry table row.
+ * @class
+ */
+class TelemetryTableRow {
+  /**
+   * Constructs a new TelemetryTableRow instance.
+   * @param {Object} datum - The telemetry data for the row.
+   * @param {Object} columns - The columns configuration for the table.
+   * @param {string} objectKeyString - The key string for the domain object associated with the row.
+   * @param {Object} limitEvaluator - The limit evaluator for evaluating limits on the data.
+   * @param {string} inPlaceUpdateKey - The key for in-place updates.
+   */
   constructor(datum, columns, objectKeyString, limitEvaluator, inPlaceUpdateKey) {
     this.columns = columns;
-
     this.datum = createNormalizedDatum(datum, columns);
     this.fullDatum = datum;
     this.limitEvaluator = limitEvaluator;
@@ -31,65 +42,109 @@ export default class TelemetryTableRow {
     this.inPlaceUpdateKey = inPlaceUpdateKey;
   }
 
+  /**
+   * Gets the formatted datum for the row.
+   * @param {Object} headers - The headers configuration for the table.
+   * @returns {Object} The formatted datum with values for each column.
+   */
   getFormattedDatum(headers) {
+    // Example: { columnKey: 'formattedValue' }
     return Object.keys(headers).reduce((formattedDatum, columnKey) => {
       formattedDatum[columnKey] = this.getFormattedValue(columnKey);
-
       return formattedDatum;
     }, {});
   }
 
+  /**
+   * Gets the formatted value for a specific column.
+   * @param {string} key - The key of the column.
+   * @returns {string} The formatted value for the column.
+   */
   getFormattedValue(key) {
+    // Example: 'formattedValue'
     let column = this.columns[key];
-
     return column && column.getFormattedValue(this.datum[key]);
   }
 
+  /**
+   * Gets the parsed value for a specific column.
+   * @param {string} key - The key of the column.
+   * @returns {any} The parsed value for the column.
+   */
   getParsedValue(key) {
+    // Example: parsedValue
     let column = this.columns[key];
-
     return column && column.getParsedValue(this.datum[key]);
   }
 
+  /**
+   * Gets the component name for rendering a cell in a specific column.
+   * @param {string} key - The key of the column.
+   * @returns {string} The component name for rendering the cell.
+   */
   getCellComponentName(key) {
+    // Example: 'CellComponent'
     let column = this.columns[key];
-
     return column && column.getCellComponentName && column.getCellComponentName();
   }
 
+  /**
+   * Gets the CSS class for the row.
+   * @returns {string} The CSS class for the row.
+   */
   getRowClass() {
+    // Example: 'rowClass'
     if (!this.rowClass) {
       let limitEvaluation = this.limitEvaluator.evaluate(this.datum);
       this.rowClass = limitEvaluation && limitEvaluation.cssClass;
     }
-
     return this.rowClass;
   }
 
+  /**
+   * Gets the CSS classes for each cell in the row based on limit evaluations.
+   * @returns {Object} The CSS classes for each cell in the row.
+   */
   getCellLimitClasses() {
+    // Example: { columnKey: 'limitClass' }
     if (!this.cellLimitClasses) {
       this.cellLimitClasses = Object.values(this.columns).reduce((alarmStateMap, column) => {
         if (!column.isUnit) {
           let limitEvaluation = this.limitEvaluator.evaluate(this.datum, column.getMetadatum());
           alarmStateMap[column.getKey()] = limitEvaluation && limitEvaluation.cssClass;
         }
-
         return alarmStateMap;
       }, {});
     }
-
     return this.cellLimitClasses;
   }
 
+  /**
+   * Gets the contextual domain object associated with the row.
+   * @param {Object} openmct - The Open MCT object.
+   * @param {string} objectKeyString - The key string for the domain object.
+   * @returns {Object} The contextual domain object.
+   */
   getContextualDomainObject(openmct, objectKeyString) {
+    // Example: { id: 'domainObjectId', name: 'Domain Object' }
     return openmct.objects.get(objectKeyString);
   }
 
+  /**
+   * Gets the context menu actions for the row.
+   * @returns {Array} The context menu actions.
+   */
   getContextMenuActions() {
+    // Example: ['action1', 'action2']
     return ['viewDatumAction', 'viewHistoricalData'];
   }
 
+  /**
+   * Updates the row with new telemetry data.
+   * @param {Object} updatesToDatum - The updates to the telemetry data.
+   */
   updateWithDatum(updatesToDatum) {
+    // Example: { updatedKey: 'updatedValue' }
     const normalizedUpdatesToDatum = createNormalizedDatum(updatesToDatum, this.columns);
     this.datum = {
       ...this.datum,
@@ -121,3 +176,5 @@ function createNormalizedDatum(datum, columns) {
 
   return normalizedDatum;
 }
+
+export default TelemetryTableRow;

--- a/src/plugins/timeConductor/ConductorHistory.vue
+++ b/src/plugins/timeConductor/ConductorHistory.vue
@@ -35,15 +35,15 @@
 </template>
 
 <script>
-const DEFAULT_DURATION_FORMATTER = 'duration';
-const LOCAL_STORAGE_HISTORY_KEY_FIXED = 'tcHistory';
-const LOCAL_STORAGE_HISTORY_KEY_REALTIME = 'tcHistoryRealtime';
-const DEFAULT_RECORDS_LENGTH = 10;
-
 import { millisecondsToDHMS } from 'utils/duration';
 
 import { REALTIME_MODE_KEY, TIME_CONTEXT_EVENTS } from '../../api/time/constants.js';
 import UTCTimeFormat from '../utcTimeSystem/UTCTimeFormat.js';
+
+const DEFAULT_DURATION_FORMATTER = 'duration';
+const LOCAL_STORAGE_HISTORY_KEY_FIXED = 'tcHistory';
+const LOCAL_STORAGE_HISTORY_KEY_REALTIME = 'tcHistoryRealtime';
+const DEFAULT_RECORDS_LENGTH = 10;
 
 export default {
   inject: ['openmct', 'configuration'],

--- a/src/ui/inspector/InspectorStylesSpecMocks.js
+++ b/src/ui/inspector/InspectorStylesSpecMocks.js
@@ -20,7 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-export const mockTelemetryTableSelection = [
+const mockTelemetryTableSelection = [
   [
     {
       context: {
@@ -37,7 +37,7 @@ export const mockTelemetryTableSelection = [
   ]
 ];
 
-export const mockStyle = {
+const mockStyle = {
   backgroundColor: '#ff0000',
   border: '#ff0000',
   color: '#ff0000'
@@ -194,17 +194,25 @@ const mockTextBox5Path = {
   }
 };
 
-export const mockMultiSelectionSameStyles = [
+const mockMultiSelectionSameStyles = [
   [mockTextBox2Path, mockDisplayLayoutPath],
   [mockTextBox3Path, mockDisplayLayoutPath]
 ];
 
-export const mockMultiSelectionMixedStyles = [
+const mockMultiSelectionMixedStyles = [
   [mockTextBox1Path, mockDisplayLayoutPath],
   [mockTextBox2Path, mockDisplayLayoutPath]
 ];
 
-export const mockMultiSelectionNonSpecificStyles = [
+const mockMultiSelectionNonSpecificStyles = [
   [mockTextBox4Path, mockDisplayLayoutPath],
   [mockTextBox5Path, mockDisplayLayoutPath]
 ];
+
+export {
+  mockMultiSelectionMixedStyles,
+  mockMultiSelectionNonSpecificStyles,
+  mockMultiSelectionSameStyles,
+  mockStyle,
+  mockTelemetryTableSelection
+};

--- a/src/ui/layout/RecentObjectsList.vue
+++ b/src/ui/layout/RecentObjectsList.vue
@@ -35,9 +35,9 @@
 </template>
 
 <script>
+import RecentObjectsListItem from './RecentObjectsListItem.vue';
 const MAX_RECENT_ITEMS = 20;
 const LOCAL_STORAGE_KEY__RECENT_OBJECTS = 'mct-recent-objects';
-import RecentObjectsListItem from './RecentObjectsListItem.vue';
 export default {
   name: 'RecentObjectsList',
   components: {

--- a/src/ui/registries/ToolbarRegistry.js
+++ b/src/ui/registries/ToolbarRegistry.js
@@ -26,7 +26,7 @@
  * @interface ToolbarRegistry
  * @memberof module:openmct
  */
-export default function ToolbarRegistry() {
+function ToolbarRegistry() {
   this.providers = {};
 }
 
@@ -115,3 +115,5 @@ ToolbarRegistry.prototype.addProvider = function (provider) {
  * @param {object} selection the selection object
  * @returns {Object[]} an array of objects defining controls for the toolbar.
  */
+
+export default ToolbarRegistry;

--- a/src/ui/registries/ViewRegistry.js
+++ b/src/ui/registries/ViewRegistry.js
@@ -30,7 +30,7 @@ const DEFAULT_VIEW_PRIORITY = 100;
  * @interface ViewRegistry
  * @memberof module:openmct
  */
-export default function ViewRegistry() {
+function ViewRegistry() {
   EventEmitter.apply(this);
   this.providers = {};
 }
@@ -270,3 +270,5 @@ ViewRegistry.prototype.getByVPID = function (vpid) {
  * @param {*} object the object to be edit
  * @returns {module:openmct.View} an editable view of this domain object
  */
+
+export default ViewRegistry;

--- a/src/utils/template/templateHelpers.js
+++ b/src/utils/template/templateHelpers.js
@@ -1,4 +1,10 @@
-export function convertTemplateToHTML(templateString) {
+/**
+ * Converts a template string to an array of HTML elements.
+ *
+ * @param {string} templateString - The template string to convert.
+ * @returns {HTMLElement[]} An array of HTML elements.
+ */
+function convertTemplateToHTML(templateString) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(templateString, 'text/html');
 
@@ -14,10 +20,19 @@ export function convertTemplateToHTML(templateString) {
   return Array.from(fragment.children);
 }
 
-export function toggleClass(element, className) {
+/**
+ * Toggles a CSS class on an element.
+ *
+ * @param {HTMLElement} element - The element to toggle the class on.
+ * @param {string} className - The class name to toggle.
+ * @returns {void}
+ */
+function toggleClass(element, className) {
   if (element.classList.contains(className)) {
     element.classList.remove(className);
   } else {
     element.classList.add(className);
   }
 }
+
+export { convertTemplateToHTML, toggleClass };

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -192,8 +192,18 @@ function getLatestTelemetry(telemetry = [], opts = {}) {
 
 /**
  * Generates mock objects based on the provided options.
- *
- * Example usage:
+ * @param {Object} opts - Options for generating mock objects.
+ * @param {string} [opts.type='default'] - The type of mock objects to generate.
+ * @param {string[]} [opts.objectKeyStrings] - The object keys to include in the mock objects.
+ * @param {Object} [opts.telemetryConfig] - Configuration for customizing the telemetry data in the mock objects.
+ * @param {string[]} [opts.telemetryConfig.keys] - The keys to include in the telemetry data.
+ * @param {string} [opts.telemetryConfig.format='utc'] - The format of the telemetry data.
+ * @param {Object} [opts.telemetryConfig.hints] - The hints for each telemetry key.
+ * @param {Object} [opts.overwrite] - Object containing fields to overwrite in the generated mock objects.
+ * @returns {Object} The generated mock objects.
+ * @throws {string} Throws an error if the optional parameter "objectKeyStrings" is provided but is not an array of string object keys.
+ * @throws {string} Throws an error if no mock object is found for a given object key and type.
+ * @example
  * getMockObjects({
  *     name: 'Jamie Telemetry',
  *     keys: ['test','other','yeah','sup'],
@@ -210,17 +220,6 @@ function getLatestTelemetry(telemetry = [], opts = {}) {
  *     }
  * })
  *
- * @param {Object} opts - Options for generating mock objects.
- * @param {string} [opts.type='default'] - The type of mock objects to generate.
- * @param {string[]} [opts.objectKeyStrings] - The object keys to include in the mock objects.
- * @param {Object} [opts.telemetryConfig] - Configuration for customizing the telemetry data in the mock objects.
- * @param {string[]} [opts.telemetryConfig.keys] - The keys to include in the telemetry data.
- * @param {string} [opts.telemetryConfig.format='utc'] - The format of the telemetry data.
- * @param {Object} [opts.telemetryConfig.hints] - The hints for each telemetry key.
- * @param {Object} [opts.overwrite] - Object containing fields to overwrite in the generated mock objects.
- * @returns {Object} The generated mock objects.
- * @throws {string} Throws an error if the optional parameter "objectKeyStrings" is provided but is not an array of string object keys.
- * @throws {string} Throws an error if no mock object is found for a given object key and type.
  */
 function getMockObjects(opts = {}) {
   opts.type = opts.type || 'default';

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -35,7 +35,12 @@ const DEFAULT_TIME_OPTIONS = {
   }
 };
 
-export function createOpenMct(timeSystemOptions = DEFAULT_TIME_OPTIONS) {
+/**
+ * Creates an instance of Open MCT with the specified time system options.
+ * @param {Object} [timeSystemOptions=DEFAULT_TIME_OPTIONS] - The time system options.
+ * @returns {MCT} The created Open MCT instance.
+ */
+function createOpenMct(timeSystemOptions = DEFAULT_TIME_OPTIONS) {
   const openmct = markRaw(new MCT());
   openmct.install(openmct.plugins.LocalStorage());
   openmct.install(openmct.plugins.UTCTimeSystem());
@@ -54,7 +59,12 @@ export function createOpenMct(timeSystemOptions = DEFAULT_TIME_OPTIONS) {
   return openmct;
 }
 
-export function createMouseEvent(eventName) {
+/**
+ * Creates a new MouseEvent with the specified event name.
+ * @param {string} eventName - The name of the event.
+ * @returns {MouseEvent} The created MouseEvent.
+ */
+function createMouseEvent(eventName) {
   return new MouseEvent(eventName, {
     bubbles: true,
     cancelable: true,
@@ -62,7 +72,14 @@ export function createMouseEvent(eventName) {
   });
 }
 
-export function spyOnBuiltins(functionNames, object = window) {
+/**
+ * Spies on built-in functions.
+ *
+ * @param {Array<string>} functionNames - An array of function names to spy on.
+ * @param {Object} [object=window] - The object on which the functions are defined (default is the global `window` object).
+ * @throws {string} If a built-in spy function is already defined for a function name.
+ */
+function spyOnBuiltins(functionNames, object = window) {
   functionNames.forEach((functionName) => {
     if (nativeFunctions[functionName]) {
       throw `Builtin spy function already defined for ${functionName}`;
@@ -77,12 +94,23 @@ export function spyOnBuiltins(functionNames, object = window) {
   });
 }
 
-export function clearBuiltinSpies() {
+/**
+ * Clears the built-in spies by restoring the original functions.
+ * @param {Object[]} nativeFunctions - The array of native functions to clear.
+ */
+function clearBuiltinSpies() {
   nativeFunctions.forEach(clearBuiltinSpy);
   nativeFunctions = [];
 }
 
-export function resetApplicationState(openmct) {
+/**
+ * Resets the application state by clearing built-in spies and destroying the openmct instance.
+ * If the window location hash is not empty, it will reset the hash and resolve the promise after the hash change event.
+ * If the window location hash is empty, it will immediately resolve the promise.
+ * @param {Object} openmct - The openmct instance to destroy (optional).
+ * @returns {Promise} A promise that resolves after the application state has been reset.
+ */
+function resetApplicationState(openmct) {
   let promise;
 
   clearBuiltinSpies();
@@ -108,12 +136,17 @@ export function resetApplicationState(openmct) {
   return promise;
 }
 
-// required: key
-// optional: element, keyCode, type
-export function simulateKeyEvent(opts) {
+/**
+ * Simulates a keyboard event.
+ * @param {Object} opts - The options for the keyboard event.
+ * @param {string} opts.key - The key value of the event.
+ * @param {HTMLElement} [opts.element=document] - The element to dispatch the event on.
+ * @param {number} [opts.keyCode] - The key code of the event.
+ * @param {string} [opts.type='keydown'] - The type of the event.
+ */
+function simulateKeyEvent(opts) {
   if (!opts.key) {
     console.warn('simulateKeyEvent needs a key');
-
     return;
   }
 
@@ -129,11 +162,22 @@ export function simulateKeyEvent(opts) {
   el.dispatchEvent(event);
 }
 
+/**
+ * Restores the original implementation of a built-in function by assigning the native function back to the object.
+ * @param {Object} funcDefinition - The definition of the built-in function.
+ */
 function clearBuiltinSpy(funcDefinition) {
   funcDefinition.object[funcDefinition.functionName] = funcDefinition.nativeFunction;
 }
 
-export function getLatestTelemetry(telemetry = [], opts = {}) {
+/**
+ * Get the latest telemetry data from an array of telemetry objects.
+ * @param {Object[]} telemetry - The array of telemetry objects.
+ * @param {Object} opts - Options for getting the latest telemetry.
+ * @param {string} [opts.timeFormat='utc'] - The time format to use for comparison.
+ * @returns {Object} The latest telemetry object.
+ */
+function getLatestTelemetry(telemetry = [], opts = {}) {
   let latest = [];
   let timeFormat = opts.timeFormat || 'utc';
 
@@ -146,23 +190,39 @@ export function getLatestTelemetry(telemetry = [], opts = {}) {
   return latest;
 }
 
-// EXAMPLE:
-// getMockObjects({
-//     name: 'Jamie Telemetry',
-//     keys: ['test','other','yeah','sup'],
-//     format: 'local',
-//     telemetryConfig: {
-//          hints: {
-//              test: {
-//                  domain: 1
-//              },
-//              other: {
-//                  range: 2
-//              }
-//          }
-//      }
-// })
-export function getMockObjects(opts = {}) {
+/**
+ * Generates mock objects based on the provided options.
+ *
+ * Example usage:
+ * getMockObjects({
+ *     name: 'Jamie Telemetry',
+ *     keys: ['test','other','yeah','sup'],
+ *     format: 'local',
+ *     telemetryConfig: {
+ *         hints: {
+ *             test: {
+ *                 domain: 1
+ *             },
+ *             other: {
+ *                 range: 2
+ *             }
+ *         }
+ *     }
+ * })
+ *
+ * @param {Object} opts - Options for generating mock objects.
+ * @param {string} [opts.type='default'] - The type of mock objects to generate.
+ * @param {string[]} [opts.objectKeyStrings] - The object keys to include in the mock objects.
+ * @param {Object} [opts.telemetryConfig] - Configuration for customizing the telemetry data in the mock objects.
+ * @param {string[]} [opts.telemetryConfig.keys] - The keys to include in the telemetry data.
+ * @param {string} [opts.telemetryConfig.format='utc'] - The format of the telemetry data.
+ * @param {Object} [opts.telemetryConfig.hints] - The hints for each telemetry key.
+ * @param {Object} [opts.overwrite] - Object containing fields to overwrite in the generated mock objects.
+ * @returns {Object} The generated mock objects.
+ * @throws {string} Throws an error if the optional parameter "objectKeyStrings" is provided but is not an array of string object keys.
+ * @throws {string} Throws an error if no mock object is found for a given object key and type.
+ */
+function getMockObjects(opts = {}) {
   opts.type = opts.type || 'default';
   if (opts.objectKeyStrings && !Array.isArray(opts.objectKeyStrings)) {
     throw `"getMockObjects" optional parameter "objectKeyStrings" must be an array of string object keys`;
@@ -239,14 +299,17 @@ export function getMockObjects(opts = {}) {
   return requestedMocks;
 }
 
-// EXAMPLE:
-// getMockTelemetry({
-//     name: 'My Telemetry',
-//     keys: ['test','other','yeah','sup'],
-//     count: 8,
-//     format: 'local'
-// })
-export function getMockTelemetry(opts = {}) {
+/**
+ * Generates mock telemetry data.
+ * @param {Object} opts - Options for generating mock telemetry.
+ * @param {number} [opts.count=2] - The number of telemetry data points to generate.
+ * @param {string} [opts.format='utc'] - The format of the telemetry data.
+ * @param {string} [opts.name='Mock Telemetry Datum'] - The name of the telemetry data.
+ * @param {string[]} [opts.keys] - The keys to include in the telemetry data.
+ * @param {number} [opts.keyCount] - The number of keys to include in the telemetry data.
+ * @returns {Object[]} An array of mock telemetry data points.
+ */
+function getMockTelemetry(opts = {}) {
   let count = opts.count || 2;
   let format = opts.format || 'utc';
   let name = opts.name || 'Mock Telemetry Datum';
@@ -280,7 +343,7 @@ export function getMockTelemetry(opts = {}) {
 }
 
 // used to inject into tests that require a render
-export function renderWhenVisible(func) {
+function renderWhenVisible(func) {
   func();
   return true;
 }
@@ -362,3 +425,16 @@ function setMockObjects() {
     }
   };
 }
+
+export {
+  clearBuiltinSpies,
+  createMouseEvent,
+  createOpenMct,
+  getLatestTelemetry,
+  getMockObjects,
+  getMockTelemetry,
+  renderWhenVisible,
+  resetApplicationState,
+  simulateKeyEvent,
+  spyOnBuiltins
+};


### PR DESCRIPTION
Closes #7339 

### Describe your changes:
Adds linting for commonjs and amd imports now that we've made the change to become a module.
Lots of drivebys for JSDocs
Started toying with es6 class conversion

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Is this a breaking change to be called out in the release notes?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
