### PR TITLE
fix: allow user selection on status bar datetime

### DIFF
--- a/src/ui/layout/status-bar/indicators.scss
+++ b/src/ui/layout/status-bar/indicators.scss
@@ -132,3 +132,11 @@ body.phone.portrait {
     display: none;
   }
 }
+
+/* Allow text selection for clock indicator */
+.c-indicator.t-indicator-clock {
+  user-select: text;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+}


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7764 

### Describe your changes:
This adds back the selection on the status bar datetime, allowing users to copy and paste this information. 
This seems to already have been patched in the Time Conductor maybe by @davetsay as mentioned in the issue

<img width="424" alt="Capture d’écran, le 2025-06-25 à 00 52 10" src="https://github.com/user-attachments/assets/1a821d2f-94d7-48ed-9837-126242e5b37d" />


### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [X] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
