### PR TITLE
[Notebook] Browse Bar holding onto stale model, reverts changes

### DIFF
--- a/e2e/appActions.js
+++ b/e2e/appActions.js
@@ -683,31 +683,18 @@ async function linkParameterToObject(page, parameterName, objectName) {
 }
 
 /**
- * @param {import('@playwright/test').Page} page
- * @param {string} myItemsFolderName
- * @param {string} url
- * @param {string} newName
- */
-async function renameObjectFromContextMenu(page, url, newName) {
-  await openObjectTreeContextMenu(page, url);
-  await page.getByRole('menuitem', { name: 'Edit Properties' }).click();
-  const nameInput = page.getByLabel('Title', { exact: true });
-  await nameInput.fill('');
-  await nameInput.fill(newName);
-  await page.getByRole('button', { name: 'Save' }).click();
-}
-
-/**
- * Open the given `domainObject`'s context menu from the object tree.
- * Expands the path to the object and scrolls to it if necessary.
+ * Rename the currently viewed `domainObject` from the browse bar.
  *
  * @param {import('@playwright/test').Page} page
- * @param {string} url the url to the object
+ * @param {string} newName
  */
-async function openObjectTreeContextMenu(page, url) {
-  await page.goto(url);
-  await page.getByLabel('Show selected item in tree').click();
-  await page.getByRole('button', { name: 'More actions' }).click();
+async function renameCurrentObjectFromBrowseBar(page, newName) {
+  const nameInput = page.getByLabel('Browse bar object name');
+  await nameInput.click();
+  await nameInput.fill('');
+  await nameInput.fill(newName);
+  // Click the browse bar container to save changes
+  await page.getByLabel('Browse bar', { exact: true }).click();
 }
 
 export {
@@ -721,8 +708,7 @@ export {
   linkParameterToObject,
   navigateToObjectWithFixedTimeBounds,
   navigateToObjectWithRealTime,
-  openObjectTreeContextMenu,
-  renameObjectFromContextMenu,
+  renameCurrentObjectFromBrowseBar,
   setEndOffset,
   setFixedIndependentTimeConductorBounds,
   setFixedTimeMode,

--- a/e2e/appActions.js
+++ b/e2e/appActions.js
@@ -682,6 +682,34 @@ async function linkParameterToObject(page, parameterName, objectName) {
   await page.getByLabel('Save').click();
 }
 
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} myItemsFolderName
+ * @param {string} url
+ * @param {string} newName
+ */
+async function renameObjectFromContextMenu(page, url, newName) {
+  await openObjectTreeContextMenu(page, url);
+  await page.getByRole('menuitem', { name: 'Edit Properties' }).click();
+  const nameInput = page.getByLabel('Title', { exact: true });
+  await nameInput.fill('');
+  await nameInput.fill(newName);
+  await page.getByRole('button', { name: 'Save' }).click();
+}
+
+/**
+ * Open the given `domainObject`'s context menu from the object tree.
+ * Expands the path to the object and scrolls to it if necessary.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} url the url to the object
+ */
+async function openObjectTreeContextMenu(page, url) {
+  await page.goto(url);
+  await page.getByLabel('Show selected item in tree').click();
+  await page.getByRole('button', { name: 'More actions' }).click();
+}
+
 export {
   createDomainObjectWithDefaults,
   createExampleTelemetryObject,
@@ -693,6 +721,8 @@ export {
   linkParameterToObject,
   navigateToObjectWithFixedTimeBounds,
   navigateToObjectWithRealTime,
+  openObjectTreeContextMenu,
+  renameObjectFromContextMenu,
   setEndOffset,
   setFixedIndependentTimeConductorBounds,
   setFixedTimeMode,

--- a/e2e/tests/functional/renaming.e2e.spec.js
+++ b/e2e/tests/functional/renaming.e2e.spec.js
@@ -24,7 +24,7 @@
 This test suite is dedicated to tests for renaming objects, and their global application effects.
 */
 
-import { createDomainObjectWithDefaults } from '../../appActions.js';
+import { createDomainObjectWithDefaults, renameObjectFromContextMenu } from '../../appActions.js';
 import { expect, test } from '../../baseFixtures.js';
 
 test.describe('Renaming objects', () => {

--- a/e2e/tests/functional/renaming.e2e.spec.js
+++ b/e2e/tests/functional/renaming.e2e.spec.js
@@ -24,7 +24,7 @@
 This test suite is dedicated to tests for renaming objects, and their global application effects.
 */
 
-import { createDomainObjectWithDefaults, renameObjectFromContextMenu } from '../../appActions.js';
+import { createDomainObjectWithDefaults } from '../../appActions.js';
 import { expect, test } from '../../baseFixtures.js';
 
 test.describe('Renaming objects', () => {
@@ -73,3 +73,33 @@ test.describe('Renaming objects', () => {
     expect(title).toBe(clock.name);
   });
 });
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {string} myItemsFolderName
+ * @param {string} url
+ * @param {string} newName
+ */
+async function renameObjectFromContextMenu(page, url, newName) {
+  await openObjectTreeContextMenu(page, url);
+  await page.locator('li:text("Edit Properties")').click();
+  const nameInput = page.getByLabel('Title', { exact: true });
+  await nameInput.fill('');
+  await nameInput.fill(newName);
+  await page.locator('[aria-label="Save"]').click();
+}
+
+/**
+ * Open the given `domainObject`'s context menu from the object tree.
+ * Expands the path to the object and scrolls to it if necessary.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} url the url to the object
+ */
+async function openObjectTreeContextMenu(page, url) {
+  await page.goto(url);
+  await page.getByLabel('Show selected item in tree').click();
+  await page.locator('.is-navigated-object').click({
+    button: 'right'
+  });
+}

--- a/e2e/tests/functional/renaming.e2e.spec.js
+++ b/e2e/tests/functional/renaming.e2e.spec.js
@@ -73,33 +73,3 @@ test.describe('Renaming objects', () => {
     expect(title).toBe(clock.name);
   });
 });
-
-/**
- * @param {import('@playwright/test').Page} page
- * @param {string} myItemsFolderName
- * @param {string} url
- * @param {string} newName
- */
-async function renameObjectFromContextMenu(page, url, newName) {
-  await openObjectTreeContextMenu(page, url);
-  await page.locator('li:text("Edit Properties")').click();
-  const nameInput = page.getByLabel('Title', { exact: true });
-  await nameInput.fill('');
-  await nameInput.fill(newName);
-  await page.locator('[aria-label="Save"]').click();
-}
-
-/**
- * Open the given `domainObject`'s context menu from the object tree.
- * Expands the path to the object and scrolls to it if necessary.
- *
- * @param {import('@playwright/test').Page} page
- * @param {string} url the url to the object
- */
-async function openObjectTreeContextMenu(page, url) {
-  await page.goto(url);
-  await page.getByLabel('Show selected item in tree').click();
-  await page.locator('.is-navigated-object').click({
-    button: 'right'
-  });
-}

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -20,7 +20,7 @@
  at runtime from the About dialog for additional information.
 -->
 <template>
-  <div class="l-browse-bar">
+  <div class="l-browse-bar" aria-label="Browse bar">
     <div class="l-browse-bar__start">
       <button
         v-if="hasParent"
@@ -35,6 +35,7 @@
         </div>
         <span
           ref="objectName"
+          aria-label="Browse bar object name"
           class="l-browse-bar__object-name c-object-label__name"
           :class="{ 'c-input-inline': isPersistable }"
           :contenteditable="isNameEditable"

--- a/src/ui/router/Browse.js
+++ b/src/ui/router/Browse.js
@@ -80,13 +80,11 @@ class Browse {
     this.#openmct.layout.$refs.browseBar.viewKey = viewProvider.key;
   }
 
-  #updateDocumentTitleOnNameMutation(newName) {
-    if (typeof newName === 'string' && newName !== document.title) {
-      document.title = newName;
-      this.#openmct.layout.$refs.browseBar.domainObject = {
-        ...this.#openmct.layout.$refs.browseBar.domainObject,
-        name: newName
-      };
+  #handelBrowseObjectUpdate(newObject) {
+    this.#openmct.layout.$refs.browseBar.domainObject = newObject;
+
+    if (typeof newObject.name === 'string' && newObject.name !== document.title) {
+      document.title = newObject.name;
     }
   }
 
@@ -120,8 +118,8 @@ class Browse {
     document.title = this.#browseObject.name; //change document title to current object in main view
     this.#unobserve = this.#openmct.objects.observe(
       this.#browseObject,
-      'name',
-      this.#updateDocumentTitleOnNameMutation.bind(this)
+      '*',
+      this.#handelBrowseObjectUpdate.bind(this)
     );
     const currentProvider = this.#openmct.objectViews.getByProviderKey(currentViewKey);
     if (currentProvider && currentProvider.canView(this.#browseObject, this.#openmct.router.path)) {

--- a/src/ui/router/Browse.js
+++ b/src/ui/router/Browse.js
@@ -80,7 +80,7 @@ class Browse {
     this.#openmct.layout.$refs.browseBar.viewKey = viewProvider.key;
   }
 
-  #handelBrowseObjectUpdate(newObject) {
+  #handleBrowseObjectUpdate(newObject) {
     this.#openmct.layout.$refs.browseBar.domainObject = newObject;
 
     if (typeof newObject.name === 'string' && newObject.name !== document.title) {
@@ -119,7 +119,7 @@ class Browse {
     this.#unobserve = this.#openmct.objects.observe(
       this.#browseObject,
       '*',
-      this.#handelBrowseObjectUpdate.bind(this)
+      this.#handleBrowseObjectUpdate.bind(this)
     );
     const currentProvider = this.#openmct.objectViews.getByProviderKey(currentViewKey);
     if (currentProvider && currentProvider.canView(this.#browseObject, this.#openmct.router.path)) {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7943 7943<!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
In Browse.js instead of just watching the name of the domain object to update the page title, we watch the whole object and update the whole object, while also updating the page title if necessary.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
