### PR TITLE
Condition Sets can incorrectly evaluate telemetry objects that update infrequently

### DIFF
--- a/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
@@ -117,7 +117,7 @@ test.describe('Basic Condition Set Use', () => {
     await page.getByLabel('Conditions View').click();
     await expect(page.getByText('Current Output')).toBeVisible();
   });
-  test('ConditionSet has produces an output when telemetry is available, and does not when it is not', async ({
+  test('ConditionSet produces an output when telemetry is available, and does not when it is not', async ({
     page
   }) => {
     const exampleTelemetry = await createExampleTelemetryObject(page);
@@ -288,19 +288,14 @@ test.describe('Basic Condition Set Use', () => {
     await setRealTimeMode(page);
     await page.getByLabel('Create', { exact: true }).click();
     await page.getByLabel('State Generator').click();
-    //await page.getByLabel('Title', { exact: true }).click();
     await page.getByLabel('Title', { exact: true }).fill('P1');
-    //await page.getByLabel('State Duration (seconds)').click();
     await page.getByLabel('State Duration (seconds)').fill('1');
     await page.getByLabel('Save').click();
     await page.getByLabel('Create', { exact: true }).click();
     await page.getByLabel('State Generator').click();
-    //await page.getByLabel('Title', { exact: true }).click();
     await page.getByLabel('Title', { exact: true }).fill('P2');
-    //await page.getByLabel('State Duration (seconds)', { exact: true }).click();
     await page.getByLabel('State Duration (seconds)', { exact: true }).fill('1');
     await page.getByRole('treeitem', { name: 'Test Condition Set' }).click();
-    //await page.getByLabel('Modal Overlay').getByLabel('Navigate to Unnamed Condition').click();
     await page.getByLabel('Save').click();
     await page.getByLabel('Expand My Items folder').click();
     await page.getByRole('treeitem', { name: 'Test Condition Set' }).click();
@@ -310,29 +305,23 @@ test.describe('Basic Condition Set Use', () => {
     await page.getByLabel('Criterion Telemetry Selection').selectOption({ label: 'P1' });
     await page.getByLabel('Criterion Metadata Selection').selectOption('value');
     await page.getByLabel('Criterion Comparison Selection').selectOption('equalTo');
-    //await page.getByLabel('Criterion Input').click();
     await page.getByLabel('Criterion Input').fill('1');
     await page.getByLabel('Add Criteria - Enabled').click();
     await page.getByLabel('Criterion Telemetry Selection').nth(1).selectOption({ label: 'P2' });
     await page.getByLabel('Criterion Metadata Selection').nth(1).selectOption('value');
     await page.getByLabel('Criterion Comparison Selection').nth(1).selectOption('equalTo');
-    //await page.getByLabel('Criterion Input').nth(1).click();
     await page.getByLabel('Criterion Input').nth(1).fill('1');
-    //await page.getByLabel('Condition Name Input').first().dblclick();
     await page.getByLabel('Add Condition').click();
-    //await page.getByText('Condition Name Output').first().click();
     await page.getByLabel('Condition Name Input').first().fill('P1 IS OFF OR P2 IS OFF');
     await page.getByLabel('Condition Trigger').first().selectOption('any');
     await page.getByLabel('Criterion Telemetry Selection').first().selectOption({ label: 'P1' });
     await page.getByLabel('Criterion Metadata Selection').first().selectOption('value');
     await page.getByLabel('Criterion Comparison Selection').first().selectOption('equalTo');
-    //await page.getByLabel('Criterion Input').first().click();
     await page.getByLabel('Criterion Input').first().fill('0');
     await page.getByLabel('Add Criteria - Enabled').first().click();
     await page.getByLabel('Criterion Telemetry Selection').nth(1).selectOption({ label: 'P2' });
     await page.getByLabel('Criterion Metadata Selection').nth(1).selectOption('value');
     await page.getByLabel('Criterion Comparison Selection').nth(1).selectOption('equalTo');
-    //await page.getByLabel('Criterion Input').nth(1).click();
     await page.getByLabel('Criterion Input').nth(1).fill('0');
     await page.getByLabel('Condition Name Input').first().dblclick();
     await page.getByLabel('Save').click();

--- a/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
@@ -116,7 +116,7 @@ test.describe('Basic Condition Set Use', () => {
     await page.getByLabel('Conditions View').click();
     await expect(page.getByText('Current Output')).toBeVisible();
   });
-  test('ConditionSet has correct outputs when telemetry is and is not available', async ({
+  test('ConditionSet has produces an output when telemetry is available, and does not when it is not', async ({
     page
   }) => {
     const exampleTelemetry = await createExampleTelemetryObject(page);

--- a/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
@@ -282,7 +282,9 @@ test.describe('Basic Condition Set Use', () => {
     await page.goto(exampleTelemetry.url);
   });
 
-  test('Short circuit evaluation does not cause incorrect evaluation https://github.com/nasa/openmct/issues/7992', async ({ page }) => {
+  test('Short circuit evaluation does not cause incorrect evaluation https://github.com/nasa/openmct/issues/7992', async ({
+    page
+  }) => {
     await setRealTimeMode(page);
     await page.getByLabel('Create', { exact: true }).click();
     await page.getByLabel('State Generator').click();

--- a/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
@@ -27,7 +27,8 @@ demonstrate some playwright for test developers. This pattern should not be re-u
 
 import {
   createDomainObjectWithDefaults,
-  createExampleTelemetryObject
+  createExampleTelemetryObject,
+  setRealTimeMode
 } from '../../../../appActions.js';
 import { expect, test } from '../../../../pluginFixtures.js';
 
@@ -279,6 +280,110 @@ test.describe('Basic Condition Set Use', () => {
     await expect(outputValue).toHaveText('false');
 
     await page.goto(exampleTelemetry.url);
+  });
+
+  test('Short circuit evaluation does not cause incorrect evaluation https://github.com/nasa/openmct/issues/7992', async ({ page }) => {
+    await setRealTimeMode(page);
+    await page.getByLabel('Create', { exact: true }).click();
+    await page.getByLabel('State Generator').click();
+    //await page.getByLabel('Title', { exact: true }).click();
+    await page.getByLabel('Title', { exact: true }).fill('P1');
+    //await page.getByLabel('State Duration (seconds)').click();
+    await page.getByLabel('State Duration (seconds)').fill('1');
+    await page.getByLabel('Save').click();
+    await page.getByLabel('Create', { exact: true }).click();
+    await page.getByLabel('State Generator').click();
+    //await page.getByLabel('Title', { exact: true }).click();
+    await page.getByLabel('Title', { exact: true }).fill('P2');
+    //await page.getByLabel('State Duration (seconds)', { exact: true }).click();
+    await page.getByLabel('State Duration (seconds)', { exact: true }).fill('1');
+    await page.getByRole('treeitem', { name: 'Test Condition Set' }).click();
+    //await page.getByLabel('Modal Overlay').getByLabel('Navigate to Unnamed Condition').click();
+    await page.getByLabel('Save').click();
+    await page.getByLabel('Expand My Items folder').click();
+    await page.getByRole('treeitem', { name: 'Test Condition Set' }).click();
+    await page.getByLabel('Edit Object').click();
+    await page.getByLabel('Add Condition').click();
+    await page.getByLabel('Condition Name Input').first().fill('P1 IS ON AND P2 IS ON');
+    await page.getByLabel('Criterion Telemetry Selection').selectOption({ label: 'P1' });
+    await page.getByLabel('Criterion Metadata Selection').selectOption('value');
+    await page.getByLabel('Criterion Comparison Selection').selectOption('equalTo');
+    //await page.getByLabel('Criterion Input').click();
+    await page.getByLabel('Criterion Input').fill('1');
+    await page.getByLabel('Add Criteria - Enabled').click();
+    await page.getByLabel('Criterion Telemetry Selection').nth(1).selectOption({ label: 'P2' });
+    await page.getByLabel('Criterion Metadata Selection').nth(1).selectOption('value');
+    await page.getByLabel('Criterion Comparison Selection').nth(1).selectOption('equalTo');
+    //await page.getByLabel('Criterion Input').nth(1).click();
+    await page.getByLabel('Criterion Input').nth(1).fill('1');
+    //await page.getByLabel('Condition Name Input').first().dblclick();
+    await page.getByLabel('Add Condition').click();
+    //await page.getByText('Condition Name Output').first().click();
+    await page.getByLabel('Condition Name Input').first().fill('P1 IS OFF OR P2 IS OFF');
+    await page.getByLabel('Condition Trigger').first().selectOption('any');
+    await page.getByLabel('Criterion Telemetry Selection').first().selectOption({ label: 'P1' });
+    await page.getByLabel('Criterion Metadata Selection').first().selectOption('value');
+    await page.getByLabel('Criterion Comparison Selection').first().selectOption('equalTo');
+    //await page.getByLabel('Criterion Input').first().click();
+    await page.getByLabel('Criterion Input').first().fill('0');
+    await page.getByLabel('Add Criteria - Enabled').first().click();
+    await page.getByLabel('Criterion Telemetry Selection').nth(1).selectOption({ label: 'P2' });
+    await page.getByLabel('Criterion Metadata Selection').nth(1).selectOption('value');
+    await page.getByLabel('Criterion Comparison Selection').nth(1).selectOption('equalTo');
+    //await page.getByLabel('Criterion Input').nth(1).click();
+    await page.getByLabel('Criterion Input').nth(1).fill('0');
+    await page.getByLabel('Condition Name Input').first().dblclick();
+    await page.getByLabel('Save').click();
+    await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
+    await page.getByLabel('Edit Object').click();
+
+    /**
+     * Create default conditions for test. Start with invalid values to put condition set into
+     * "default" state
+     */
+    await page.getByLabel('Test Data Telemetry Selection').selectOption({ label: 'P1' });
+    await page.getByLabel('Test Data Metadata Selection').selectOption({ label: 'Value' });
+    await page.getByLabel('Test Data Input').fill('3');
+    await page.getByLabel('Add Test Datum').click();
+    await page.getByLabel('Test Data Telemetry Selection').nth(1).selectOption({ label: 'P2' });
+    await page.getByLabel('Test Data Metadata Selection').nth(1).selectOption({ label: 'Value' });
+    await page.getByLabel('Test Data Input').nth(1).fill('3');
+    await page.getByLabel('Apply Test Data').nth(1).click();
+
+    let activeCondition = page.getByLabel('Active Condition Set Condition');
+    let activeConditionName = activeCondition.getByLabel('Condition Name Label');
+
+    await expect(activeConditionName).toHaveText('Default');
+
+    /**
+     * Set P1 to 0
+     */
+    await page.getByLabel('Test Data Input').nth(0).fill('0');
+
+    activeCondition = page.getByLabel('Active Condition Set Condition');
+    activeConditionName = activeCondition.getByLabel('Condition Name Label');
+
+    await expect(activeConditionName).toHaveText('P1 IS OFF OR P2 IS OFF');
+
+    /**
+     * Set P2 to 1
+     */
+    await page.getByLabel('Test Data Input').nth(1).fill('1');
+
+    activeCondition = page.getByLabel('Active Condition Set Condition');
+    activeConditionName = activeCondition.getByLabel('Condition Name Label');
+
+    await expect(activeConditionName).toHaveText('P1 IS OFF OR P2 IS OFF');
+
+    /**
+     * Set P1 to 1
+     */
+    await page.getByLabel('Test Data Input').nth(0).fill('1');
+
+    activeCondition = page.getByLabel('Active Condition Set Condition');
+    activeConditionName = activeCondition.getByLabel('Condition Name Label');
+
+    await expect(activeConditionName).toHaveText('P1 IS ON AND P2 IS ON');
   });
 
   test.fixme('Ensure condition sets work with telemetry like operator status', ({ page }) => {

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -87,14 +87,16 @@ export default class Condition extends EventEmitter {
 
     // if all the criteria in this condition have no telemetry, we want to force the condition result to evaluate
     if (this.hasNoTelemetry() || this.isTelemetryUsed(telemetryIdThatChanged)) {
+      const currentTimeSystemKey = this.openmct.time.getTimeSystem().key;
+
       this.criteria.forEach((criterion) => {
         if (this.isAnyOrAllTelemetry(criterion)) {
           criterion.updateResult(latestDataTable, this.conditionManager.telemetryObjects);
         } else {
           const relevantDatum = latestDataTable.get(criterion.telemetryObjectIdAsString);
 
-          if (relevantDatum !== undefined) {
-            criterion.updateResult(relevantDatum);
+          if (criterion.shouldUpdateResult(relevantDatum, currentTimeSystemKey)) {
+            criterion.updateResult(relevantDatum, currentTimeSystemKey);
           }
         }
       });

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -103,7 +103,6 @@ export default class Condition extends EventEmitter {
         this.criteria.map((criterion) => criterion.result),
         this.trigger
       );
-
     }
   }
 

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -195,7 +195,7 @@ export default class Condition extends EventEmitter {
   findCriterion(id) {
     let criterion;
 
-    for (let i = 0, ii = this.criteria.length; i < ii; i++) {
+    for (let i = 0; i < this.criteria.length; i++) {
       if (this.criteria[i].id === id) {
         criterion = {
           item: this.criteria[i],

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -71,21 +71,24 @@ export default class Condition extends EventEmitter {
     this.handleTelemetryStaleness = this.handleTelemetryStaleness.bind(this);
   }
 
-  updateResult(datum) {
-    if (!datum || !datum.id) {
+  updateResult(latestDataTable) {
+    if (!latestDataTable) {
       console.log('no data received');
-
       return;
     }
 
+    const hasNoTelemetry = this.hasNoTelemetry();
+
     // if all the criteria in this condition have no telemetry, we want to force the condition result to evaluate
-    if (this.hasNoTelemetry() || this.isTelemetryUsed(datum.id)) {
+    //if (this.hasNoTelemetry() || this.isTelemetryUsed(latestDataTable.id)) {
       this.criteria.forEach((criterion) => {
         if (this.isAnyOrAllTelemetry(criterion)) {
-          criterion.updateResult(datum, this.conditionManager.telemetryObjects);
+          criterion.updateResult(latestDataTable, this.conditionManager.telemetryObjects);
         } else {
-          if (criterion.usesTelemetry(datum.id)) {
-            criterion.updateResult(datum);
+          const relevantDatum = latestDataTable.get(criterion.telemetryObjectIdAsString);
+
+          if (relevantDatum !== undefined){
+            criterion.updateResult(relevantDatum);
           }
         }
       });
@@ -94,7 +97,7 @@ export default class Condition extends EventEmitter {
         this.criteria.map((criterion) => criterion.result),
         this.trigger
       );
-    }
+    //}
   }
 
   isAnyOrAllTelemetry(criterion) {

--- a/src/plugins/condition/Condition.js
+++ b/src/plugins/condition/Condition.js
@@ -88,13 +88,11 @@ export default class Condition extends EventEmitter {
     // if all the criteria in this condition have no telemetry, we want to force the condition result to evaluate
     if (this.hasNoTelemetry() || this.isTelemetryUsed(telemetryIdThatChanged)) {
       const currentTimeSystemKey = this.openmct.time.getTimeSystem().key;
-
       this.criteria.forEach((criterion) => {
         if (this.isAnyOrAllTelemetry(criterion)) {
           criterion.updateResult(latestDataTable, this.conditionManager.telemetryObjects);
         } else {
           const relevantDatum = latestDataTable.get(criterion.telemetryObjectIdAsString);
-
           if (criterion.shouldUpdateResult(relevantDatum, currentTimeSystemKey)) {
             criterion.updateResult(relevantDatum, currentTimeSystemKey);
           }
@@ -105,6 +103,7 @@ export default class Condition extends EventEmitter {
         this.criteria.map((criterion) => criterion.result),
         this.trigger
       );
+
     }
   }
 
@@ -260,7 +259,7 @@ export default class Condition extends EventEmitter {
       this.timeSystems,
       this.openmct.time.getTimeSystem()
     );
-    this.conditionManager.updateCurrentCondition(latestTimestamp);
+    this.conditionManager.updateCurrentCondition(latestTimestamp, this);
   }
 
   handleTelemetryStaleness() {

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -474,7 +474,7 @@ export default class ConditionManager extends EventEmitter {
 
   updateTestData(testData) {
     if (!_.isEqual(testData, this.testData)) {
-      this.testData = testData;
+      this.testData = JSON.parse(JSON.stringify(testData));
       this.openmct.objects.mutate(
         this.conditionSetDomainObject,
         'configuration.conditionTestData',

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -421,10 +421,8 @@ export default class ConditionManager extends EventEmitter {
 
   updateConditionResults(normalizedDatum) {
     //We want to stop when the first condition evaluates to true.
-    this.conditions.some((condition) => {
+    this.conditions.forEach((condition) => {
       condition.updateResult(normalizedDatum);
-
-      return condition.result === true;
     });
   }
 

--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -421,8 +421,10 @@ export default class ConditionManager extends EventEmitter {
 
   updateConditionResults(normalizedDatum) {
     //We want to stop when the first condition evaluates to true.
-    this.conditions.forEach((condition) => {
+    this.conditions.some((condition) => {
       condition.updateResult(normalizedDatum);
+
+      return condition.result === true;
     });
   }
 

--- a/src/plugins/condition/ConditionSpec.js
+++ b/src/plugins/condition/ConditionSpec.js
@@ -97,9 +97,15 @@ describe('The condition', function () {
     mockTimeSystems = {
       key: 'utc'
     };
-    openmct.time = jasmine.createSpyObj('time', ['getAllTimeSystems', 'on', 'off']);
+    openmct.time = jasmine.createSpyObj('time', [
+      'getTimeSystem',
+      'getAllTimeSystems',
+      'on',
+      'off'
+    ]);
+    openmct.time.getTimeSystem.and.returnValue({ key: 'utc' });
     openmct.time.getAllTimeSystems.and.returnValue([mockTimeSystems]);
-    openmct.time.getTimeSystem.and.returnValue();
+    //openmct.time.getTimeSystem.and.returnValue();
     openmct.time.on.and.returnValue(() => {});
     openmct.time.off.and.returnValue(() => {});
 
@@ -158,18 +164,23 @@ describe('The condition', function () {
   });
 
   it('keeps the old result new telemetry data is not used by it', function () {
-    conditionObj.updateResult({
+    const latestDataTable = new Map();
+    latestDataTable.set(testTelemetryObject.identifier.key, {
       value: '0',
       utc: 'Hi',
       id: testTelemetryObject.identifier.key
     });
+    conditionObj.updateResult(latestDataTable, testTelemetryObject.identifier.key);
+
     expect(conditionObj.result).toBeTrue();
 
-    conditionObj.updateResult({
+    latestDataTable.set(testTelemetryObject.identifier.key, {
       value: '1',
       utc: 'Hi',
       id: '1234'
     });
+
+    conditionObj.updateResult(latestDataTable, testTelemetryObject.identifier.key);
     expect(conditionObj.result).toBeTrue();
   });
 });

--- a/src/plugins/condition/ConditionSpec.js
+++ b/src/plugins/condition/ConditionSpec.js
@@ -53,6 +53,7 @@ describe('The condition', function () {
         valueMetadatas: [
           {
             key: 'some-key',
+            source: 'some-key',
             name: 'Some attribute',
             hints: {
               range: 2
@@ -60,6 +61,7 @@ describe('The condition', function () {
           },
           {
             key: 'utc',
+            source: 'utc',
             name: 'Time',
             format: 'utc',
             hints: {
@@ -88,11 +90,19 @@ describe('The condition', function () {
     openmct.telemetry = jasmine.createSpyObj('telemetry', [
       'isTelemetryObject',
       'subscribe',
-      'getMetadata'
+      'getMetadata',
+      'getValueFormatter'
     ]);
     openmct.telemetry.isTelemetryObject.and.returnValue(true);
     openmct.telemetry.subscribe.and.returnValue(function () {});
     openmct.telemetry.getMetadata.and.returnValue(testTelemetryObject.telemetry);
+    openmct.telemetry.getValueFormatter.and.callFake((metadatum) => {
+      return {
+        parse(input) {
+          return input;
+        }
+      };
+    });
 
     mockTimeSystems = {
       key: 'utc'
@@ -120,7 +130,7 @@ describe('The condition', function () {
             id: '1234-5678-9999-0000',
             operation: 'equalTo',
             input: ['0'],
-            metadata: 'value',
+            metadata: 'testSource',
             telemetry: testTelemetryObject.identifier
           }
         ]
@@ -174,13 +184,13 @@ describe('The condition', function () {
 
     expect(conditionObj.result).toBeTrue();
 
-    latestDataTable.set(testTelemetryObject.identifier.key, {
+    latestDataTable.set('1234', {
       value: '1',
       utc: 'Hi',
       id: '1234'
     });
 
-    conditionObj.updateResult(latestDataTable, testTelemetryObject.identifier.key);
+    conditionObj.updateResult(latestDataTable, '1234');
     expect(conditionObj.result).toBeTrue();
   });
 });

--- a/src/plugins/condition/ConditionSpec.js
+++ b/src/plugins/condition/ConditionSpec.js
@@ -99,6 +99,7 @@ describe('The condition', function () {
     };
     openmct.time = jasmine.createSpyObj('time', ['getAllTimeSystems', 'on', 'off']);
     openmct.time.getAllTimeSystems.and.returnValue([mockTimeSystems]);
+    openmct.time.getTimeSystem.and.returnValue();
     openmct.time.on.and.returnValue(() => {});
     openmct.time.off.and.returnValue(() => {});
 
@@ -156,12 +157,14 @@ describe('The condition', function () {
     expect(conditionObj.criteria.length).toEqual(0);
   });
 
-  it('gets the result of a condition when new telemetry data is received', function () {
-    conditionObj.updateResult({
+  fit('gets the result of a condition when new telemetry data is received', function () {
+    const latestDataTable = new Map();
+    latestDataTable.set(testTelemetryObject.identifier.key, {
       value: '0',
       utc: 'Hi',
       id: testTelemetryObject.identifier.key
     });
+    conditionObj.updateResult(latestDataTable, testTelemetryObject.identifier.key);
     expect(conditionObj.result).toBeTrue();
   });
 

--- a/src/plugins/condition/ConditionSpec.js
+++ b/src/plugins/condition/ConditionSpec.js
@@ -157,26 +157,6 @@ describe('The condition', function () {
     expect(conditionObj.criteria.length).toEqual(0);
   });
 
-  fit('gets the result of a condition when new telemetry data is received', function () {
-    const latestDataTable = new Map();
-    latestDataTable.set(testTelemetryObject.identifier.key, {
-      value: '0',
-      utc: 'Hi',
-      id: testTelemetryObject.identifier.key
-    });
-    conditionObj.updateResult(latestDataTable, testTelemetryObject.identifier.key);
-    expect(conditionObj.result).toBeTrue();
-  });
-
-  it('gets the result of a condition when new telemetry data is received', function () {
-    conditionObj.updateResult({
-      value: '1',
-      utc: 'Hi',
-      id: testTelemetryObject.identifier.key
-    });
-    expect(conditionObj.result).toBeFalse();
-  });
-
   it('keeps the old result new telemetry data is not used by it', function () {
     conditionObj.updateResult({
       value: '0',

--- a/src/plugins/condition/components/ConditionItem.vue
+++ b/src/plugins/condition/components/ConditionItem.vue
@@ -24,7 +24,7 @@
   <div
     class="c-condition-h"
     :class="{ 'is-drag-target': draggingOver }"
-    aria-label="Condition Set Condition"
+    :aria-label="conditionSetLabel"
     @dragover.prevent
     @drop.prevent="dropCondition($event, conditionIndex)"
     @dragenter="dragEnter($event, conditionIndex)"
@@ -53,7 +53,9 @@
           @click="expanded = !expanded"
         ></span>
 
-        <span class="c-condition__name">{{ condition.configuration.name }}</span>
+        <span class="c-condition__name" aria-label="Condition Name Label">{{
+          condition.configuration.name
+        }}</span>
         <span class="c-condition__summary">
           <template v-if="!condition.isDefault && !canEvaluateCriteria"> Define criteria </template>
           <span v-else>
@@ -259,6 +261,17 @@ export default {
     };
   },
   computed: {
+    conditionSetLabel() {
+      let label;
+
+      if (this.condition.id === this.currentConditionId) {
+        label = 'Active Condition Set Condition';
+      } else {
+        label = 'Condition Set Condition';
+      }
+
+      return label;
+    },
     triggers() {
       const keys = Object.keys(TRIGGER);
       const triggerOptions = [];

--- a/src/plugins/condition/components/TestData.vue
+++ b/src/plugins/condition/components/TestData.vue
@@ -114,7 +114,7 @@
         class="c-button c-button--major icon-plus labeled"
         @click="addTestInput"
       >
-        <span class="c-cs-button__label">Add Test Datum</span>
+        <span class="c-cs-button__label" aria-label="Add Test Datum">Add Test Datum</span>
       </button>
     </div>
   </section>

--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -181,13 +181,19 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
 
     if (validatedData && !this.isStalenessCheck()) {
       if (this.isOldCheck()) {
-        if (this.ageCheck?.[validatedData.id]) {
-          this.ageCheck[validatedData.id].update(validatedData);
-        }
+        Object.keys(this.telemetryDataCache).forEach((objectIdKeystring) => {
+          if (this.ageCheck?.[objectIdKeystring]) {
+            this.ageCheck[objectIdKeystring].update(validatedData[objectIdKeystring]);
+          }
 
-        this.telemetryDataCache[validatedData.id] = false;
+          this.telemetryDataCache[objectIdKeystring] = false;
+        });
       } else {
-        this.telemetryDataCache[validatedData.id] = this.computeResult(validatedData);
+        Object.keys(this.telemetryDataCache).forEach((objectIdKeystring) => {
+          this.telemetryDataCache[objectIdKeystring] = this.computeResult(
+            validatedData[objectIdKeystring]
+          );
+        });
       }
     }
 

--- a/src/plugins/condition/criterion/AllTelemetryCriterion.js
+++ b/src/plugins/condition/criterion/AllTelemetryCriterion.js
@@ -190,8 +190,9 @@ export default class AllTelemetryCriterion extends TelemetryCriterion {
         });
       } else {
         Object.keys(this.telemetryDataCache).forEach((objectIdKeystring) => {
+          const telemetryObject = telemetryObjects[objectIdKeystring];
           this.telemetryDataCache[objectIdKeystring] = this.computeResult(
-            validatedData[objectIdKeystring]
+            this.createNormalizedDatum(validatedData[objectIdKeystring], telemetryObject)
           );
         });
       }

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -272,8 +272,8 @@ export default class TelemetryCriterion extends EventEmitter {
         this.input.forEach((input) => params.push(input));
       }
 
-      if (typeof this.comparator === 'function') {
-        result = Boolean(this.comparator(params));
+      if (typeof this.#comparator === 'function') {
+        result = Boolean(this.#comparator(params));
       }
     }
 

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -254,7 +254,7 @@ export default class TelemetryCriterion extends EventEmitter {
   }
 
   #findOperation(operation) {
-    for (let i = 0, ii = OPERATIONS.length; i < ii; i++) {
+    for (let i = 0; i < OPERATIONS.length; i++) {
       if (operation === OPERATIONS[i].name) {
         return OPERATIONS[i].operation;
       }

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -91,7 +91,6 @@ export default class TelemetryCriterion extends EventEmitter {
     if (this.ageCheck) {
       this.ageCheck.clear();
     }
-
     this.ageCheck = checkIfOld(this.handleOldTelemetry.bind(this), this.input[0] * 1000);
   }
 
@@ -161,7 +160,6 @@ export default class TelemetryCriterion extends EventEmitter {
   createNormalizedDatum(telemetryDatum, endpoint) {
     const id = this.openmct.objects.makeKeyString(endpoint.identifier);
     const metadata = this.openmct.telemetry.getMetadata(endpoint).valueMetadatas;
-
     const normalizedDatum = Object.values(metadata).reduce((datum, metadatum) => {
       const formatter = this.openmct.telemetry.getValueFormatter(metadatum);
       datum[metadatum.key] = formatter.parse(telemetryDatum[metadatum.source]);

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -196,7 +196,9 @@ export default class TelemetryCriterion extends EventEmitter {
     return dataIsDefined && (hasTimeSystemChanged || isCacheStale);
   }
   updateResult(data, currentTimeSystemKey) {
-    const validatedData = this.isValid() ? data : {};
+    const validatedData = this.isValid()
+      ? this.createNormalizedDatum(data, this.telemetryObject)
+      : {};
 
     if (!this.isStalenessCheck()) {
       if (this.isOldCheck()) {

--- a/src/plugins/condition/criterion/TelemetryCriterion.js
+++ b/src/plugins/condition/criterion/TelemetryCriterion.js
@@ -31,6 +31,7 @@ import { checkIfOld } from '../utils/time.js';
 export default class TelemetryCriterion extends EventEmitter {
   #lastUpdated;
   #lastTimeSystem;
+  #comparator;
 
   /**
    * Subscribes/Unsubscribes to telemetry and emits the result
@@ -50,6 +51,7 @@ export default class TelemetryCriterion extends EventEmitter {
     this.id = telemetryDomainObjectDefinition.id;
     this.telemetry = telemetryDomainObjectDefinition.telemetry;
     this.operation = telemetryDomainObjectDefinition.operation;
+    this.#comparator = this.#findOperation(this.operation);
     this.input = telemetryDomainObjectDefinition.input;
     this.metadata = telemetryDomainObjectDefinition.metadata;
     this.result = undefined;
@@ -251,7 +253,7 @@ export default class TelemetryCriterion extends EventEmitter {
       });
   }
 
-  findOperation(operation) {
+  #findOperation(operation) {
     for (let i = 0, ii = OPERATIONS.length; i < ii; i++) {
       if (operation === OPERATIONS[i].name) {
         return OPERATIONS[i].operation;
@@ -264,15 +266,14 @@ export default class TelemetryCriterion extends EventEmitter {
   computeResult(data) {
     let result = false;
     if (data) {
-      let comparator = this.findOperation(this.operation);
       let params = [];
       params.push(data[this.metadata]);
       if (this.isValidInput()) {
         this.input.forEach((input) => params.push(input));
       }
 
-      if (typeof comparator === 'function') {
-        result = Boolean(comparator(params));
+      if (typeof this.comparator === 'function') {
+        result = Boolean(this.comparator(params));
       }
     }
 

--- a/src/plugins/condition/criterion/TelemetryCriterionSpec.js
+++ b/src/plugins/condition/criterion/TelemetryCriterionSpec.js
@@ -106,7 +106,7 @@ describe('The telemetry criterion', function () {
       id: 'test-criterion-id',
       telemetry: openmct.objects.makeKeyString(testTelemetryObject.identifier),
       operation: 'textContains',
-      metadata: 'value',
+      metadata: 'testSource',
       input: ['Hell'],
       telemetryObjects: { [testTelemetryObject.identifier.key]: testTelemetryObject }
     };


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
* Fixes https://github.com/nasa/openmct/issues/7992
* Fixes https://github.com/nasa/openmct/issues/8060

Fixes a bug in Condition Sets that sometimes caused incorrect output. There are two things that are important to know about condition sets in order to understand what's going wrong here:
1. Condition sets use short-circuit evaluation as a performance optimization, meaning that if a condition evaluates to true, subsequent conditions in the condition set will not be evaluated.
5. Criteria are only evaluated when a new telemetry value is received. Their evaluation result is cached, and the cached value used for evaluation of the condition set to which they belong. This is another performance optimization, if the telemetry value didn't change, then don't bother re-evaluating any criteria based on that telemetry object.

If you combine these together, criteria can "miss" telemetry updates because of short-circuit evaluation, and then use a stale cached value for subsequent evaluation.

### Describe your changes:

* Renames variable to avoid `condition.condition`
* Modifies condition evaluation logic [to provide a table of latest telemetry values](https://github.com/nasa/openmct/pull/8041/files#diff-2d003d796f4ffa7dc7edb76a078db1f2d8534a29ad3bce035591ef5ec73f9559R82) instead of relying upon a cached evaluation result that might be stale
* Optimization to avoid flat search of all conditions every time a value is received https://github.com/nasa/openmct/pull/8041/files#diff-486148e15c06c3403c47d65083107e8eeacf6591150e38f5690aaa6dc24c51b1L307
* Providing latest telemetry value table allows us to [retain short-circuit evaluation](https://github.com/nasa/openmct/pull/8041/files#diff-486148e15c06c3403c47d65083107e8eeacf6591150e38f5690aaa6dc24c51b1R417)
* [Fixes a bug that was preventing test data change detection from working](https://github.com/nasa/openmct/pull/8041/files#diff-486148e15c06c3403c47d65083107e8eeacf6591150e38f5690aaa6dc24c51b1R483). Test data had become reactified so the code never detected a change.

### TO DO
* [ ] Replace unit test with e2e

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
