### PR TITLE
Fix memory leak in IndependentTimeContext by cleaning up global listeners

### DIFF
--- a/src/api/time/IndependentTimeContext.js
+++ b/src/api/time/IndependentTimeContext.js
@@ -538,6 +538,37 @@ class IndependentTimeContext extends TimeContext {
     }
   }
 
+  /**
+   * Clean up this time context by removing all event listeners and clearing references.
+   * This method is idempotent and safe to call multiple times.
+   */
+  destroy() {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+
+    // Stop following any upstream time context
+    this.stopFollowingTimeContext();
+
+    // Remove global time context listeners registered in constructor
+    if (this.globalTimeContext) {
+      this.globalTimeContext.off('refreshContext', this.refreshContext);
+      this.globalTimeContext.off('removeOwnContext', this.removeIndependentContext);
+    }
+
+    // Clean up active clock listener if present
+    if (this.activeClock) {
+      this.activeClock.off('tick', this.tick);
+    }
+
+    // Clear internal references
+    this.globalTimeContext = undefined;
+    this.upstreamTimeContext = undefined;
+    this.activeClock = undefined;
+  }
+
   #copy(object) {
     return JSON.parse(JSON.stringify(object));
   }

--- a/src/api/time/TimeAPI.js
+++ b/src/api/time/TimeAPI.js
@@ -206,7 +206,11 @@ class TimeAPI extends GlobalTimeContext {
       const newPath = this.openmct.objects.getRelativePath(objectPath);
 
       if (currentPath !== newPath) {
-        // If the path has changed, update the context.
+        // If the path has changed, destroy the old context before replacing it
+        // to prevent memory leaks from retained event listeners
+        if (viewTimeContext && typeof viewTimeContext.destroy === 'function') {
+          viewTimeContext.destroy();
+        }
         this.independentContexts.delete(viewKey);
         viewTimeContext = new IndependentTimeContext(this.openmct, this, objectPath);
         this.independentContexts.set(viewKey, viewTimeContext);

--- a/src/api/time/independentTimeAPISpec.js
+++ b/src/api/time/independentTimeAPISpec.js
@@ -259,4 +259,150 @@ describe('The Independent Time API', function () {
       destroyTimeContext();
     });
   });
