### PR TITLE
[CI] Parallelize visual test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,11 @@ jobs:
     steps:
       - build_and_install:
           node-version: lts/iron
-      - run: npm run test:e2e:visual:<<parameters.suite>>
+      - run:
+          command: |
+            mkdir test-results
+            TESTFILES=$(circleci tests glob "e2e/**/*.spec.js")
+            echo "$TESTFILES" | circleci tests run --command="xargs npm run test:e2e:visual:<<parameters.suite>>" --verbose --split-by=timings
       - store_test_results:
           path: test-results/results.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,14 +220,15 @@ jobs:
             equal: [42, 42] # Always run codecov reports regardless of test failure https://discuss.circleci.com/t/make-custom-command-run-always-with-when-always/38957/2
           steps:
             - generate_and_store_version_and_filesystem_artifacts
-  visual-a11y-tests:
+  visual-a11y:
     parameters:
       suite:
         type: string # ci or full
     executor: pw-focal-development
+    parallelism: 2
     steps:
       - build_and_install:
-          node-version: lts/hydrogen
+          node-version: lts/iron
       - run: npm run test:e2e:visual:<<parameters.suite>>
       - store_test_results:
           path: test-results/results.xml
@@ -254,8 +255,8 @@ workflows:
           name: e2e-stable
           suite: stable
       - e2e-mobile
-      - visual-a11y-tests:
-          name: visual-a11y-test-ci
+      - visual-a11y:
+          name: visual-a11y-ci
           suite: ci
 
   the-nightly: #These jobs do not run on PRs, but against master at night
@@ -274,8 +275,8 @@ workflows:
       - e2e-mobile
       - perf-test
       - mem-test
-      - visual-a11y-tests:
-          name: visual-a11y-test-nightly
+      - visual-a11y:
+          name: visual-a11y-nightly
           suite: full
       - e2e-couchdb
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ executors:
       NODE_ENV: development # Needed to ensure 'dist' folder created and devDependencies installed
       PERCY_POSTINSTALL_BROWSER: "true" # Needed to store the percy browser in cache deps
       PERCY_LOGLEVEL: "debug" # Enable DEBUG level logging for Percy (Issue: https://github.com/nasa/openmct/issues/5742)
+      PERCY_PARALLEL_TOTAL: 2
   ubuntu:
     machine:
       image: ubuntu-2204:current


### PR DESCRIPTION
Closes #7615 

### Describe your changes:
Originally, the intent of this ticket was to make sure we only had one worker per shard. Upon investigation, I discovered that we were already setting workers to 1.
This ticket improves runtime by running the tests in parallel

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
