### PR TITLE
Cherry pick 8065 - Condition sets failing to evaluate telemetry where source and key do not match in metadata

### DIFF
--- a/src/plugins/condition/ConditionManager.js
+++ b/src/plugins/condition/ConditionManager.js
@@ -465,7 +465,7 @@ export default class ConditionManager extends EventEmitter {
     const normalizedDatum = Object.values(metadata).reduce((datum, metadatum) => {
       const testValue = this.getTestData(metadatum, endpoint.identifier);
       const formatter = this.openmct.telemetry.getValueFormatter(metadatum);
-      datum[metadatum.source || metadatum.key] =
+      datum[metadatum.key] =
         testValue !== undefined
           ? formatter.parse(testValue)
           : formatter.parse(telemetryDatum[metadatum.source]);


### PR DESCRIPTION
PR: https://github.com/nasa/openmct/pull/8065
Issue: https://github.com/nasa/openmct/issues/7992