### PR TITLE
fix: mitigate potential prototype pollution in DisplayLayoutToolbar

### DIFF
--- a/src/plugins/displayLayout/DisplayLayoutToolbar.js
+++ b/src/plugins/displayLayout/DisplayLayoutToolbar.js
@@ -528,7 +528,12 @@ export default class DisplayLayoutToolbar {
     let property = Object.assign({}, object);
 
     while (splitPath.length && property) {
-      property = property[splitPath.shift()];
+      const key = splitPath.shift();
+      // Prevent prototype pollution by blocking access to sensitive properties
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return undefined;
+      }
+      property = property[key];
     }
 
     return property;


### PR DESCRIPTION
### Description
This PR addresses a potential prototype pollution vulnerability in the `DisplayLayoutToolbar` plugin. The `#getPropertyFromPath` method was traversing object paths without validating keys, which could allow sensitive properties like `__proto__` or `constructor` to be accessed or modified.

### Changes
- Added a validation check in `#getPropertyFromPath` to block access to `__proto__`, `constructor`, and `prototype` keys during traversal.
- Ensures the function safely returns `undefined` when a restricted key is encountered.

### Impact
Prevents potential logic corruption or Denial of Service (DoS) attacks through crafted layout configurations.