### PR TITLE
chore(deps): bump lodash to 4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "karma-spec-reporter": "0.0.36",
         "karma-webpack": "5.0.1",
         "location-bar": "3.0.1",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "marked": "15.0.7",
         "mini-css-extract-plugin": "2.9.2",
         "moment": "2.30.1",
@@ -7524,10 +7524,11 @@
       "dev": true
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "karma-spec-reporter": "0.0.36",
     "karma-webpack": "5.0.1",
     "location-bar": "3.0.1",
-    "lodash": "4.17.21",
+    "lodash": "4.17.23",
     "marked": "15.0.7",
     "mini-css-extract-plugin": "2.9.2",
     "moment": "2.30.1",


### PR DESCRIPTION
We just released a security patch in 4.17.23 for CVE-2025-13465 (https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg)