### PR TITLE
[`#gold`] reset telemetry collection subscription on `_reset()`

### DIFF
--- a/src/api/telemetry/TelemetryCollection.js
+++ b/src/api/telemetry/TelemetryCollection.js
@@ -480,6 +480,7 @@ export default class TelemetryCollection extends EventEmitter {
     this.emit('clear');
 
     this._requestHistoricalTelemetry();
+    this._initiateSubscriptionTelemetry();
   }
 
   /**


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Cherry-pick of #8252 PR into master

### Describe your changes:
* re-init subscription on reset instead of only re-requesting historical

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
