### PR TITLE
Don't disallow mouse events when in compact mode for plots

### DIFF
--- a/e2e/tests/functional/plugins/plot/plotControlsCompactMode.e2e.spec.js
+++ b/e2e/tests/functional/plugins/plot/plotControlsCompactMode.e2e.spec.js
@@ -1,0 +1,58 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2025, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/*
+ * This test suite is dedicated to testing the rendering and interaction of plots.
+ *
+ */
+
+import { createDomainObjectWithDefaults } from '../../../../appActions.js';
+import { expect, test } from '../../../../pluginFixtures.js';
+
+test.describe('Plot Controls in compact mode', () => {
+  let timeStrip;
+
+  test.beforeEach(async ({ page }) => {
+    // Open a browser, navigate to the main page, and wait until all networkevents to resolve
+    await page.goto('./', { waitUntil: 'domcontentloaded' });
+    timeStrip = await createDomainObjectWithDefaults(page, {
+      type: 'Time Strip'
+    });
+
+    // Create an overlay plot with a sine wave generator
+    await createDomainObjectWithDefaults(page, {
+      type: 'Sine Wave Generator',
+      parent: timeStrip.uuid
+    });
+    await page.goto(`${timeStrip.url}`);
+  });
+
+  test('Plots show cursor guides', async ({ page }) => {
+    // hover over plot for plot controls
+    await page.getByLabel('Plot Canvas').hover();
+    // click on cursor guides control
+    await page.getByTitle('Toggle cursor guides').click();
+    await page.getByLabel('Plot Canvas').hover();
+    await expect(page.getByLabel('Vertical cursor guide')).toBeVisible();
+    await expect(page.getByLabel('Horizontal cursor guide')).toBeVisible();
+  });
+});

--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -164,11 +164,13 @@
           <div
             v-show="cursorGuide"
             ref="cursorGuideVertical"
+            aria-label="Vertical cursor guide"
             class="c-cursor-guide--v js-cursor-guide--v"
           ></div>
           <div
             v-show="cursorGuide"
             ref="cursorGuideHorizontal"
+            aria-label="Horizontal cursor guide"
             class="c-cursor-guide--h js-cursor-guide--h"
           ></div>
         </div>

--- a/src/plugins/plot/MctPlot.vue
+++ b/src/plugins/plot/MctPlot.vue
@@ -854,13 +854,11 @@ export default {
 
       this.canvas = this.$refs.chartContainer.querySelectorAll('canvas')[1];
 
-      if (!this.options.compact) {
-        this.listenTo(this.canvas, 'mousemove', this.trackMousePosition, this);
-        this.listenTo(this.canvas, 'mouseleave', this.untrackMousePosition, this);
-        this.listenTo(this.canvas, 'mousedown', this.onMouseDown, this);
-        this.listenTo(this.canvas, 'click', this.selectNearbyAnnotations, this);
-        this.listenTo(this.canvas, 'wheel', this.wheelZoom, this);
-      }
+      this.listenTo(this.canvas, 'mousemove', this.trackMousePosition, this);
+      this.listenTo(this.canvas, 'mouseleave', this.untrackMousePosition, this);
+      this.listenTo(this.canvas, 'mousedown', this.onMouseDown, this);
+      this.listenTo(this.canvas, 'click', this.selectNearbyAnnotations, this);
+      this.listenTo(this.canvas, 'wheel', this.wheelZoom, this);
     },
 
     marqueeAnnotations(annotationsToSelect) {
@@ -1115,19 +1113,21 @@ export default {
       this.listenTo(window, 'mouseup', this.onMouseUp, this);
       this.listenTo(window, 'mousemove', this.trackMousePosition, this);
 
-      // track frozen state on mouseDown to be read on mouseUp
-      const isFrozen =
-        this.config.xAxis.get('frozen') === true && this.config.yAxis.get('frozen') === true;
-      this.isFrozenOnMouseDown = isFrozen;
+      if (!this.options.compact) {
+        // track frozen state on mouseDown to be read on mouseUp
+        const isFrozen =
+          this.config.xAxis.get('frozen') === true && this.config.yAxis.get('frozen') === true;
+        this.isFrozenOnMouseDown = isFrozen;
 
-      if (event.altKey && !event.shiftKey) {
-        return this.startPan(event);
-      } else if (event.altKey && event.shiftKey) {
-        this.freeze();
+        if (event.altKey && !event.shiftKey) {
+          return this.startPan(event);
+        } else if (event.altKey && event.shiftKey) {
+          this.freeze();
 
-        return this.startMarquee(event, true);
-      } else {
-        return this.startMarquee(event, false);
+          return this.startMarquee(event, true);
+        } else {
+          return this.startMarquee(event, false);
+        }
       }
     },
 
@@ -1158,11 +1158,15 @@ export default {
     },
 
     isMouseClick() {
-      if (!this.marquee) {
+      // We may not have a marquee if we've disabled pan/zoom, but we still need to know if it's a mouse click for highlights and lock points.
+      if (!this.marquee && !this.positionOverPlot) {
         return false;
       }
 
-      const { start, end } = this.marquee;
+      const { start, end } = this.marquee ?? {
+        start: this.positionOverPlot,
+        end: this.positionOverPlot
+      };
       const someYPositionOverPlot = start.y.some((y) => y);
 
       return start.x === end.x && someYPositionOverPlot;

--- a/src/plugins/plot/PlotView.vue
+++ b/src/plugins/plot/PlotView.vue
@@ -162,14 +162,6 @@ export default {
       }
     }
   },
-  watch: {
-    gridLines(newGridLines) {
-      this.gridLines = newGridLines;
-    },
-    cursorGuide(newCursorGuide) {
-      this.cursorGuide = newCursorGuide;
-    }
-  },
   created() {
     eventHelpers.extend(this);
     this.imageExporter = new ImageExporter(this.openmct);


### PR DESCRIPTION
Closes #7968 #7969

### Describe your changes:
Allow highlights and locking highlight points for plots in compact mode.
Cursor guides and grid lines for stacked plots also fixed.
Synchronized cursor guides and grid lines in compact mode will be done in #7960.
Still disallow pan and zoom in compact mode - this will be handled in #7958.


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
