### PR TITLE
Ensure a request for telemetry happens in Condition Sets

### DIFF
--- a/e2e/tests/functional/plugins/conditionSet/conditionSet.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSet.e2e.spec.js
@@ -457,4 +457,11 @@ test.describe('Basic Condition Set Use', () => {
 
     await page.goto(exampleTelemetry.url);
   });
+
+  test.fixme('Ensure condition sets work with telemetry like operator status', ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/7484'
+    });
+  });
 });

--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
       openmct.install(openmct.plugins.example.EventGeneratorPlugin());
       openmct.install(openmct.plugins.example.ExampleImagery());
       openmct.install(openmct.plugins.example.ExampleTags());
+      openmct.install(openmct.plugins.example.ExampleUser());
 
       openmct.install(openmct.plugins.Espresso());
       openmct.install(openmct.plugins.MyItems());

--- a/index.html
+++ b/index.html
@@ -105,7 +105,6 @@
       openmct.install(openmct.plugins.example.EventGeneratorPlugin());
       openmct.install(openmct.plugins.example.ExampleImagery());
       openmct.install(openmct.plugins.example.ExampleTags());
-      openmct.install(openmct.plugins.example.ExampleUser());
 
       openmct.install(openmct.plugins.Espresso());
       openmct.install(openmct.plugins.MyItems());

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -56,20 +56,31 @@ export default class ConditionManager extends EventEmitter {
     );
   }
 
