### PR TITLE
Set default mode and bounds last in time conductor plugin

### DIFF
--- a/src/plugins/timeConductor/plugin.js
+++ b/src/plugins/timeConductor/plugin.js
@@ -140,9 +140,6 @@ export default function (config) {
       }
     }
 
-    openmct.time.setMode(defaultMode, defaultClock ? clockOffsets : defaultBounds);
-    openmct.time.setTimeSystem(defaults.timeSystem, defaultBounds);
-
     //We are going to set the clockOffsets in fixed time mode since the conductor components down the line need these
     if (clockOffsets && defaultMode === FIXED_MODE_KEY) {
       openmct.time.setClockOffsets(clockOffsets);
@@ -151,6 +148,8 @@ export default function (config) {
     if (defaultBounds && defaultMode === REALTIME_MODE_KEY) {
       openmct.time.setBounds(clockOffsets);
     }
+    openmct.time.setMode(defaultMode, defaultClock ? clockOffsets : defaultBounds);
+    openmct.time.setTimeSystem(defaults.timeSystem, defaultBounds);
 
     openmct.on('start', function () {
       mountComponent(openmct, config);


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7963 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

Change just moves the 'setMode' and 'setTimeSystem' functions to be performed last in the time conductor plugin, after the setBounds and setClockOffsets calls, which override the defaults intended. 


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
