### PR TITLE
Fix plot duplication and purging logic

### DIFF
--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -1113,6 +1113,7 @@ export default {
       }
 
       this.listenTo(window, 'mouseup', this.onMouseUp, this);
+      // TODO:  Why do we need this mousemove listener when we have a mousemove listener on the canvas above?
       this.listenTo(window, 'mousemove', this.trackMousePosition, this);
 
       // track frozen state on mouseDown to be read on mouseUp
@@ -1133,6 +1134,7 @@ export default {
 
     onMouseUp(event) {
       this.stopListening(window, 'mouseup', this.onMouseUp, this);
+      // TODO: Why do we need this when we have a mousemove listener on the canvas above?
       this.stopListening(window, 'mousemove', this.trackMousePosition, this);
 
       if (this.isMouseClick() && event.shiftKey) {

--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -230,7 +230,9 @@ export default class PlotSeries extends Model {
       const newPoints = _(data)
         .concat(points)
         .sortBy(this.getXVal)
-        .uniq(true, (point) => [this.getXVal(point), this.getYVal(point)].join())
+        .sortedUniqBy((point) => {
+          return [this.getXVal(point), this.getYVal(point)].join();
+        })
         .value();
       this.reset(newPoints);
     } catch (error) {
@@ -429,7 +431,7 @@ export default class PlotSeries extends Model {
     let data = this.getSeriesData();
     let insertIndex = data.length;
     const currentYVal = this.getYVal(newData);
-    const lastYVal = this.getYVal(data[insertIndex - 1]);
+    const lastYVal = insertIndex > 0 ? this.getYVal(data[insertIndex - 1]) : undefined;
 
     if (this.isValueInvalid(currentYVal) && this.isValueInvalid(lastYVal)) {
       console.warn(`[Plot] Invalid Y Values detected: ${currentYVal} ${lastYVal}`);

--- a/src/plugins/plot/configuration/PlotSeries.js
+++ b/src/plugins/plot/configuration/PlotSeries.js
@@ -507,8 +507,12 @@ export default class PlotSeries extends Model {
     const pointsToRemove = startIndex + (data.length - endIndex + 1);
     if (pointsToRemove > 0) {
       if (pointsToRemove < 1000) {
+        // Remove all points up to the start index
         data.slice(0, startIndex).forEach(this.remove, this);
-        data.slice(endIndex, data.length).forEach(this.remove, this);
+        // Re-calculate the endIndex since the data array has changed,
+        // then remove items from endIndex to the end of the array
+        const newEndIndex = endIndex - startIndex + 1;
+        data.slice(newEndIndex, data.length).forEach(this.remove, this);
         this.updateSeriesData(data);
         this.resetStats();
       } else {

--- a/src/plugins/telemetryTable/TelemetryTableConfiguration.js
+++ b/src/plugins/telemetryTable/TelemetryTableConfiguration.js
@@ -142,7 +142,7 @@ export default class TelemetryTableConfiguration extends EventEmitter {
   getAllHeaders() {
     let flattenedColumns = _.flatten(Object.values(this.columns));
     /* eslint-disable you-dont-need-lodash-underscore/uniq */
-    let headers = _.uniq(flattenedColumns, false, (column) => column.getKey()).reduce(
+    let headers = _.uniqBy(flattenedColumns, (column) => column.getKey()).reduce(
       fromColumnsToHeadersMap,
       {}
     );


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7926

### Describe your changes:
1. Duplicate data was not being properly eliminated due to outdated use of lodash utility `uniq`. Replaced that with the right `.sortedUniqBy`
2. Faulty logic when records out of range are being purged. Fixed that logic to take into account in-place data modification.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
