### PR TITLE
[Mobile] Center Confirmation Dialog Texts

### DIFF
--- a/e2e/playwright-mobile.config.js
+++ b/e2e/playwright-mobile.config.js
@@ -3,7 +3,6 @@
 
 import { devices } from '@playwright/test';
 const MAX_FAILURES = 5;
-const NUM_WORKERS = 2;
 
 import { fileURLToPath } from 'url';
 
@@ -20,7 +19,8 @@ const config = {
     reuseExistingServer: true //This was originally disabled to prevent differences in local debugging vs. CI. However, it significantly speeds up local debugging.
   },
   maxFailures: MAX_FAILURES, //Limits failures to 5 to reduce CI Waste
-  workers: NUM_WORKERS, //Limit to 2 for CircleCI Agent
+  workers: 1, //Limit to 1 due to resource constraints similar to https://github.com/percy/cli/discussions/1067
+
   use: {
     baseURL: 'http://localhost:8080/',
     headless: true,

--- a/e2e/tests/mobile/smoke.e2e.spec.js
+++ b/e2e/tests/mobile/smoke.e2e.spec.js
@@ -61,10 +61,10 @@ test('Remove Object and confirmation dialog @mobile', async ({ page }) => {
   //Clicking on the search result takes you to the object
   await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
   await page.getByTitle('Collapse Browse Pane').click();
-  expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
+  await expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
   //Verify both objects are in view
-  expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
-  expect(await page.getByLabel('Child Layout 2 Layout')).toBeVisible();
+  await expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
+  await expect(await page.getByLabel('Child Layout 2 Layout')).toBeVisible();
   //Remove First Object to bring up confirmation dialog
   await page.getByLabel('View menu items').nth(1).click();
   await page.getByLabel('Remove').click();

--- a/e2e/tests/mobile/smoke.e2e.spec.js
+++ b/e2e/tests/mobile/smoke.e2e.spec.js
@@ -34,20 +34,16 @@ Make no assumptions about the order that elements appear in the DOM.
 */
 
 import { expect, test } from '../../pluginFixtures.js';
-
 test('Verify that My Items Tree appears @mobile', async ({ page, openmctConfig }) => {
   const { myItemsFolderName } = openmctConfig;
   //Go to baseURL
   await page.goto('./');
-
   //My Items to be visible
   await expect(page.getByRole('treeitem', { name: `${myItemsFolderName}` })).toBeVisible();
 });
-
 test('Verify that user can search @mobile', async ({ page }) => {
   //For now, this test is going to be hardcoded against './test-data/display_layout_with_child_layouts.json'
   await page.goto('./');
-
   await page.getByRole('searchbox', { name: 'Search Input' }).click();
   await page.getByRole('searchbox', { name: 'Search Input' }).fill('Parent Display Layout');
   //Search Results appear in search modal
@@ -56,4 +52,24 @@ test('Verify that user can search @mobile', async ({ page }) => {
   await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
   await page.getByTitle('Collapse Browse Pane').click();
   await expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
+});
+test('Remove Object and confirmation dialog @mobile', async ({ page }) => {
+  await page.goto('./');
+  await page.getByRole('searchbox', { name: 'Search Input' }).click();
+  await page.getByRole('searchbox', { name: 'Search Input' }).fill('Parent Display Layout');
+  //Search Results appear in search modal
+  //Clicking on the search result takes you to the object
+  await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
+  await page.getByTitle('Collapse Browse Pane').click();
+  expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
+  //Verify both objects are in view
+  expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
+  expect(await page.getByLabel('Child Layout 2 Layout')).toBeVisible();
+  //Remove First Object to bring up confirmation dialog
+  await page.getByLabel('View menu items').nth(1).click();
+  await page.getByLabel('Remove').click();
+  await page.getByRole('button', { name: 'OK' }).click();
+  //Verify that the object is removed
+  await expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
+  expect(await page.getByLabel('Child Layout 2 Layout').count()).toBe(0);
 });

--- a/src/api/overlays/components/OverlayComponent.vue
+++ b/src/api/overlays/components/OverlayComponent.vue
@@ -29,27 +29,29 @@
         class="c-click-icon c-overlay__close-button icon-x"
         @click.stop="destroy"
       ></button>
-      <div
-        ref="element"
-        class="c-overlay__contents js-notebook-snapshot-item-wrapper"
-        tabindex="0"
-        aria-modal="true"
-        aria-label="Overlay"
-        role="dialog"
-      ></div>
-      <div v-if="buttons" class="c-overlay__button-bar">
-        <button
-          v-for="(button, index) in buttons"
-          ref="buttons"
-          :key="index"
-          class="c-button js-overlay__button"
+      <div class="c-overlay__content-wrapper">
+        <div
+          ref="element"
+          class="c-overlay__contents js-notebook-snapshot-item-wrapper"
           tabindex="0"
-          :class="{ 'c-button--major': focusIndex === index }"
-          @focus="focusIndex = index"
-          @click="buttonClickHandler(button.callback)"
-        >
-          {{ button.label }}
-        </button>
+          aria-modal="true"
+          aria-label="Overlay"
+          role="dialog"
+        ></div>
+        <div v-if="buttons" class="c-overlay__button-bar">
+          <button
+            v-for="(button, index) in buttons"
+            ref="buttons"
+            :key="index"
+            class="c-button js-overlay__button"
+            tabindex="0"
+            :class="{ 'c-button--major': focusIndex === index }"
+            @focus="focusIndex = index"
+            @click="buttonClickHandler(button.callback)"
+          >
+            {{ button.label }}
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/src/api/overlays/components/dialog-component.scss
+++ b/src/api/overlays/components/dialog-component.scss
@@ -8,7 +8,9 @@
 .c-message {
   display: flex;
   align-items: center;
-
+  body.mobile & { // Centers confirmation dialog on screen.
+    margin-top: 40vh; 
+  }
   > * + * {
     margin-left: $interiorMarginLg;
   }

--- a/src/api/overlays/components/dialog-component.scss
+++ b/src/api/overlays/components/dialog-component.scss
@@ -8,16 +8,14 @@
 .c-message {
   display: flex;
   align-items: center;
-  body.mobile & { // Centers confirmation dialog on screen.
-    margin-top: 40vh; 
-  }
+
   > * + * {
     margin-left: $interiorMarginLg;
   }
 
   &__icon {
     // Holds a background SVG graphic
-    $s: 80px;
+    $s: 50px;
     flex: 0 0 auto;
     min-width: $s;
     min-height: $s;

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -32,7 +32,6 @@
       position: relative;
       height: 100vh;
       width: 100vw;
-      justify-content: center;
     }
   }
 

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -28,6 +28,12 @@
     display: flex;
     flex-direction: column;
     padding: $overlayInnerMargin;
+    body.mobile & { // Centers the overlay dialog for mobile
+      position: relative;
+      height: 100vh;
+      width: 100vw;
+      justify-content: center;
+    }
   }
 
   &__close-button {
@@ -45,6 +51,9 @@
     flex-direction: column;
     outline: none;
     overflow: auto;
+    body.mobile & {
+      flex: none;
+    }
   }
 
   &__top-bar {
@@ -78,6 +87,9 @@
     display: flex;
     justify-content: flex-end;
     margin-top: $interiorMargin;
+    body.mobile & {
+      justify-content: center;
+    }
 
     > * + * {
       margin-left: $interiorMargin;

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -53,10 +53,14 @@
     overflow: auto;
     flex-direction: column;
     gap: $interiorMargin;
-    margin: $overlayInnerMargin;
 
     body.desktop & {
       overflow: hidden;
+    }
+
+    .l-overlay-fit &,
+    .l-overlay-dialog & {
+      margin: $overlayInnerMargin;
     }
   }
 

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -87,7 +87,8 @@
     justify-content: flex-end;
     margin-top: $interiorMargin;
     body.mobile & {
-      justify-content: center;
+      justify-content: flex-end;
+      padding-right: $interiorMargin;
     }
 
     > * + * {

--- a/src/api/overlays/components/overlay-component.scss
+++ b/src/api/overlays/components/overlay-component.scss
@@ -19,7 +19,9 @@
   z-index: 70;
 
   &__blocker {
-    display: none; // Mobile-first
+    // Mobile-first: use the blocker to create a full look to dialogs
+    @include abs();
+    background: $colorBodyBg;
   }
 
   &__outer {
@@ -27,11 +29,12 @@
     background: $colorBodyBg;
     display: flex;
     flex-direction: column;
-    padding: $overlayInnerMargin;
-    body.mobile & { // Centers the overlay dialog for mobile
-      position: relative;
-      height: 100vh;
-      width: 100vw;
+
+    body.mobile .l-overlay-fit & {
+      // Vertically center small dialogs in mobile
+      top: 50%;
+      bottom: auto;
+      transform: translateY(-50%);
     }
   }
 
@@ -42,6 +45,19 @@
     top: $p;
     right: $p;
     z-index: 99;
+  }
+
+  &__content-wrapper {
+    display: flex;
+    height: 100%;
+    overflow: auto;
+    flex-direction: column;
+    gap: $interiorMargin;
+    margin: $overlayInnerMargin;
+
+    body.desktop & {
+      overflow: hidden;
+    }
   }
 
   &__contents {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches --> https://github.com/nasa/openmct/issues/7347
### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
- Add code to classes that are used for _only_ confirmation dialogs such that the text and buttons for such messages are centered, rather than floating to the top. This will improve overall mobile UX. 
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this change backwards compatible? For example, developers won't need to change how they are calling the API or how they've extended core plugins such as Tables or Plots.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Is this a breaking change to be called out in the release notes?
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
