### PR TITLE
[Forms] Fix label for attribute associations (#7981)

### DIFF
--- a/src/api/forms/components/controls/AutoCompleteField.vue
+++ b/src/api/forms/components/controls/AutoCompleteField.vue
@@ -23,6 +23,7 @@
   <div ref="autoCompleteForm" class="form-control c-input--autocomplete js-autocomplete">
     <div class="c-input--autocomplete__wrapper">
       <input
+        :id="`form-${model.key}`"
         ref="autoCompleteInput"
         v-model="field"
         class="c-input--autocomplete__input js-autocomplete__input"

--- a/src/api/forms/components/controls/CheckBoxField.vue
+++ b/src/api/forms/components/controls/CheckBoxField.vue
@@ -23,7 +23,7 @@
 <template>
   <span class="form-control shell">
     <span class="field control" :class="model.cssClass">
-      <input type="checkbox" :checked="isChecked" @input="toggleCheckBox" />
+      <input :id="`form-${model.key}`" type="checkbox" :checked="isChecked" @input="toggleCheckBox" />
     </span>
   </span>
 </template>

--- a/src/api/forms/components/controls/NumberField.vue
+++ b/src/api/forms/components/controls/NumberField.vue
@@ -24,6 +24,7 @@
   <span class="form-control shell">
     <span class="field control" :class="model.cssClass">
       <input
+        :id="`form-${model.key}`"
         v-model="field"
         :aria-label="model.name"
         type="number"

--- a/src/api/forms/components/controls/SelectField.vue
+++ b/src/api/forms/components/controls/SelectField.vue
@@ -23,6 +23,7 @@
 <template>
   <div class="form-control select-field">
     <select
+      :id="`form-${model.key}`"
       v-model="selected"
       required="model.required"
       name="mctControl"

--- a/src/api/forms/components/controls/TextAreaField.vue
+++ b/src/api/forms/components/controls/TextAreaField.vue
@@ -24,7 +24,7 @@
   <span class="form-control shell">
     <span class="field control" :class="model.cssClass">
       <textarea
-        :id="`${model.key}-textarea`"
+        :id="`form-${model.key}`"
         v-model="field"
         type="text"
         :size="model.size"

--- a/src/api/forms/components/controls/ToggleSwitchField.vue
+++ b/src/api/forms/components/controls/ToggleSwitchField.vue
@@ -24,7 +24,7 @@
   <span class="form-control shell">
     <span class="field control" :class="model.cssClass">
       <ToggleSwitch
-        id="switchId"
+        :id="`form-${model.key}`"
         :checked="isChecked"
         :name="model.name"
         @change="toggleCheckBox"
@@ -34,8 +34,6 @@
 </template>
 
 <script>
-import { v4 as uuid } from 'uuid';
-
 import ToggleSwitch from '@/ui/components/ToggleSwitch.vue';
 
 import toggleMixin from '../../toggle-check-box-mixin.js';
@@ -53,7 +51,6 @@ export default {
   },
   data() {
     return {
-      switchId: `toggleSwitch-${uuid}`,
       isChecked: this.model.value
     };
   }


### PR DESCRIPTION
Closes #7981

### Describe your changes:
Form labels have a `for` attribute pointing to `form-${row.key}`, but most form controls were missing the matching `id` attribute. This meant clicking a label didn't focus its input (accessibility break).

Added/fixed `id` attributes on: TextAreaField, SelectField, NumberField, AutoCompleteField, CheckBoxField, and ToggleSwitchField. Also removed unused `uuid` import from ToggleSwitchField.

**To test:**
1. Click "+ Create" and select "Clock"
2. Click the "Notes" label
3. Textarea should now receive focus

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?