### PR TITLE
Handle paste events for images and text properly

### DIFF
--- a/.webpack/webpack.prod.mjs
+++ b/.webpack/webpack.prod.mjs
@@ -15,5 +15,5 @@ export default merge(common, {
       __OPENMCT_ROOT_RELATIVE__: '""'
     })
   ],
-  devtool: 'source-map'
+  devtool: 'eval-source-map'
 });

--- a/.webpack/webpack.prod.mjs
+++ b/.webpack/webpack.prod.mjs
@@ -15,5 +15,5 @@ export default merge(common, {
       __OPENMCT_ROOT_RELATIVE__: '""'
     })
   ],
-  devtool: 'eval-source-map'
+  devtool: 'source-map'
 });

--- a/e2e/helper/hotkeys/clipboard.js
+++ b/e2e/helper/hotkeys/clipboard.js
@@ -23,13 +23,23 @@
 const isMac = process.platform === 'darwin';
 const modifier = isMac ? 'Meta' : 'Control';
 
+/**
+ * @param {import('@playwright/test').Page} page
+ */
 async function selectAll(page) {
   await page.keyboard.press(`${modifier}+KeyA`);
 }
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
 async function copy(page) {
   await page.keyboard.press(`${modifier}+KeyC`);
 }
 
+/**
+ * @param {import('@playwright/test').Page} page
+ */
 async function paste(page) {
   await page.keyboard.press(`${modifier}+KeyV`);
 }

--- a/e2e/helper/hotkeys/clipboard.js
+++ b/e2e/helper/hotkeys/clipboard.js
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+const isMac = process.platform === 'darwin';
+const modifier = isMac ? 'Meta' : 'Control';
+
+async function selectAll(page) {
+  await page.keyboard.press(`${modifier}+KeyA`);
+}
+async function copy(page) {
+  await page.keyboard.press(`${modifier}+KeyC`);
+}
+
+async function paste(page) {
+  await page.keyboard.press(`${modifier}+KeyV`);
+}
+
+export { copy, paste, selectAll };

--- a/e2e/helper/hotkeys/hotkeys.js
+++ b/e2e/helper/hotkeys/hotkeys.js
@@ -1,0 +1,31 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { copy, paste, selectAll } from './clipboard.js';
+
+const hotkeys = {};
+
+hotkeys.copy = copy;
+hotkeys.paste = paste;
+hotkeys.selectAll = selectAll;
+
+export default hotkeys;

--- a/e2e/helper/hotkeys/hotkeys.js
+++ b/e2e/helper/hotkeys/hotkeys.js
@@ -20,12 +20,4 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import { copy, paste, selectAll } from './clipboard.js';
-
-const hotkeys = {};
-
-hotkeys.copy = copy;
-hotkeys.paste = paste;
-hotkeys.selectAll = selectAll;
-
-export default hotkeys;
+export * from './clipboard.js';

