### PR TITLE
Update Events view colors for better contrast

### DIFF
--- a/src/styles/_constants-espresso.scss
+++ b/src/styles/_constants-espresso.scss
@@ -366,10 +366,14 @@ $colorLimitCyanFg: #d3faff;
 $colorLimitCyanIc: #6bedff;
 
 // Events
-$colorEventPurpleFg: #6433ff;
-$colorEventRedFg: #cc0000;
-$colorEventOrangeFg: orange;
-$colorEventYellowFg: #ffcc00;
+$colorEventPurpleFg: #aB8fff;
+$colorEventRedFg: #ff9999;
+$colorEventOrangeFg: #ff8800;
+$colorEventYellowFg: #ffdb63;
+$colorEventPurpleBg: #31204a;
+$colorEventRedBg: #3c1616;
+$colorEventOrangeBg: #3e2a13;
+$colorEventYellowBg: #3e3316;
 
 // Bubble colors
 $colorInfoBubbleBg: #dddddd;

--- a/src/styles/_constants-maelstrom.scss
+++ b/src/styles/_constants-maelstrom.scss
@@ -369,10 +369,14 @@ $colorLimitCyanFg: #d3faff;
 $colorLimitCyanIc: #6bedff;
 
 // Events
-$colorEventPurpleFg: #6433ff;
-$colorEventRedFg: #cc0000;
-$colorEventOrangeFg: orange;
-$colorEventYellowFg: #ffcc00;
+$colorEventPurpleFg: #aB8fff;
+$colorEventRedFg: #ff9999;
+$colorEventOrangeFg: #ff8800;
+$colorEventYellowFg: #ffdb63;
+$colorEventPurpleBg: #31204a;
+$colorEventRedBg: #3c1616;
+$colorEventOrangeBg: #3e2a13;
+$colorEventYellowBg: #3e3316;
 
 // Bubble colors
 $colorInfoBubbleBg: #dddddd;

--- a/src/styles/_constants-snow.scss
+++ b/src/styles/_constants-snow.scss
@@ -367,9 +367,13 @@ $colorLimitCyanIc: #1795c0;
 
 // Events
 $colorEventPurpleFg: #6433ff;
-$colorEventRedFg: #cc0000;
-$colorEventOrangeFg: orange;
-$colorEventYellowFg: #ffcc00;
+$colorEventRedFg: #aa0000;
+$colorEventOrangeFg: #b84900;
+$colorEventYellowFg: #867109;
+$colorEventPurpleBg: #ebe7fb;
+$colorEventRedBg: #fcefef;
+$colorEventOrangeBg: #ffece3;
+$colorEventYellowBg: #fdf8eb;
 
 // Bubble colors
 $colorInfoBubbleBg: $colorMenuBg;

--- a/src/styles/_status.scss
+++ b/src/styles/_status.scss
@@ -237,18 +237,23 @@ tr {
 
 .is-event {
   &--purple {
+    background-color: $colorEventPurpleBg !important;
     color: $colorEventPurpleFg !important;
   }
   &--red {
+    background-color: $colorEventRedBg !important;
     color: $colorEventRedFg !important;
   }
   &--orange {
+    background-color: $colorEventOrangeBg !important;
     color: $colorEventOrangeFg !important;
   }
   &--yellow {
+    background-color: $colorEventYellowBg !important;
     color: $colorEventYellowFg !important;
   }
   &--no-style {
-    color: inherit;
+    background-color: $colorBodyBg !important;
+    color: $colorBodyFg !important;
   }
 }


### PR DESCRIPTION
Closes #7410. Note that this depends on #7315 to pass accessibility contrast requirements.

- Event display approach modified to include background color.
- Theme colors modified and constrast verified via Wave a11y browser plugin.

<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Is this a breaking change to be called out in the release notes?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
