### PR TITLE
security: harden default CouchDB credentials

### DIFF
--- a/src/plugins/persistence/couch/couchdb-compose.yaml
+++ b/src/plugins/persistence/couch/couchdb-compose.yaml
@@ -7,7 +7,7 @@ services:
     volumes:
       - couchdb:/opt/couchdb/data
     environment:
-      COUCHDB_USER: admin
-      COUCHDB_PASSWORD: password
+      COUCHDB_USER: ${COUCHDB_USER:-admin}
+      COUCHDB_PASSWORD: ${COUCHDB_PASSWORD:-must_be_changed}
 volumes:
   couchdb:


### PR DESCRIPTION
Updated the CouchDB Docker Compose configuration to remove hardcoded default credentials. Using a hardcoded password like `password` is a security risk, especially if the service is accidentally exposed or used in shared environments.

### Changes
- Replaced the hardcoded `COUCHDB_PASSWORD` with an environment variable reference `${COUCHDB_PASSWORD:-must_be_changed}`.
- Added a default `COUCHDB_USER` variable reference for consistency.

This change encourages better security hygiene by forcing users to define credentials via environment variables while providing a clear indicator that the default value must be updated.

**Proof of Concept:**
A simple port scan for 5984 could allow unauthorized administrative access if the container is running with these default settings. By transitioning to environment variables, we reduce the blast radius of default configurations.