### PR TITLE
[Mobile] Allow automatic closing of panes when nav object is clicked

### DIFF
--- a/e2e/tests/mobile/smoke.e2e.spec.js
+++ b/e2e/tests/mobile/smoke.e2e.spec.js
@@ -34,62 +34,40 @@ Make no assumptions about the order that elements appear in the DOM.
 */
 
 import { expect, test } from '../../pluginFixtures.js';
-
-test.describe('Smoke tests for @mobile', () => {
-  test.beforeEach(async ({ page }) => {
-    //For now, this test is going to be hardcoded against './test-data/display_layout_with_child_layouts.json'
-    await page.goto('./');
-  });
-
-  test('Verify that My Items Tree appears @mobile', async ({ page }) => {
-    //My Items to be visible
-    await expect(page.getByRole('treeitem', { name: 'My Items' })).toBeVisible();
-  });
-
-  test('Verify that user can search @mobile', async ({ page }) => {
-    await page.getByRole('searchbox', { name: 'Search Input' }).click();
-    await page.getByRole('searchbox', { name: 'Search Input' }).fill('Parent Display Layout');
-    //Search Results appear in search modal
-    await expect(
-      page.getByLabel('Object Results').getByText('Parent Display Layout')
-    ).toBeVisible();
-    //Clicking on the search result takes you to the object
-    await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
-    await page.getByTitle('Collapse Browse Pane').click();
-    await expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
-  });
-
-  test('Verify that user can change time conductor @mobile', async ({ page }) => {
-    //Collapse Browse Pane to get more Time Conductor space
-    await page.getByLabel('Collapse Browse Pane').click();
-    //Open Time Conductor and change to Real Time Mode and set offset hour by 1 hour
-    // Disabling line because we're intentionally obscuring the text
-    // eslint-disable-next-line playwright/no-force-option
-    await page.getByLabel('Time Conductor Mode').click({ force: true });
-    await page.getByLabel('Time Conductor Mode Menu').click();
-    await page.getByLabel('Real-Time').click();
-    await page.getByLabel('Start offset hours').fill('01');
-    await page.getByLabel('Submit time offsets').click();
-    await expect(page.getByLabel('Start offset: 01:30:00')).toBeVisible();
-  });
-
-  test('Remove Object and confirmation dialog @mobile', async ({ page }) => {
-    await page.getByRole('searchbox', { name: 'Search Input' }).click();
-    await page.getByRole('searchbox', { name: 'Search Input' }).fill('Parent Display Layout');
-    //Search Results appear in search modal
-    //Clicking on the search result takes you to the object
-    await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
-    await page.getByTitle('Collapse Browse Pane').click();
-    await expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
-    //Verify both objects are in view
-    await expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
-    await expect(await page.getByLabel('Child Layout 2 Layout')).toBeVisible();
-    //Remove First Object to bring up confirmation dialog
-    await page.getByLabel('View menu items').nth(1).click();
-    await page.getByLabel('Remove').click();
-    await page.getByRole('button', { name: 'OK' }).click();
-    //Verify that the object is removed
-    await expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
-    expect(await page.getByLabel('Child Layout 2 Layout').count()).toBe(0);
-  });
+test('Verify that My Items Tree appears @mobile', async ({ page, openmctConfig }) => {
+  const { myItemsFolderName } = openmctConfig;
+  //Go to baseURL
+  await page.goto('./');
+  //My Items to be visible
+  await expect(page.getByRole('treeitem', { name: `${myItemsFolderName}` })).toBeVisible();
+});
+test('Verify that user can search @mobile', async ({ page }) => {
+  //For now, this test is going to be hardcoded against './test-data/display_layout_with_child_layouts.json'
+  await page.goto('./');
+  await page.getByRole('searchbox', { name: 'Search Input' }).click();
+  await page.getByRole('searchbox', { name: 'Search Input' }).fill('Parent Display Layout');
+  //Search Results appear in search modal
+  await expect(page.getByLabel('Object Results').getByText('Parent Display Layout')).toBeVisible();
+  //Clicking on the search result takes you to the object
+  await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
+  await expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
+});
+test('Remove Object and confirmation dialog @mobile', async ({ page }) => {
+  await page.goto('./');
+  await page.getByRole('searchbox', { name: 'Search Input' }).click();
+  await page.getByRole('searchbox', { name: 'Search Input' }).fill('Parent Display Layout');
+  //Search Results appear in search modal
+  //Clicking on the search result takes you to the object
+  await page.getByLabel('Object Results').getByText('Parent Display Layout').click();
+  await expect(page.getByRole('main').getByText('Parent Display Layout')).toBeVisible();
+  //Verify both objects are in view
+  await expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
+  await expect(await page.getByLabel('Child Layout 2 Layout')).toBeVisible();
+  //Remove First Object to bring up confirmation dialog
+  await page.getByLabel('View menu items').nth(1).click();
+  await page.getByLabel('Remove').click();
+  await page.getByRole('button', { name: 'OK' }).click();
+  //Verify that the object is removed
+  await expect(await page.getByLabel('Child Layout 1 Layout')).toBeVisible();
+  expect(await page.getByLabel('Child Layout 2 Layout').count()).toBe(0);
 });

--- a/src/ui/layout/layout.scss
+++ b/src/ui/layout/layout.scss
@@ -67,6 +67,7 @@
     }
   }
 
