### PR TITLE
Add logger util and startup info

### DIFF
--- a/openmct.js
+++ b/openmct.js
@@ -31,8 +31,12 @@ if (document.currentScript) {
 }
 
 import { MCT } from './src/MCT.js';
+import { info } from './src/utils/logger.js';
 
 const openmct = new MCT();
+
+// Startup log
+info('Open MCT starting');
 
 export default openmct;
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,12 +1,12 @@
-const LOG_LEVEL = (typeof process !== 'undefined' && process.env && process.env.OPENMCT_LOG) ||
-    (typeof window !== 'undefined' && window.__OPENMCT_DEBUG__) || '';
+const LOG_LEVEL = (typeof process !== 'undefined' && process.env && process.env.OPENMCT_LOG)
+    || (typeof window !== 'undefined' && !!window.__OPENMCT_DEBUG__ && 'debug')
+    || '';
 
 export function info(...args) {
     console.info('[openmct]', ...args);
 }
-
 export function debug(...args) {
-    if (LOG_LEVEL === 'debug') {
+    if (LOG_LEVEL === 'debug' || LOG_LEVEL === true) {
         console.debug('[openmct][debug]', ...args);
     }
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,20 @@
+const LOG_LEVEL = (typeof process !== 'undefined' && process.env && process.env.OPENMCT_LOG) ||
+    (typeof window !== 'undefined' && window.__OPENMCT_DEBUG__) || '';
+
+export function info(...args) {
+    console.info('[openmct]', ...args);
+}
+
+export function debug(...args) {
+    if (LOG_LEVEL === 'debug') {
+        console.debug('[openmct][debug]', ...args);
+    }
+}
+
+export function warn(...args) {
+    console.warn('[openmct][warn]', ...args);
+}
+
+export function error(...args) {
+    console.error('[openmct][error]', ...args);
+}


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Adds a simple, opt-in logger utility and a single startup info log. This is a non-functional, developer-facing change that standardizes log output and enables optional debug logging via environment or browser flag.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
