### PR TITLE
Independent time conductor related handling for plot synchronization.

### DIFF
--- a/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
@@ -113,9 +113,8 @@ test.describe('Plot Controls', () => {
   Test to verify that switching a plot's time context from global to
   its own independent time context and then back to global context works correctly.
 
-  After switching from independent time context to the global time context in real time mode,
-  triggering 'synchronize time conductor' action should have the desired affect of putting the
-  global time conductor in fixed time span mode (including showing the popup modal).
+  After switching from fixed time mode (ITC) to real time mode (global context),
+  the pause control for the plot should be available, indicating that it is following the right context.
   */
   test('Plots follow the right time context', async ({ page }) => {
     // Set realtime mode with 2 second window
@@ -129,49 +128,33 @@ test.describe('Plot Controls', () => {
       endSecs: '01'
     };
 
-    // Switch to real-time mode
+    // Set global time conductor to real-time mode
     await setRealTimeMode(page);
-
-    // Set start time offset
-    await setStartOffset(page, startOffset);
-
-    // Set end time offset
-    await setEndOffset(page, endOffset);
 
     // hover over plot for plot controls
     await page.getByLabel('Plot Canvas').hover();
-    // click on pause control
-    await page.getByTitle('Pause incoming real-time data').click();
-    // expect plot to be paused
-    await expect(page.getByTitle('Resume displaying real-time data')).toBeVisible();
-    // synchronize time conductor
-    await page.getByTitle('Synchronize Time Conductor').click();
-
-    // expect warning message, ack it.
-    await expect(page.getByLabel('Modal Overlay')).toBeVisible();
-    await page.getByLabel('Modal Overlay').getByRole('button', { name: 'OK' }).click();
-
-    //confirm that you're now in fixed mode
-    await expect(page.getByLabel('Time Conductor Mode')).toHaveText('Fixed Timespan');
+    // Ensure pause control is visible since global time conductor is in Real time mode.
+    await expect(page.getByTitle('Pause incoming real-time data')).toBeVisible();
 
     // Toggle independent time conductor ON
     await page.getByLabel('Enable Independent Time Conductor').click();
-    // Toggle independent time conductor OFF
-    await page.getByLabel('Disable Independent Time Conductor').click();
 
-    // Switch to real-time mode
-    await setRealTimeMode(page);
+    // Bring up the independent time conductor popup and switch to fixed time mode
+    await page.getByLabel('Independent Time Conductor Settings').click();
+    await page.getByLabel('Independent Time Conductor Mode Menu').click();
+    await page.getByRole('menuitem', { name: /Fixed Timespan/ }).click();
+
     // hover over plot for plot controls
     await page.getByLabel('Plot Canvas').hover();
-    // click on pause control
-    await page.getByTitle('Pause incoming real-time data').click();
-    // expect plot to be paused
-    await expect(page.getByTitle('Resume displaying real-time data')).toBeVisible();
-    // synchronize time conductor
-    await page.getByTitle('Synchronize Time Conductor').click();
+    // Ensure pause control is no longer visible since the plot is following the independent time context
+    await expect(page.getByTitle('Pause incoming real-time data')).toBeHidden();
 
-    // expect warning message, ack it.
-    await expect(page.getByLabel('Modal Overlay')).toBeVisible();
-    await page.getByLabel('Modal Overlay').getByRole('button', { name: 'OK' }).click();
+    // Toggle independent time conductor OFF - Note that the global time conductor is still in Real time mode
+    await page.getByLabel('Disable Independent Time Conductor').click();
+
+    // hover over plot for plot controls
+    await page.getByLabel('Plot Canvas').hover();
+    // Ensure pause control is visible since the global time conductor is in real time mode
+    await expect(page.getByTitle('Pause incoming real-time data')).toBeVisible();
   });
 });

--- a/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
@@ -143,6 +143,9 @@ test.describe('Plot Controls', () => {
     await expect(page.getByLabel('Modal Overlay')).toBeVisible();
     await page.getByLabel('Modal Overlay').getByRole('button', { name: 'OK' }).click();
 
+    //confirm that you're now in fixed mode
+    await expect(page.getByLabel('Time Conductor Mode')).toHaveText('Fixed Timespan');
+
     // Toggle independent time conductor ON
     await page.getByLabel('Enable Independent Time Conductor').click();
     // Toggle independent time conductor OFF

--- a/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
@@ -108,4 +108,59 @@ test.describe('Plot Controls', () => {
     // Expect before and after plot points to match
     await expect(plotPixelSizeAtPause).toEqual(plotPixelSizeAfterWait);
   });
+
+  test('Plots follow the right time context', async ({ page }) => {
+    // Set realtime mode with 2 second window
+    const startOffset = {
+      startMins: '00',
+      startSecs: '01'
+    };
+
+    const endOffset = {
+      endMins: '00',
+      endSecs: '01'
+    };
+
+    // Switch to real-time mode
+    await setRealTimeMode(page);
+
+    // Set start time offset
+    await setStartOffset(page, startOffset);
+
+    // Set end time offset
+    await setEndOffset(page, endOffset);
+
+    // hover over plot for plot controls
+    await page.getByLabel('Plot Canvas').hover();
+    // click on pause control
+    await page.getByTitle('Pause incoming real-time data').click();
+    // expect plot to be paused
+    await expect(page.getByTitle('Resume displaying real-time data')).toBeVisible();
+    // synchronize time conductor
+    await page.getByTitle('Synchronize Time Conductor').click();
+
+    // expect warning message, ack it.
+    await expect(page.getByLabel('Modal Overlay')).toBeVisible();
+    await page.getByLabel('Modal Overlay').getByRole('button', { name: 'OK' }).click();
+
+    // Toggle independent time conductor ON
+    await page.getByLabel('Enable Independent Time Conductor').click();
+    // Toggle independent time conductor OFF
+    await page.getByLabel('Disable Independent Time Conductor').click();
+
+    // Switch to real-time mode
+    await setRealTimeMode(page);
+    // hover over plot for plot controls
+    await page.getByLabel('Plot Canvas').hover();
+    // click on pause control
+    await page.getByTitle('Pause incoming real-time data').click();
+    // expect plot to be paused
+    await expect(page.getByTitle('Resume displaying real-time data')).toBeVisible();
+    // synchronize time conductor
+    await page.getByTitle('Synchronize Time Conductor').click();
+
+    // expect warning message, ack it.
+    await expect(page.getByLabel('Modal Overlay')).toBeVisible();
+    await page.getByLabel('Modal Overlay').getByRole('button', { name: 'OK' }).click();
+  });
 });

--- a/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
@@ -117,17 +117,6 @@ test.describe('Plot Controls', () => {
   the pause control for the plot should be available, indicating that it is following the right context.
   */
   test('Plots follow the right time context', async ({ page }) => {
-    // Set realtime mode with 2 second window
-    const startOffset = {
-      startMins: '00',
-      startSecs: '01'
-    };
-
-    const endOffset = {
-      endMins: '00',
-      endSecs: '01'
-    };
-
     // Set global time conductor to real-time mode
     await setRealTimeMode(page);
 

--- a/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotControls.e2e.spec.js
@@ -109,6 +109,14 @@ test.describe('Plot Controls', () => {
     await expect(plotPixelSizeAtPause).toEqual(plotPixelSizeAfterWait);
   });
 
+  /*
+  Test to verify that switching a plot's time context from global to
+  its own independent time context and then back to global context works correctly.
+
+  After switching from independent time context to the global time context in real time mode,
+  triggering 'synchronize time conductor' action should have the desired affect of putting the
+  global time conductor in fixed time span mode (including showing the popup modal).
+  */
   test('Plots follow the right time context', async ({ page }) => {
     // Set realtime mode with 2 second window
     const startOffset = {

--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -441,7 +441,9 @@ class IndependentTimeContext extends TimeContext {
     this.emit('bounds', this.getBounds());
     this.emit(TIME_CONTEXT_EVENTS.boundsChanged, this.getBounds());
     // Also emit the mode in case it's different from previous time context
-    this.emit(TIME_CONTEXT_EVENTS.modeChanged, this.#copy(this.getMode()));
+    if (this.getMode()) {
+      this.emit(TIME_CONTEXT_EVENTS.modeChanged, this.#copy(this.getMode()));
+    }
   }
 
   /**
@@ -517,7 +519,9 @@ class IndependentTimeContext extends TimeContext {
       this.emit('bounds', this.getBounds());
       this.emit(TIME_CONTEXT_EVENTS.boundsChanged, this.getBounds());
       // Also emit the mode in case it's different from the global time context
-      this.emit(TIME_CONTEXT_EVENTS.modeChanged, this.#copy(this.getMode()));
+      if (this.getMode()) {
+        this.emit(TIME_CONTEXT_EVENTS.modeChanged, this.#copy(this.getMode()));
+      }
       // now that the view's context is set, tell others to check theirs in case they were following this view's context.
       this.globalTimeContext.emit('refreshContext', viewKey);
     }

--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -360,6 +360,18 @@ class IndependentTimeContext extends TimeContext {
   }
 
   /**
+   * @returns {boolean}
+   * @override
+   */
+  isFixed() {
+    if (this.upstreamTimeContext) {
+      return this.upstreamTimeContext.isFixed(...arguments);
+    } else {
+      return super.isFixed(...arguments);
+    }
+  }
+
+  /**
    * @returns {number}
    * @override
    */
@@ -400,7 +412,7 @@ class IndependentTimeContext extends TimeContext {
   }
 
   /**
-   * Reset the time context to the global time context
+   * Reset the time context from the global time context
    */
   resetContext() {
     if (this.upstreamTimeContext) {
@@ -428,6 +440,8 @@ class IndependentTimeContext extends TimeContext {
     // Emit bounds so that views that are changing context get the upstream bounds
     this.emit('bounds', this.getBounds());
     this.emit(TIME_CONTEXT_EVENTS.boundsChanged, this.getBounds());
+    // Also emit the mode in case it's different from previous time context
+    this.emit(TIME_CONTEXT_EVENTS.modeChanged, this.#copy(this.getMode()));
   }
 
   /**
@@ -502,6 +516,8 @@ class IndependentTimeContext extends TimeContext {
       // Emit bounds so that views that are changing context get the upstream bounds
       this.emit('bounds', this.getBounds());
       this.emit(TIME_CONTEXT_EVENTS.boundsChanged, this.getBounds());
+      // Also emit the mode in case it's different from the global time context
+      this.emit(TIME_CONTEXT_EVENTS.modeChanged, this.#copy(this.getMode()));
       // now that the view's context is set, tell others to check theirs in case they were following this view's context.
       this.globalTimeContext.emit('refreshContext', viewKey);
     }

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -23,6 +23,7 @@
 import { FIXED_MODE_KEY, REALTIME_MODE_KEY } from '@/api/time/constants';
 import IndependentTimeContext from '@/api/time/IndependentTimeContext';
 
+import { TIME_CONTEXT_EVENTS } from './constants';
 import GlobalTimeContext from './GlobalTimeContext.js';
 
 /**
@@ -142,7 +143,7 @@ class TimeAPI extends GlobalTimeContext {
   addIndependentContext(key, value, clockKey) {
     let timeContext = this.getIndependentContext(key);
 
-    //stop following upstream time context since the view has it's own
+    //stop following upstream time context since the view has its own
     timeContext.resetContext();
 
     if (clockKey) {
@@ -151,6 +152,12 @@ class TimeAPI extends GlobalTimeContext {
     } else {
       timeContext.setMode(FIXED_MODE_KEY, value);
     }
+
+    // Also emit the mode in case it's different from the previous time context
+    timeContext.emit(
+      TIME_CONTEXT_EVENTS.modeChanged,
+      JSON.parse(JSON.stringify(timeContext.getMode()))
+    );
 
     // Notify any nested views to update, pass in the viewKey so that particular view can skip getting an upstream context
     this.emit('refreshContext', key);

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -154,10 +154,7 @@ class TimeAPI extends GlobalTimeContext {
     }
 
     // Also emit the mode in case it's different from the previous time context
-    timeContext.emit(
-      TIME_CONTEXT_EVENTS.modeChanged,
-      JSON.parse(JSON.stringify(timeContext.getMode()))
-    );
+    timeContext.emit(TIME_CONTEXT_EVENTS.modeChanged, structuredClone(timeContext.getMode()));
 
     // Notify any nested views to update, pass in the viewKey so that particular view can skip getting an upstream context
     this.emit('refreshContext', key);

--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -537,6 +537,7 @@ export default {
       this.followTimeContext();
     },
     followTimeContext() {
+      this.updateMode();
       this.updateDisplayBounds(this.timeContext.getBounds());
       this.timeContext.on('modeChanged', this.updateMode);
       this.timeContext.on('boundsChanged', this.updateDisplayBounds);

--- a/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
+++ b/src/plugins/timeConductor/independent/IndependentTimeConductor.vue
@@ -243,12 +243,20 @@ export default {
       this.timeContext.off(TIME_CONTEXT_EVENTS.modeChanged, this.setTimeOptionsMode);
     },
     setTimeOptionsClock(clock) {
+      // If the user has persisted any time options, then don't override them with global settings.
+      if (this.independentTCEnabled) {
+        return;
+      }
       this.setTimeOptionsOffsets();
       this.timeOptions.clock = clock.key;
     },
     setTimeOptionsMode(mode) {
-      this.setTimeOptionsOffsets();
-      this.timeOptions.mode = mode;
+      // If the user has persisted any time options, then don't override them with global settings.
+      if (this.independentTCEnabled) {
+        this.setTimeOptionsOffsets();
+        this.timeOptions.mode = mode;
+        this.isFixed = this.timeOptions.mode === FIXED_MODE_KEY;
+      }
     },
     setTimeOptionsOffsets() {
       this.timeOptions.clockOffsets =


### PR DESCRIPTION
Closes #7737

### Describe your changes:
Ensure that the mode set when independent time conductor is enabled/disabled is propagated correctly.

Also ensure that global time conductor changes are not picked up by the independent time conductor when the user has enabled it at least once before


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
