### PR TITLE
Adds new check to clearData that enables data clearing on overlay plots.

### DIFF
--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -734,6 +734,21 @@ export default {
         );
       });
     },
+    plotCompositionContainsId(domainObjectToFind) {
+      if (!this.domainObject.composition) {
+        return false;
+      }
+      if (!domainObjectToFind.identifier) {
+        return false;
+      }
+
+      return this.domainObject.composition.some((compositionIdentifier) => {
+        return this.openmct.objects.areIdsEqual(
+          compositionIdentifier,
+          domainObjectToFind.identifier
+        );
+      });
+    },
 
     clearData(domainObjectToClear) {
       // If we don't have an object to clear (global), or the IDs are equal, just clear the data.
@@ -747,7 +762,8 @@ export default {
           domainObjectToClear.identifier,
           this.domainObject.identifier
         ) ||
-        this.compositionPathContainsId(domainObjectToClear)
+        this.compositionPathContainsId(domainObjectToClear) ||
+        this.plotCompositionContainsId(domainObjectToClear)
       ) {
         this.clearSeries();
       }


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Closes https://github.com/nasa/openmct/issues/7947

This change adds a new case to the existing 3 logic scenarios in the ClearData function (new case in bold): 

- if no domain object (clear data)
- else if the object requesting the clear is the same as the currently plotting object (clear data)
- else if the object requesting the clear's composition contains the currently plotting object (clear data)
- **else if the object requesting the clear is within the composition of the currently plotting object (clear data)**

I maintain that the 3rd case, compositionPathContainsId may have originally been intended to capture the 4th case, but I don't want to break someone else's work so it is safer to just cover the currently missing 4th case.  

To test this change, you'll have to do the following: 

1. Add 'openmct.objectViews.emit('clearData',domainObject);'
    to the [TelemetryMeanProvider](https://github.com/nasa/openmct/blob/d74e1b19b61d636aebf41e774e75dfb0558157c2/src/plugins/telemetryMean/src/MeanTelemetryProvider.js#L84). 
2. Create a new mean object and select it in the tree. 
4. Put the mean object into an overlay plot and zoom out. The mean should be re-calculated and re-plotted on every zoom level. 

Note: This is much easier to test with a server responding to telemetry requests as opposed to using sine wave generators. 

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
