### PR TITLE
fix(e2e): specify `.nyc_output` path as custom config setting

### DIFF
--- a/.webpack/webpack.coverage.mjs
+++ b/.webpack/webpack.coverage.mjs
@@ -16,7 +16,6 @@ config.module.rules.push({
     loader: 'babel-loader',
     options: {
       retainLines: true,
-      // eslint-disable-next-line no-undef
       plugins: [
         [
           'babel-plugin-istanbul',

--- a/e2e/playwright-ci.config.js
+++ b/e2e/playwright-ci.config.js
@@ -3,6 +3,7 @@
 
 // eslint-disable-next-line no-unused-vars
 import { devices } from '@playwright/test';
+import { fileURLToPath } from 'url';
 const MAX_FAILURES = 5;
 const NUM_WORKERS = 2;
 
@@ -15,7 +16,7 @@ const config = {
   timeout: 60 * 1000,
   webServer: {
     command: 'npm run start:coverage',
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 200 * 1000,
     reuseExistingServer: true //This was originally disabled to prevent differences in local debugging vs. CI. However, it significantly speeds up local debugging.
@@ -28,7 +29,9 @@ const config = {
     ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
-    video: 'off'
+    video: 'off',
+    // @ts-ignore - custom configuration option for nyc codecoverage output path
+    coveragePath: fileURLToPath(new URL('../.nyc_output', import.meta.url))
   },
   projects: [
     {

--- a/e2e/playwright-local.config.js
+++ b/e2e/playwright-local.config.js
@@ -1,6 +1,6 @@
 // playwright.config.js
 // @ts-check
-
+import { fileURLToPath } from 'url';
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   retries: 0,
@@ -10,7 +10,7 @@ const config = {
   timeout: 30 * 1000,
   webServer: {
     command: 'npm run start:coverage',
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 120 * 1000,
     reuseExistingServer: true

--- a/e2e/playwright-mobile.config.js
+++ b/e2e/playwright-mobile.config.js
@@ -14,7 +14,7 @@ const config = {
   timeout: 30 * 1000,
   webServer: {
     command: 'npm run start:coverage',
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 200 * 1000,
     reuseExistingServer: true //This was originally disabled to prevent differences in local debugging vs. CI. However, it significantly speeds up local debugging.
@@ -28,7 +28,9 @@ const config = {
     ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
-    video: 'off'
+    video: 'off',
+    // @ts-ignore - custom configuration option for nyc codecoverage output path
+    coveragePath: fileURLToPath(new URL('../.nyc_output', import.meta.url))
   },
   projects: [
     {

--- a/e2e/playwright-performance-dev.config.js
+++ b/e2e/playwright-performance-dev.config.js
@@ -1,6 +1,6 @@
 // playwright.config.js
 // @ts-check
-
+import { fileURLToPath } from 'url';
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   retries: 1, //Only for debugging purposes for trace: 'on-first-retry'
@@ -10,7 +10,7 @@ const config = {
   workers: 1, //Only run in serial with 1 worker
   webServer: {
     command: 'npm run start', //need development mode for performance.marks and others
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 200 * 1000,
     reuseExistingServer: false

--- a/e2e/playwright-performance-prod.config.js
+++ b/e2e/playwright-performance-prod.config.js
@@ -1,6 +1,6 @@
 // playwright.config.js
 // @ts-check
-
+import { fileURLToPath } from 'url';
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   retries: 0, //Only for debugging purposes for trace: 'on-first-retry'
@@ -10,7 +10,7 @@ const config = {
   workers: 1, //Only run in serial with 1 worker
   webServer: {
     command: 'npm run start:prod', //Production mode
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 200 * 1000,
     reuseExistingServer: false //Must be run with this option to prevent dev mode

--- a/e2e/playwright-visual-a11y.config.js
+++ b/e2e/playwright-visual-a11y.config.js
@@ -1,6 +1,6 @@
 // playwright.config.js
 // @ts-check
-
+import { fileURLToPath } from 'url';
 /** @type {import('@playwright/test').PlaywrightTestConfig<{ theme: string }>} */
 const config = {
   retries: 0, // Visual tests should never retry due to snapshot comparison errors. Leaving as a shim
@@ -10,7 +10,7 @@ const config = {
   workers: 1, //Lower stress on Circle CI Agent for Visual tests https://github.com/percy/cli/discussions/1067
   webServer: {
     command: 'npm run start:coverage',
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 200 * 1000,
     reuseExistingServer: !process.env.CI

--- a/e2e/playwright-watch.config.js
+++ b/e2e/playwright-watch.config.js
@@ -1,6 +1,5 @@
 // playwright.config.js
 // @ts-check
-
 import { devices } from '@playwright/test';
 import { fileURLToPath } from 'url';
 
@@ -11,7 +10,7 @@ const config = {
   timeout: 60 * 1000,
   webServer: {
     command: 'npm run start', //Start in dev mode for hot reloading
-    cwd: '../', // Provide cwd for the root of the project
+    cwd: fileURLToPath(new URL('../', import.meta.url)), // Provide cwd for the root of the project
     url: 'http://localhost:8080/#',
     timeout: 200 * 1000,
     reuseExistingServer: true //This was originally disabled to prevent differences in local debugging vs. CI. However, it significantly speeds up local debugging.


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7657 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Allow specifying the path to output `.nyc_output` raw code coverage *.json in playwright config so we can ensure the e2e coverage is generated against the correct sourcemap paths

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