+
   &__pane-tree,
   &__pane-inspector {
     .l-pane__contents {
@@ -154,7 +155,7 @@
 
   body.phone.portrait & {
     &__pane-tree {
-      width: calc(100% - #{$mobileMenuIconD + (2 * nth($shellPanePad, 2))});
+      width: calc(100% - #{$mobileMenuIconD + (2 * nth($shellPanePad, 2))}) !important;
 
       + .l-pane {
         // Hide pane-main when this pane is expanded
@@ -168,6 +169,11 @@
         pointer-events: inherit;
         transition: opacity 250ms ease 250ms;
       }
+    }
+  }
+  body.phone.landscape & {
+    &__pane-tree{
+      width: 40% !important;
     }
   }
 

--- a/src/ui/router/ApplicationRouter.js
+++ b/src/ui/router/ApplicationRouter.js
@@ -24,6 +24,10 @@ import EventEmitter from 'EventEmitter';
 import LocationBar from 'location-bar';
 import _ from 'lodash';
 
+import Agent from '@/utils/agent/Agent';
+
+const HIDE_TREE_PARAM = 'hideTree';
+
 class ApplicationRouter extends EventEmitter {
   /**
      * events
@@ -49,6 +53,10 @@ class ApplicationRouter extends EventEmitter {
     this.started = false;
 
     this.setHash = _.debounce(this.setHash.bind(this), 300);
+
+    const agent = new Agent(window);
+
+    this.isMobile = agent.isMobile();
 
     openmct.once('destroy', () => {
       this.destroy();
@@ -136,6 +144,10 @@ class ApplicationRouter extends EventEmitter {
    */
   navigate(hash) {
     this.handleLocationChange(hash.substring(1));
+
+    if (this.isMobile) {
+      this.setSearchParam(HIDE_TREE_PARAM, 'true');
+    }
   }
 
   /**

--- a/src/ui/router/ApplicationRouter.js
+++ b/src/ui/router/ApplicationRouter.js
@@ -54,9 +54,8 @@ class ApplicationRouter extends EventEmitter {
 
     this.setHash = _.debounce(this.setHash.bind(this), 300);
 
-    const agent = new Agent(window);
-
-    this.isMobile = agent.isMobile();
+    this.agent = new Agent(window);
+    this.isMobile = this.agent.isMobile();
 
     openmct.once('destroy', () => {
       this.destroy();
@@ -145,7 +144,7 @@ class ApplicationRouter extends EventEmitter {
   navigate(hash) {
     this.handleLocationChange(hash.substring(1));
 
-    if (this.isMobile) {
+    if (this.isMobile && this.agent.isPortrait()) {
       this.setSearchParam(HIDE_TREE_PARAM, 'true');
     }
   }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes  https://github.com/nasa/openmct/issues/7313<!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
- Adds vue logic such that when a mobile device is in portrait mode, clicking on navigation objects (from the tree, Recent Objects, or search) will automatically close the pane and navigate the user to the selected object
- Adds CSS logic such that the Object Tree is a static width. Currently, our code uses the desktop logic, causing the tree to change widths whenever we switch from desktop to mobile. 

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Is this a breaking change to be called out in the release notes?
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
