### PR TITLE
Fix accessibility: align View Switcher accessible name with visible label

### DIFF
--- a/src/plugins/imagery/components/ImageryViewMenuSwitcher.vue
+++ b/src/plugins/imagery/components/ImageryViewMenuSwitcher.vue
@@ -1,3 +1,24 @@
+<!--
+ Open MCT, Copyright (c) 2014-2024, United States Government
+ as represented by the Administrator of the National Aeronautics and Space
+ Administration. All rights reserved.
+
+ Open MCT is licensed under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+
+ Open MCT includes source code licensed under additional open source
+ licenses. See the Open Source Licenses file (LICENSES.md) included with
+ this source code distribution or the Licensing information page available
+ at runtime from the About dialog for additional information.
+-->
 <template>
   <div class="c-switcher-menu">
     <button


### PR DESCRIPTION
### What this Pull-Request does

This PR fixes an accessibility issue in the Imagery View Switcher.

The button shows text like “Grid View” or “List View”, but the screen reader label
was always “Open the View Switcher Menu”. Because these didn’t match, accessibility
tools flagged it and screen reader / voice users could get confused.

### What changed

The button’s accessible label now includes the visible view name
(“Grid View” or “List View”), so what users see and what assistive
technology announces are consistent.

### Why this is useful

- Fixes an accessibility warning reported by IBM Equal Access
- Makes the View Switcher easier to use with screen readers and voice control
- No visual or behavior changes

### Notes

This is a small accessibility-only change. Nothing else was modified.
This is an accessibility-only change and should be safe to merge.
