### PR TITLE
Don't change sort order when changing performance mode

### DIFF
--- a/src/plugins/telemetryTable/TelemetryTable.js
+++ b/src/plugins/telemetryTable/TelemetryTable.js
@@ -172,8 +172,7 @@ export default class TelemetryTable extends EventEmitter {
     this.removeTelemetryCollection(keyString);
 
     let sortOptions = this.configuration.getConfiguration().sortOptions;
-    requestOptions.order =
-      sortOptions?.direction ?? (this.telemetryMode === 'performance' ? 'desc' : 'asc');
+    requestOptions.order = sortOptions?.direction ?? 'desc'; // default to descending
 
     if (this.telemetryMode === 'performance') {
       requestOptions.size = this.rowLimit;

--- a/src/plugins/telemetryTable/components/TableComponent.vue
+++ b/src/plugins/telemetryTable/components/TableComponent.vue
@@ -722,6 +722,7 @@ export default {
       }
     },
     initiateSort(columnKey, swapOrder = true) {
+      console.log('swapOrder', swapOrder)
       if (swapOrder) {
         // If sorting by the same column, flip the sort direction.
         if (this.sortOptions.key === columnKey) {

--- a/src/plugins/telemetryTable/components/TableComponent.vue
+++ b/src/plugins/telemetryTable/components/TableComponent.vue
@@ -721,18 +721,22 @@ export default {
         this.initiateSort(columnKey);
       }
     },
-    initiateSort(columnKey) {
-      // If sorting by the same column, flip the sort direction.
-      if (this.sortOptions.key === columnKey) {
-        if (this.sortOptions.direction === 'asc') {
-          this.sortOptions.direction = 'desc';
+    initiateSort(columnKey, swapOrder = true) {
+      if (swapOrder) {
+        // If sorting by the same column, flip the sort direction.
+        if (this.sortOptions.key === columnKey) {
+          this.sortOptions.direction = this.sortOptions.direction === 'asc' ? 'desc' : 'asc';
         } else {
-          this.sortOptions.direction = 'asc';
+          this.sortOptions = {
+            key: columnKey,
+            direction: 'desc'
+          };
         }
       } else {
+        // Do not swap the sort order, just set the column key
         this.sortOptions = {
           key: columnKey,
-          direction: 'desc'
+          direction: this.sortOptions.direction || 'desc'
         };
       }
 
@@ -1240,7 +1244,7 @@ export default {
         this.openmct.notifications.info(
           'Switched to Performance Mode: Table now sorted by time for optimized efficiency.'
         );
-        this.initiateSort(timeSystemKey);
+        this.initiateSort(timeSystemKey, false); // Pass false to avoid swapping the sort order
       }
     },
     setRowHeight(height) {

--- a/src/plugins/telemetryTable/components/TableComponent.vue
+++ b/src/plugins/telemetryTable/components/TableComponent.vue
@@ -721,23 +721,18 @@ export default {
         this.initiateSort(columnKey);
       }
     },
-    initiateSort(columnKey, swapOrder = true) {
-      console.log('swapOrder', swapOrder)
-      if (swapOrder) {
-        // If sorting by the same column, flip the sort direction.
-        if (this.sortOptions.key === columnKey) {
-          this.sortOptions.direction = this.sortOptions.direction === 'asc' ? 'desc' : 'asc';
+    initiateSort(columnKey) {
+      // If sorting by the same column, flip the sort direction.
+      if (this.sortOptions.key === columnKey) {
+        if (this.sortOptions.direction === 'asc') {
+          this.sortOptions.direction = 'desc';
         } else {
-          this.sortOptions = {
-            key: columnKey,
-            direction: 'desc'
-          };
+          this.sortOptions.direction = 'asc';
         }
       } else {
-        // Do not swap the sort order, just set the column key
         this.sortOptions = {
           key: columnKey,
-          direction: this.sortOptions.direction || 'desc'
+          direction: 'desc'
         };
       }
 
@@ -1245,7 +1240,7 @@ export default {
         this.openmct.notifications.info(
           'Switched to Performance Mode: Table now sorted by time for optimized efficiency.'
         );
-        this.initiateSort(timeSystemKey, false); // Pass false to avoid swapping the sort order
+        this.initiateSort(timeSystemKey);
       }
     },
     setRowHeight(height) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7809<!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Modified the `addTelemetryObject` method to NOT swap the sort order of the request and to default to any set order or descending.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
