### PR TITLE
Fix percy snapshots

### DIFF
--- a/e2e/playwright-visual-a11y.config.js
+++ b/e2e/playwright-visual-a11y.config.js
@@ -29,6 +29,20 @@ const config = {
       use: {
         browserName: 'chromium'
       }
+    },
+    {
+      name: 'chrome-snow-theme', //Runs the same visual tests but with snow-theme enabled
+      use: {
+        browserName: 'chromium',
+        theme: 'snow'
+      }
+    },
+    {
+      name: 'darkmatter-theme', //Runs the same visual tests but with darkmatter-theme
+      use: {
+        browserName: 'chromium',
+        theme: 'darkmatter'
+      }
     }
   ],
   reporter: [


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes https://github.com/nasa/openmct/issues/8239

### Describe your changes:
Hide the clock for nightly builds as well as regular ones.

Here's my theory about what's going on -
* Percy compares snapshots against the most recent build from master
* Since we have a pretty low rate of merges into Master at the moment the most recent snapshots are usually from the nightly build
* The nightly build does not suppress the clock like the PR builds do. (original PR build fix #7850)

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? N/A
* [ ] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change? N/A

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
