### PR TITLE
Filter values as a string not an object

### DIFF
--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -30,6 +30,7 @@
  * @property {string} end The end time property of the activity
  * @property {string} id The unique id of the activity. This is required to allow setting activity states
  * @property {object} displayProperties a list of key: value pairs that specifies which properties of the activity should be displayed when it is selected. Ex. {'location': 'Location', 'metadata.length_in_meters', 'Length (meters)'}
+ * @property {object} filterMetadata a list of strings that specifies which properties of the activity be included for filtering. Ex. {'description','properties.length_in_meters'}
  */
 
 import _ from 'lodash';

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -62,9 +62,9 @@ export function getValidatedData(domainObject) {
           groupActivity.filterMetadataValues = [];
           sourceMap.filterMetadata.forEach((property) => {
             const value = _.get(activity, property);
-            groupActivity.filterMetadataValues.push({
-              value
-            });
+            if (value !== undefined) {
+              groupActivity.filterMetadataValues.push(value);
+            }
           });
         }
 

--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -63,7 +63,7 @@ export function getValidatedData(domainObject) {
           groupActivity.filterMetadataValues = [];
           sourceMap.filterMetadata.forEach((property) => {
             const value = _.get(activity, property);
-            if (value !== undefined) {
+            if (value !== undefined && value !== null) {
               groupActivity.filterMetadataValues.push(value);
             }
           });

--- a/src/plugins/timelist/inspector/FilteringComponent.vue
+++ b/src/plugins/timelist/inspector/FilteringComponent.vue
@@ -150,7 +150,7 @@ export default {
         return true;
       }
 
-      const regex = new RegExp(/^([a-zA-Z0-9_\-\s,])+$/g);
+      const regex = new RegExp(/^([a-zA-Z0-9_.\-\s,])+$/g);
 
       return regex.test(value);
     }


### PR DESCRIPTION
Closes #7389 

### Describe your changes:
Use the value of a property for filtering metadata as a string if it is not undefined.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Is this a breaking change to be called out in the release notes?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
