### PR TITLE
For the setTimeConductorMode, use the close time popup button rather than the submit button to dismiss time popup

### DIFF
--- a/e2e/appActions.js
+++ b/e2e/appActions.js
@@ -392,7 +392,8 @@ async function setTimeConductorMode(page, isFixedTimespan = true) {
     await page.getByRole('menuitem', { name: /Real-Time/ }).click();
     await page.waitForURL(/tc\.mode=local/);
   }
-  await page.getByLabel('Submit time offsets').or(page.getByLabel('Submit time bounds')).click();
+  //dismiss the time conductor popup
+  await page.getByLabel('Discard changes and close time popup').click();
 }
 
 /**

--- a/src/plugins/timeConductor/TimePopupFixed.vue
+++ b/src/plugins/timeConductor/TimePopupFixed.vue
@@ -87,7 +87,7 @@
         ></button>
         <button
           class="c-button icon-x"
-          aria-label="Discard time bounds"
+          aria-label="Discard changes and close time popup"
           @click.prevent="hide"
         ></button>
       </div>

--- a/src/plugins/timeConductor/TimePopupRealtime.vue
+++ b/src/plugins/timeConductor/TimePopupRealtime.vue
@@ -132,7 +132,7 @@
         ></button>
         <button
           class="c-button icon-x"
-          aria-label="Discard time offsets"
+          aria-label="Discard changes and close time popup"
           @click.prevent="hide"
         ></button>
       </div>


### PR DESCRIPTION
Closes #7614

### Describe your changes:
The submit button(s) in the realtime and fixed time popups trigger network requests (right now).
Also created an issue to perform a noop if there are no changes when submit button is clicked in the time popup here: 
#7616
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