-  subscribeToTelemetry(endpoint) {
-    const id = this.openmct.objects.makeKeyString(endpoint.identifier);
-    if (this.subscriptions[id]) {
-      console.log('subscription already exists');
+  async requestLatestValue(endpoint) {
+    const options = {
+      size: 1,
+      strategy: 'latest'
+    };
+    const latestData = await this.openmct.telemetry.request(endpoint, options);
+    this.telemetryReceived(endpoint, latestData[0]);
+  }
 
+  subscribeToTelemetry(endpoint) {
+    const telemetryKeyString = this.openmct.objects.makeKeyString(endpoint.identifier);
+    if (this.subscriptions[telemetryKeyString]) {
       return;
     }
 
     const metadata = this.openmct.telemetry.getMetadata(endpoint);
 
-    this.telemetryObjects[id] = Object.assign({}, endpoint, {
+    this.telemetryObjects[telemetryKeyString] = Object.assign({}, endpoint, {
       telemetryMetaData: metadata ? metadata.valueMetadatas : []
     });
-    this.subscriptions[id] = this.openmct.telemetry.subscribe(
+
+    // get latest telemetry value (in case subscription is cached and no new data is coming in)
+    this.requestLatestValue(endpoint);
+
+    this.subscriptions[telemetryKeyString] = this.openmct.telemetry.subscribe(
       endpoint,
       this.telemetryReceived.bind(this, endpoint)
     );
@@ -91,7 +102,7 @@ export default class ConditionManager extends EventEmitter {
 
     //force re-computation of condition set result as we might be in a state where
     // there is no telemetry datum coming in for a while or at all.
-    let latestTimestamp = getLatestTimestamp(
+    const latestTimestamp = getLatestTimestamp(
       {},
       {},
       this.timeSystems,
@@ -334,57 +345,54 @@ export default class ConditionManager extends EventEmitter {
     return currentCondition;
   }
 
-  requestLADConditionSetOutput(options) {
+  async requestLADConditionSetOutput(options) {
     if (!this.conditions.length) {
-      return Promise.resolve([]);
+      return [];
     }
 
-    return this.compositionLoad.then(() => {
-      let latestTimestamp;
-      let conditionResults = {};
-      let nextLegOptions = { ...options };
-      delete nextLegOptions.onPartialResponse;
+    await this.compositionLoad;
 
-      const conditionRequests = this.conditions.map((condition) =>
-        condition.requestLADConditionResult(nextLegOptions)
+    let latestTimestamp;
+    let conditionResults = {};
+    let nextLegOptions = { ...options };
+    delete nextLegOptions.onPartialResponse;
+
+    const results = Promise.all(
+      this.conditions.map((condition) => condition.requestLADConditionResult(nextLegOptions))
+    );
+
+    results.forEach((resultObj) => {
+      const {
+        id,
+        data,
+        data: { result }
+      } = resultObj;
+
+      if (this.findConditionById(id)) {
+        conditionResults[id] = Boolean(result);
+      }
+
+      latestTimestamp = getLatestTimestamp(
+        latestTimestamp,
+        data,
+        this.timeSystems,
+        this.openmct.time.timeSystem()
       );
-
-      return Promise.all(conditionRequests).then((results) => {
-        results.forEach((resultObj) => {
-          const {
-            id,
-            data,
-            data: { result }
-          } = resultObj;
-          if (this.findConditionById(id)) {
-            conditionResults[id] = Boolean(result);
-          }
-
-          latestTimestamp = getLatestTimestamp(
-            latestTimestamp,
-            data,
-            this.timeSystems,
-            this.openmct.time.timeSystem()
-          );
-        });
-
-        if (!Object.values(latestTimestamp).some((timeSystem) => timeSystem)) {
-          return [];
-        }
-
-        const currentCondition = this.getCurrentConditionLAD(conditionResults);
-        const currentOutput = Object.assign(
-          {
-            output: currentCondition.configuration.output,
-            id: this.conditionSetDomainObject.identifier,
-            conditionId: currentCondition.id
-          },
-          latestTimestamp
-        );
-
-        return [currentOutput];
-      });
     });
+
+    if (!Object.values(latestTimestamp).some((timeSystem) => timeSystem)) {
+      return [];
+    }
+
+    const currentCondition = this.getCurrentConditionLAD(conditionResults);
+    const currentOutput = {
+      output: currentCondition.configuration.output,
+      id: this.conditionSetDomainObject.identifier,
+      conditionId: currentCondition.id,
+      ...latestTimestamp
+    };
+
+    return [currentOutput];
   }
 
   isTelemetryUsed(endpoint) {
@@ -400,7 +408,7 @@ export default class ConditionManager extends EventEmitter {
   }
 
   shouldEvaluateNewTelemetry(currentTimestamp) {
-    return this.openmct.time.getBounds().end >= currentTimestamp;
+    return this.openmct.time.getBounds().end > currentTimestamp;
   }
 
   telemetryReceived(endpoint, datum) {
@@ -409,7 +417,7 @@ export default class ConditionManager extends EventEmitter {
     }
 
     const normalizedDatum = this.createNormalizedDatum(datum, endpoint);
-    const timeSystemKey = this.openmct.time.timeSystem().key;
+    const timeSystemKey = this.openmct.time.getTimeSystem().key;
     let timestamp = {};
     const currentTimestamp = normalizedDatum[timeSystemKey];
     timestamp[timeSystemKey] = currentTimestamp;

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -408,7 +408,7 @@ export default class ConditionManager extends EventEmitter {
   }
 
   shouldEvaluateNewTelemetry(currentTimestamp) {
-    return this.openmct.time.getBounds().end > currentTimestamp;
+    return this.openmct.time.getBounds().end >= currentTimestamp;
   }
 
   telemetryReceived(endpoint, datum) {

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -62,6 +62,13 @@ export default class ConditionManager extends EventEmitter {
       strategy: 'latest'
     };
     const latestData = await this.openmct.telemetry.request(endpoint, options);
+
+    if (!latestData) {
+      throw new Error('Telemetry request failed by returning a falsy response');
+    }
+    if (latestData.length === 0) {
+      return;
+    }
     this.telemetryReceived(endpoint, latestData[0]);
   }
 

--- a/src/plugins/condition/ConditionSetTelemetryProvider.js
+++ b/src/plugins/condition/ConditionSetTelemetryProvider.js
@@ -40,12 +40,10 @@ export default class ConditionSetTelemetryProvider {
     return domainObject.type === 'conditionSet';
   }
 
-  request(domainObject, options) {
+  async request(domainObject, options) {
     let conditionManager = this.getConditionManager(domainObject);
-
-    return conditionManager.requestLADConditionSetOutput(options).then((latestOutput) => {
-      return latestOutput;
-    });
+    let latestOutput = await conditionManager.requestLADConditionSetOutput(options);
+    return latestOutput;
   }
 
   subscribe(domainObject, callback) {

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -725,7 +725,8 @@ describe('the plugin', function () {
         'subscribe',
         'getMetadata',
         'request',
-        'getValueFormatter'
+        'getValueFormatter',
+        'abortAllRequests'
       ]);
       openmct.telemetry.getMetadata.and.returnValue({
         ...testTelemetryObject.telemetry,

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -66,7 +66,8 @@ describe('the plugin', function () {
             format: 'utc',
             hints: {
               domain: 1
-            }
+            },
+            source: 'utc'
           },
           {
             key: 'testSource',
@@ -723,13 +724,19 @@ describe('the plugin', function () {
       openmct.telemetry = jasmine.createSpyObj('telemetry', [
         'subscribe',
         'getMetadata',
-        'request'
+        'request',
+        'getValueFormatter'
       ]);
       openmct.telemetry.getMetadata.and.returnValue({
         ...testTelemetryObject.telemetry,
-        valueMetadatas: [testTelemetryObject.telemetry.values]
+        valueMetadatas: []
       });
       openmct.telemetry.request.and.returnValue(Promise.resolve([]));
+      openmct.telemetry.getValueFormatter.and.returnValue({
+        parse: function (value) {
+          return value;
+        }
+      });
       let conditionMgr = new ConditionManager(conditionSetDomainObject, openmct);
       conditionMgr.on('conditionSetResultUpdated', mockListener);
       conditionMgr.telemetryObjects = {
@@ -750,14 +757,21 @@ describe('the plugin', function () {
       }, 400);
     });
 
-    fit('should not evaluate as old when telemetry is received in the allotted time', (done) => {
+    it('should not evaluate as old when telemetry is received in the allotted time', (done) => {
       openmct.telemetry.getMetadata = jasmine.createSpy('getMetadata');
       openmct.telemetry.getMetadata.and.returnValue({
         ...testTelemetryObject.telemetry,
         valueMetadatas: testTelemetryObject.telemetry.values
       });
+      const testDatum = {
+        'some-key2': '',
+        utc: 1,
+        testSource: '',
+        'some-key': null,
+        id: 'test-object'
+      };
       openmct.telemetry.request = jasmine.createSpy('request');
-      openmct.telemetry.request.and.returnValue(Promise.resolve([]));
+      openmct.telemetry.request.and.returnValue(Promise.resolve([testDatum]));
       const date = 1;
       conditionSetDomainObject.configuration.conditionCollection[0].configuration.criteria[0].input =
         ['0.4'];
@@ -767,9 +781,7 @@ describe('the plugin', function () {
         'test-object': testTelemetryObject
       };
       conditionMgr.updateConditionTelemetryObjects();
-      conditionMgr.telemetryReceived(testTelemetryObject, {
-        utc: date
-      });
+      conditionMgr.telemetryReceived(testTelemetryObject, testDatum);
       setTimeout(() => {
         expect(mockListener).toHaveBeenCalledWith({
           output: 'Default',

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -727,7 +727,7 @@ describe('the plugin', function () {
       ]);
       openmct.telemetry.getMetadata.and.returnValue({
         ...testTelemetryObject.telemetry,
-        valueMetadatas: []
+        valueMetadatas: [testTelemetryObject.telemetry.values]
       });
       openmct.telemetry.request.and.returnValue(Promise.resolve([]));
       let conditionMgr = new ConditionManager(conditionSetDomainObject, openmct);
@@ -754,7 +754,7 @@ describe('the plugin', function () {
       openmct.telemetry.getMetadata = jasmine.createSpy('getMetadata');
       openmct.telemetry.getMetadata.and.returnValue({
         ...testTelemetryObject.telemetry,
-        valueMetadatas: []
+        valueMetadatas: testTelemetryObject.telemetry.values
       });
       openmct.telemetry.request = jasmine.createSpy('request');
       openmct.telemetry.request.and.returnValue(Promise.resolve([]));

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -717,6 +717,17 @@ describe('the plugin', function () {
           key: 'cf4456a9-296a-4e6b-b182-62ed29cd15b9'
         }
       };
+
+      openmct.telemetry = jasmine.createSpyObj('telemetry', [
+        'subscribe',
+        'getMetadata',
+        'request'
+      ]);
+      openmct.telemetry.getMetadata.and.returnValue({
+        ...testTelemetryObject.telemetry,
+        valueMetadatas: []
+      });
+      openmct.telemetry.request.and.returnValue(Promise.resolve([]));
     });
 
     it('should evaluate as old when telemetry is not received in the allotted time', (done) => {

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -717,7 +717,9 @@ describe('the plugin', function () {
           key: 'cf4456a9-296a-4e6b-b182-62ed29cd15b9'
         }
       };
+    });
 
+    it('should evaluate as old when telemetry is not received in the allotted time', (done) => {
       openmct.telemetry = jasmine.createSpyObj('telemetry', [
         'subscribe',
         'getMetadata',
@@ -728,9 +730,6 @@ describe('the plugin', function () {
         valueMetadatas: []
       });
       openmct.telemetry.request.and.returnValue(Promise.resolve([]));
-    });
-
-    it('should evaluate as old when telemetry is not received in the allotted time', (done) => {
       let conditionMgr = new ConditionManager(conditionSetDomainObject, openmct);
       conditionMgr.on('conditionSetResultUpdated', mockListener);
       conditionMgr.telemetryObjects = {
@@ -751,7 +750,14 @@ describe('the plugin', function () {
       }, 400);
     });
 
-    it('should not evaluate as old when telemetry is received in the allotted time', (done) => {
+    fit('should not evaluate as old when telemetry is received in the allotted time', (done) => {
+      openmct.telemetry.getMetadata = jasmine.createSpy('getMetadata');
+      openmct.telemetry.getMetadata.and.returnValue({
+        ...testTelemetryObject.telemetry,
+        valueMetadatas: []
+      });
+      openmct.telemetry.request = jasmine.createSpy('request');
+      openmct.telemetry.request.and.returnValue(Promise.resolve([]));
       const date = 1;
       conditionSetDomainObject.configuration.conditionCollection[0].configuration.criteria[0].input =
         ['0.4'];

--- a/src/plugins/condition/pluginSpec.js
+++ b/src/plugins/condition/pluginSpec.js
@@ -897,6 +897,12 @@ describe('the plugin', function () {
     it('should stop evaluating conditions when a condition evaluates to true', () => {
       const date = Date.now();
       let conditionMgr = new ConditionManager(conditionSetDomainObject, openmct);
+
+      openmct.telemetry.getMetadata = jasmine.createSpy('getMetadata');
+      openmct.telemetry.getMetadata.and.returnValue({
+        ...testTelemetryObject.telemetry,
+        valueMetadatas: []
+      });
       conditionMgr.on('conditionSetResultUpdated', mockListener);
       conditionMgr.telemetryObjects = {
         'test-object': testTelemetryObject

--- a/src/plugins/notebook/pluginSpec.js
+++ b/src/plugins/notebook/pluginSpec.js
@@ -169,6 +169,8 @@ describe('Notebook plugin:', () => {
 
       openmct.editor = {};
       openmct.editor.isEditing = () => false;
+      openmct.editor.on = () => {};
+      openmct.editor.off = () => {};
 
       const applicableViews = openmct.objectViews.get(notebookViewObject, [notebookViewObject]);
       notebookViewProvider = applicableViews.find(


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7484 

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
When subscribing to telemetry in a Condition Set, we need to ensure we request telemetry in addition to a simple subscribe. This is because on telemetry like operator status, the Telemetry API may already have a subscription (due to the poll widget), and thus not create a new subscription, and thus not immediately fire a callback.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