--- a/e2e/helper/notebookUtils.js
+++ b/e2e/helper/notebookUtils.js
@@ -30,12 +30,23 @@ import { fileURLToPath } from 'url';
  * @param {import('@playwright/test').Page} page
  */
 async function enterTextEntry(page, text) {
-  // Click the 'Add Notebook Entry' area
-  await page.locator(NOTEBOOK_DROP_AREA).click();
-
-  // enter text
-  await page.getByLabel('Notebook Entry Input').last().fill(text);
+  await addNotebookEntry(page);
+  await enterTextInLastEntry(page, text);
   await commitEntry(page);
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function addNotebookEntry(page) {
+  await page.locator(NOTEBOOK_DROP_AREA).click();
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+async function enterTextInLastEntry(page, text) {
+  await page.getByLabel('Notebook Entry Input').last().fill(text);
 }
 
 /**
@@ -140,10 +151,13 @@ async function createNotebookEntryAndTags(page, iterations = 1) {
 }
 
 export {
+  addNotebookEntry,
+  commitEntry,
   createNotebookAndEntry,
   createNotebookEntryAndTags,
   dragAndDropEmbed,
   enterTextEntry,
+  enterTextInLastEntry,
   lockPage,
   startAndAddRestrictedNotebookObject
 };

--- a/e2e/helper/notebookUtils.js
+++ b/e2e/helper/notebookUtils.js
@@ -28,6 +28,7 @@ import { fileURLToPath } from 'url';
 
 /**
  * @param {import('@playwright/test').Page} page
+ * @param {string} text
  */
 async function enterTextEntry(page, text) {
   await addNotebookEntry(page);

--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -569,4 +569,23 @@ test.describe('Notebook entry tests', () => {
 
     await expect(page.locator(`text="${EXPECTED_TEXT}"`)).toBeVisible();
   });
+
+  test('Prevents pasting text into selected notebook entry if not editing', async ({ page }) => {
+    const TEST_TEXT = 'This is a test';
+
+    await page.goto(notebookObject.url);
+
+    await nbUtils.addNotebookEntry(page);
+    await nbUtils.enterTextInLastEntry(page, TEST_TEXT);
+    await hotkeys.selectAll(page);
+    await hotkeys.copy(page);
+    await hotkeys.paste(page);
+    await nbUtils.commitEntry(page);
+
+    // This should not paste text into the entry
+    await hotkeys.paste(page);
+
+    await expect(await page.locator(`text="${TEST_TEXT.repeat(1)}"`).count()).toEqual(1);
+    await expect(await page.locator(`text="${TEST_TEXT.repeat(2)}"`).count()).toEqual(0);
+  });
 });

--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -27,6 +27,7 @@ This test suite is dedicated to tests which verify the basic operations surround
 import { fileURLToPath } from 'url';
 
 import { createDomainObjectWithDefaults } from '../../../../appActions.js';
+import hotkeys from '../../../../helper/hotkeys/hotkeys.js';
 import * as nbUtils from '../../../../helper/notebookUtils.js';
 import { expect, streamToString, test } from '../../../../pluginFixtures.js';
 
@@ -545,5 +546,27 @@ test.describe('Notebook entry tests', () => {
       'blockquote:has-text("until the idea succeeds")'
     );
     await expect(secondLineOfBlockquoteText).toBeVisible();
+  });
+
+  /**
+   *  Paste into notebook entry tests
+   */
+  test('Can paste text into a notebook entry', async ({ page }) => {
+    const TEST_TEXT = 'This is a test';
+    const iterations = 20;
+    const EXPECTED_TEXT = TEST_TEXT.repeat(iterations);
+
+    await page.goto(notebookObject.url);
+
+    await nbUtils.addNotebookEntry(page);
+    await nbUtils.enterTextInLastEntry(page, TEST_TEXT);
+    await hotkeys.selectAll(page);
+    await hotkeys.copy(page);
+    for (let i = 0; i < iterations; i++) {
+      await hotkeys.paste(page);
+    }
+    await nbUtils.commitEntry(page);
+
+    await expect(page.locator(`text="${EXPECTED_TEXT}"`)).toBeVisible();
   });
 });

--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -27,7 +27,7 @@ This test suite is dedicated to tests which verify the basic operations surround
 import { fileURLToPath } from 'url';
 
 import { createDomainObjectWithDefaults } from '../../../../appActions.js';
-import hotkeys from '../../../../helper/hotkeys/hotkeys.js';
+import { copy, paste, selectAll } from '../../../../helper/hotkeys/hotkeys.js';
 import * as nbUtils from '../../../../helper/notebookUtils.js';
 import { expect, streamToString, test } from '../../../../pluginFixtures.js';
 