+
+  describe('Memory management', function () {
+    let objectPath1;
+    let objectPath2;
+    let domainObjectKey2;
+
+    beforeEach(function () {
+      domainObjectKey2 = `${domainObjectKey}-2`;
+      objectPath1 = [
+        {
+          identifier: {
+            namespace: '',
+            key: domainObjectKey
+          }
+        }
+      ];
+      objectPath2 = [
+        {
+          identifier: {
+            namespace: '',
+            key: domainObjectKey2
+          }
+        }
+      ];
+    });
+
+    it('Listeners are not leaked when contexts are replaced', function () {
+      // Get initial listener count on global time context
+      const initialRefreshCount = api.listeners('refreshContext').length;
+      const initialRemoveOwnCount = api.listeners('removeOwnContext').length;
+
+      // Create first context
+      const timeContext1 = api.getContextForView(objectPath1);
+      const afterFirstRefreshCount = api.listeners('refreshContext').length;
+      const afterFirstRemoveOwnCount = api.listeners('removeOwnContext').length;
+
+      // Verify listener count increased by 1 for each event
+      expect(afterFirstRefreshCount - initialRefreshCount).toBe(1);
+      expect(afterFirstRemoveOwnCount - initialRemoveOwnCount).toBe(1);
+
+      // Spy on getRelativePath to return different values to force replacement
+      // Track which path is being checked (old vs new) by comparing references
+      const firstContextPath = timeContext1.objectPath;
+      let callCount = 0;
+      spyOn(openmct.objects, 'getRelativePath').and.callFake(function (pathArg) {
+        callCount++;
+        // First call checks the old context's path (timeContext1.objectPath)
+        // Second call checks the new path (objectPath1 argument)
+        // Return different values to simulate path change and force replacement
+        if (callCount === 1) {
+          return 'path1'; // Return value for old context's path
+        } else {
+          return 'path2'; // Return different value for new path to force replacement
+        }
+      });
+
+      // Replace context - getRelativePath will return different values, triggering replacement
+      // which should destroy the old context before creating a new one
+      const timeContext2 = api.getContextForView(objectPath1);
+      const afterReplaceRefreshCount = api.listeners('refreshContext').length;
+      const afterReplaceRemoveOwnCount = api.listeners('removeOwnContext').length;
+
+      // Listener count should remain the same (old destroyed, new created)
+      // If old context wasn't destroyed, count would increase
+      expect(afterReplaceRefreshCount - initialRefreshCount).toBe(1);
+      expect(afterReplaceRemoveOwnCount - initialRemoveOwnCount).toBe(1);
+      expect(afterReplaceRefreshCount).toBe(afterFirstRefreshCount);
+      expect(afterReplaceRemoveOwnCount).toBe(afterFirstRemoveOwnCount);
+    });
+
+    it('Listeners are removed when destroy() is called', function () {
+      // Get initial listener count
+      const initialRefreshCount = api.listeners('refreshContext').length;
+      const initialRemoveOwnCount = api.listeners('removeOwnContext').length;
+
+      // Create a context
+      const timeContext = api.getContextForView(objectPath1);
+
+      // Verify listener count increased for global time context events
+      const afterCreateRefreshCount = api.listeners('refreshContext').length;
+      const afterCreateRemoveOwnCount = api.listeners('removeOwnContext').length;
+      expect(afterCreateRefreshCount - initialRefreshCount).toBe(1);
+      expect(afterCreateRemoveOwnCount - initialRemoveOwnCount).toBe(1);
+
+      // Test clock listener cleanup if clock is active
+      const initialTickCount = clock.listeners ? clock.listeners('tick').length : 0;
+      let hadActiveClock = false;
+      if (timeContext.activeClock !== undefined) {
+        hadActiveClock = true;
+      } else {
+        // Try to activate clock to test cleanup
+        try {
+          timeContext.clock(clockKey, { start: -10, end: 10 });
+          hadActiveClock = timeContext.activeClock !== undefined;
+        } catch (e) {
+          // Clock may not be available, continue without clock listener test
+        }
+      }
+
+      // If clock was active, verify tick listener was added
+      if (hadActiveClock && clock.listeners) {
+        const afterClockTickCount = clock.listeners('tick').length;
+        expect(afterClockTickCount - initialTickCount).toBeGreaterThanOrEqual(0);
+      }
+
+      // Destroy the context
+      timeContext.destroy();
+
+      // Verify listener count returned to initial for global time context events
+      const afterDestroyRefreshCount = api.listeners('refreshContext').length;
+      const afterDestroyRemoveOwnCount = api.listeners('removeOwnContext').length;
+      expect(afterDestroyRefreshCount).toBe(initialRefreshCount);
+      expect(afterDestroyRemoveOwnCount).toBe(initialRemoveOwnCount);
+
+      // Verify tick listener was removed if clock was active before destroy
+      if (hadActiveClock && clock.listeners) {
+        const afterDestroyTickCount = clock.listeners('tick').length;
+        expect(afterDestroyTickCount).toBe(initialTickCount);
+      }
+
+      // Verify destroy() is idempotent - can be called multiple times safely
+      expect(() => timeContext.destroy()).not.toThrow();
+      expect(api.listeners('refreshContext').length).toBe(initialRefreshCount);
+      expect(api.listeners('removeOwnContext').length).toBe(initialRemoveOwnCount);
+    });
+
+    it('Global events do not throw after replacement', function () {
+      // Create and replace contexts
+      const timeContext1 = api.getContextForView(objectPath1);
+
+      // Spy on getRelativePath to force replacement
+      let callCount = 0;
+      spyOn(openmct.objects, 'getRelativePath').and.callFake(function () {
+        callCount++;
+        return callCount === 1 ? 'path1' : 'path2';
+      });
+
+      const timeContext2 = api.getContextForView(objectPath1);
+
+      // Emit global events - should not throw errors
+      expect(() => {
+        api.emit('refreshContext', domainObjectKey);
+        api.emit('removeOwnContext', domainObjectKey);
+      }).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
This PR fixes a memory leak in the Open MCT time system caused by `IndependentTimeContext` instances registering global event listeners without removing them when the context is replaced or no longer needed. Over time, this resulted in retained contexts, accumulating listeners, and unnecessary work during time updates.
## Problem
`IndependentTimeContext registers `refreshContext` and `removeOwnContext` listeners on the global time context in its constructor. However, there was no `cleanup` mechanism when:
- a view’s time context is replaced during navigation, or
- a view is destroyed.
Although `stopFollowingTimeContext()` cleans up upstream context listeners, the global listeners registered in the constructor were never removed. As a result, old `IndependentTimeContext` instances were kept alive by listener references, leading to memory growth, zombie `callbacks` executing on every time event, and potential runtime errors in long-running sessions.

## Fix
This change introduces explicit lifecycle cleanup for independent time contexts:
- Added an idempotent destroy() method to IndependentTimeContext that:
       - stops following upstream contexts,
       - removes global time context listeners (`refreshContext, removeOwnContext`),
       - cleans up any active clock listener,
       - clears internal references to prevent retention.
- Updated TimeAPI.getContextForView() to call destroy() on the existing context before replacing it when the object path changes, ensuring old contexts are fully cleaned up.

## Tests
A new Memory management test suite was added to verify:
- global time context listeners are not leaked when contexts are replaced,
- calling destroy() removes all registered listeners and is safe to call multiple times,
- emitting global time events after context replacement does not throw.
Tests can be run with:
`npm test -- --grep "Memory management"`

## Result
- Prevents memory leaks during repeated navigation between views
- Ensures only active time contexts receive global time events
- Improves stability and performance in long-running Open MCT sessions