### PR TITLE
[Stacked Plot] fix initial drop into plot not editable

### DIFF
--- a/src/plugins/plot/stackedPlot/StackedPlotItem.vue
+++ b/src/plugins/plot/stackedPlot/StackedPlotItem.vue
@@ -121,6 +121,7 @@ export default {
       this.triggerUnsubscribeFromStaleness(domainObject);
       this.subscribeToStaleness(domainObject);
     });
+    this.setEditState(this.isEditing);
   },
   beforeUnmount() {
     this.openmct.editor.off('isEditing', this.setEditState);


### PR DESCRIPTION
Closes #7865 

### Describe your changes:
Upon initial drop into a stacked plot, the edit status of the openmct editor status was properly retrieved. However this retrieved status wasn't passed to the setEditState() function in plugins/plot/stackedPlot/StackedPlotItem.vue for handling. This fix passes the initial value to its handler resulting in an editable item upon initial drop into a stacked plot.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [X] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [X] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?

### Testing Instructions
1. Create a stacked plot and save it
2. Drag and Drop an item into the stacked plot which will put it into edit mode
3. Try to select the item to edit it's properties. The item should successfully be selectable.