@@ -564,10 +564,10 @@ test.describe('Notebook entry tests', () => {
 
     await nbUtils.addNotebookEntry(page);
     await nbUtils.enterTextInLastEntry(page, TEST_TEXT);
-    await hotkeys.selectAll(page);
-    await hotkeys.copy(page);
+    await selectAll(page);
+    await copy(page);
     for (let i = 0; i < iterations; i++) {
-      await hotkeys.paste(page);
+      await paste(page);
     }
     await nbUtils.commitEntry(page);
 
@@ -585,13 +585,13 @@ test.describe('Notebook entry tests', () => {
 
     await nbUtils.addNotebookEntry(page);
     await nbUtils.enterTextInLastEntry(page, TEST_TEXT);
-    await hotkeys.selectAll(page);
-    await hotkeys.copy(page);
-    await hotkeys.paste(page);
+    await selectAll(page);
+    await copy(page);
+    await paste(page);
     await nbUtils.commitEntry(page);
 
     // This should not paste text into the entry
-    await hotkeys.paste(page);
+    await paste(page);
 
     await expect(await page.locator(`text="${TEST_TEXT.repeat(1)}"`).count()).toEqual(1);
     await expect(await page.locator(`text="${TEST_TEXT.repeat(2)}"`).count()).toEqual(0);

--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -552,6 +552,10 @@ test.describe('Notebook entry tests', () => {
    *  Paste into notebook entry tests
    */
   test('Can paste text into a notebook entry', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/7686'
+    });
     const TEST_TEXT = 'This is a test';
     const iterations = 20;
     const EXPECTED_TEXT = TEST_TEXT.repeat(iterations);
@@ -571,6 +575,10 @@ test.describe('Notebook entry tests', () => {
   });
 
   test('Prevents pasting text into selected notebook entry if not editing', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/7686'
+    });
     const TEST_TEXT = 'This is a test';
 
     await page.goto(notebookObject.url);

--- a/src/plugins/notebook/components/NotebookEntry.vue
+++ b/src/plugins/notebook/components/NotebookEntry.vue
@@ -369,31 +369,24 @@ export default {
   },
   methods: {
     handlePaste(event) {
-      const clipboardImages = [];
-      const clipboardText = [];
       const clipboardItems = Array.from(
         (event.clipboardData || event.originalEvent.clipboardData).items
       );
+      const hasClipboardText = clipboardItems.some(
+        (clipboardItem) => clipboardItem.kind === 'string'
+      );
+      const clipboardImages = clipboardItems.filter(
+        (clipboardItem) => clipboardItem.kind === 'file' && clipboardItem.type.includes('image')
+      );
+      const hasClipboardImages = clipboardImages?.length > 0;
 
-      clipboardItems.forEach((clipboardItem) => {
-        if (clipboardItem.kind === 'file' && clipboardItem.type.includes('image')) {
-          clipboardImages.push(clipboardItem);
+      if (hasClipboardImages) {
+        if (hasClipboardText) {
+          console.warn('Image and text kinds found in paste. Only processing images.');
         }
 
-        if (clipboardItem.kind === 'string') {
-          clipboardText.push(clipboardItem);
-        }
-      });
-
-      if (clipboardImages.length > 0 && clipboardText.length > 0) {
-        console.warn('Both image and text kinds found in event.');
-      }
-
-      if (clipboardImages.length > 0) {
         this.addImageFromPaste(clipboardImages, event);
-      }
-
-      if (clipboardText.length > 0) {
+      } else if (hasClipboardText) {
         this.addTextFromPaste(event);
       }
     },


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7686

### Describe your changes:
- `paste text outside text area`: no-op
- `paste text inside text area (editing)`: default paste event behavior
- `paste image outside text area`: image attached
- `paste image inside text area (editing)`: image attached (FEATURE, DEFINITELY NOT A BUG: this persists the notebook entry, including any text edits made prior to the image paste, and leaves the entry in edit mode. If you want the entry to be committed on image paste, not in edit mode, or something else entirely, let me know @charlesh88 )



### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
