### PR TITLE
Ensure time conductor mode is set when synchronizing time range

### DIFF
--- a/e2e/tests/functional/plugins/plot/plotRendering.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotRendering.e2e.spec.js
@@ -25,7 +25,11 @@
  *
  */
 
-import {createDomainObjectWithDefaults, getCanvasPixels, setRealTimeMode} from '../../../../appActions.js';
+import {
+  createDomainObjectWithDefaults,
+  getCanvasPixels,
+  setRealTimeMode
+} from '../../../../appActions.js';
 import { expect, test } from '../../../../pluginFixtures.js';
 
 test.describe('Plot Rendering', () => {
@@ -53,7 +57,9 @@ test.describe('Plot Rendering', () => {
     await page.getByLabel('Plot Canvas').hover();
   });
 
-  test('Time conductor synchronizes with plot time range when that plot control is clicked', async ({ page }) => {
+  test('Time conductor synchronizes with plot time range when that plot control is clicked', async ({
+    page
+  }) => {
     // Navigate to Sine Wave Generator
     await page.goto(sineWaveGeneratorObject.url);
     // Switch to real-time mode

--- a/e2e/tests/functional/plugins/plot/plotRendering.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotRendering.e2e.spec.js
@@ -25,7 +25,7 @@
  *
  */
 
-import { createDomainObjectWithDefaults, getCanvasPixels } from '../../../../appActions.js';
+import {createDomainObjectWithDefaults, getCanvasPixels, setRealTimeMode} from '../../../../appActions.js';
 import { expect, test } from '../../../../pluginFixtures.js';
 
 test.describe('Plot Rendering', () => {
@@ -50,6 +50,32 @@ test.describe('Plot Rendering', () => {
       createMineFolderRequests.push(req);
     });
     expect(createMineFolderRequests.length).toEqual(0);
+    await page.getByLabel('Plot Canvas').hover();
+  });
+
+  test('Time conductor synchronizes with plot time range when that plot control is clicked', async ({ page }) => {
+    // Navigate to Sine Wave Generator
+    await page.goto(sineWaveGeneratorObject.url);
+    // Switch to real-time mode
+    await setRealTimeMode(page);
+
+    // hover over plot for plot controls
+    await page.getByLabel('Plot Canvas').hover();
+    // click on pause control
+    await page.getByTitle('Pause incoming real-time data').click();
+
+    // expect plot to be paused
+    await expect(page.getByTitle('Resume displaying real-time data')).toBeVisible();
+
+    // hover over plot for plot controls
+    await page.getByLabel('Plot Canvas').hover();
+    // click on synchronize with time conductor
+    await page.getByTitle('Synchronize Time Conductor').click();
+
+    await page.getByRole('button', { name: 'OK', exact: true }).click();
+
+    //confirm that you're now in fixed mode with the correct range
+    await expect(page.getByLabel('Time Conductor Mode')).toHaveText('Fixed Timespan');
   });
 
   test.fixme('Plot is rendered when infinity values exist', async ({ page }) => {

--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -180,6 +180,7 @@ import _ from 'lodash';
 import { useEventBus } from 'utils/useEventBus';
 import { toRaw } from 'vue';
 
+import { MODES } from '../../api/time/constants';
 import TagEditorClassNames from '../inspectorViews/annotations/tags/TagEditorClassNames.js';
 import XAxis from './axis/XAxis.vue';
 import YAxis from './axis/YAxis.vue';
@@ -1896,7 +1897,7 @@ export default {
 
     synchronizeTimeConductor() {
       const range = this.config.xAxis.get('displayRange');
-      this.timeContext.bounds({
+      this.timeContext.setMode(MODES.fixed, {
         start: range.min,
         end: range.max
       });


### PR DESCRIPTION


<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7729 

### Describe your changes:
Use setMode API to set the time span as well as the bounds instead of the old bounds time API.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
