### PR TITLE
chore(root): add eslint a11y plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,14 +16,15 @@ const config = {
     __OPENMCT_REVISION__: 'readonly',
     __OPENMCT_BUILD_BRANCH__: 'readonly'
   },
-  plugins: ['prettier', 'unicorn', 'simple-import-sort'],
+  plugins: ['prettier', 'unicorn', 'simple-import-sort', 'vuejs-accessibility'],
   extends: [
     'eslint:recommended',
     'plugin:compat/recommended',
     'plugin:vue/vue3-recommended',
     'plugin:you-dont-need-lodash-underscore/compatible',
     'plugin:prettier/recommended',
-    'plugin:no-unsanitized/DOM'
+    'plugin:no-unsanitized/DOM',
+    'plugin:vuejs-accessibility/recommended'
   ],
   parser: 'vue-eslint-parser',
   parserOptions: {
@@ -167,7 +168,19 @@ const config = {
     'vue/first-attribute-linebreak': 'error',
     'vue/multiline-html-element-content-newline': 'off',
     'vue/singleline-html-element-content-newline': 'off',
-    'vue/no-mutating-props': 'off' // TODO: Remove this rule and fix resulting errors
+    'vue/no-mutating-props': 'off', // TODO: Remove this rule and fix resulting errors
+    // TODO: A11y rules -> fix step by step
+    'vuejs-accessibility/no-static-element-interactions': 'off',
+    'vuejs-accessibility/click-events-have-key-events': 'off',
+    'vuejs-accessibility/interactive-supports-focus': 'off',
+    'vuejs-accessibility/label-has-for': 'off',
+    'vuejs-accessibility/mouse-events-have-key-events': 'off',
+    'vuejs-accessibility/role-has-required-aria-props': 'off',
+    'vuejs-accessibility/anchor-has-content': 'off',
+    'vuejs-accessibility/iframe-has-title': 'off',
+    'vuejs-accessibility/form-control-has-label': 'off',
+    'vuejs-accessibility/alt-text': 'off',
+    'vuejs-accessibility/aria-props': 'off'
   },
   overrides: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-simple-import-sort": "10.0.0",
         "eslint-plugin-unicorn": "49.0.0",
         "eslint-plugin-vue": "9.22.0",
+        "eslint-plugin-vuejs-accessibility": "^2.4.1",
         "eslint-plugin-you-dont-need-lodash-underscore": "6.13.0",
         "eventemitter3": "5.0.1",
         "file-saver": "2.0.5",
@@ -2432,6 +2433,16 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/array-flatten": {
@@ -4902,6 +4913,31 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.4.1.tgz",
+      "integrity": "sha512-ZRZhPdslplZXSF71MtSG+zXYRAT5KiHR4JVuo/DERQf9noAkDvi5W418VOE1qllmJd7wTenndxi1q8XeDMxdHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.0",
+        "emoji-regex": "^10.0.0",
+        "vue-eslint-parser": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-you-dont-need-lodash-underscore": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-simple-import-sort": "10.0.0",
     "eslint-plugin-unicorn": "49.0.0",
     "eslint-plugin-vue": "9.22.0",
+    "eslint-plugin-vuejs-accessibility": "^2.4.1",
     "eslint-plugin-you-dont-need-lodash-underscore": "6.13.0",
     "eventemitter3": "5.0.1",
     "file-saver": "2.0.5",


### PR DESCRIPTION
### Describe your changes:
Adds a11y to eslint

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
