### PR TITLE
fix: hide remove container btn when only one container exists

### DIFF
--- a/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
+++ b/e2e/tests/functional/plugins/flexibleLayout/flexibleLayout.e2e.spec.js
@@ -305,6 +305,33 @@ test.describe('Flexible Layout Toolbar Actions @localStorage', () => {
     await page.getByRole('button', { name: 'Ok', exact: true }).click();
     expect(await page.getByRole('group', { name: 'Frame' }).count()).toEqual(1);
   });
+  test('Remove Container button is not available when only one container exists', async ({
+    page
+  }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/7274'
+    });
+
+    const containerHandles = page.getByRole('columnheader', { name: 'Handle' });
+    expect(await containerHandles.count()).toEqual(2);
+
+    // remove one container so we're left with just one
+    await page.getByRole('columnheader', { name: 'Container Handle 1' }).click();
+    await page.getByTitle('Remove Container').click();
+    await page.getByRole('button', { name: 'Ok', exact: true }).click();
+    expect(await containerHandles.count()).toEqual(1);
+
+    // select the remaining container and check that remove btn is gone
+    await page.getByRole('columnheader', { name: 'Container Handle 1' }).click();
+    await expect(page.getByTitle('Remove Container')).toBeHidden();
+
+    // add a new container and verify the btn comes back
+    await page.getByTitle('Add Container').click();
+    expect(await containerHandles.count()).toEqual(2);
+    await page.getByRole('columnheader', { name: 'Container Handle 1' }).click();
+    await expect(page.getByTitle('Remove Container')).toBeVisible();
+  });
   test('Columns/Rows Layout Toggle', async ({ page }) => {
     await page.getByRole('columnheader', { name: 'Container Handle 1' }).click();
     const flexRows = page.getByLabel('Flexible Layout Row');

--- a/src/plugins/flexibleLayout/toolbarProvider.js
+++ b/src/plugins/flexibleLayout/toolbarProvider.js
@@ -158,42 +158,46 @@ function ToolbarProvider(openmct) {
           return [];
         }
 
-        deleteContainer = {
-          control: 'button',
-          domainObject: primary.context.item,
-          method: function () {
-            let containerId = primary.context.containerId;
+        // only show delete btn when theres more than one container
+        let containers = secondary.context.item.configuration.containers;
+        if (containers.length > 1) {
+          deleteContainer = {
+            control: 'button',
+            domainObject: primary.context.item,
+            method: function () {
+              let containerId = primary.context.containerId;
 
-            let prompt = openmct.overlays.dialog({
-              iconClass: 'alert',
-              message:
-                'This action will permanently delete this container from this Flexible Layout. Do you want to continue?',
-              buttons: [
-                {
-                  label: 'Ok',
-                  emphasis: 'true',
-                  callback: function () {
-                    openmct.objectViews.emit(
-                      `contextAction:${primaryKeyString}`,
-                      'deleteContainer',
-                      containerId
-                    );
-                    prompt.dismiss();
+              let prompt = openmct.overlays.dialog({
+                iconClass: 'alert',
+                message:
+                  'This action will permanently delete this container from this Flexible Layout. Do you want to continue?',
+                buttons: [
+                  {
+                    label: 'Ok',
+                    emphasis: 'true',
+                    callback: function () {
+                      openmct.objectViews.emit(
+                        `contextAction:${primaryKeyString}`,
+                        'deleteContainer',
+                        containerId
+                      );
+                      prompt.dismiss();
+                    }
+                  },
+                  {
+                    label: 'Cancel',
+                    callback: function () {
+                      prompt.dismiss();
+                    }
                   }
-                },
-                {
-                  label: 'Cancel',
-                  callback: function () {
-                    prompt.dismiss();
-                  }
-                }
-              ]
-            });
-          },
-          key: 'remove',
-          icon: 'icon-trash',
-          title: 'Remove Container'
-        };
+                ]
+              });
+            },
+            key: 'remove',
+            icon: 'icon-trash',
+            title: 'Remove Container'
+          };
+        }
 
         const domainObject = secondary.context.item;
         const keyString = openmct.objects.makeKeyString(domainObject.identifier);


### PR DESCRIPTION
Closes #7274

### Describe your changes:

The remove container button was showing up in the toolbar even when there was only one container left in the flexible layout. clicking it would either fail or delete the content inside wich is pretty confusing for users.

Added a check in `toolbarProvider.js` to only show the button when `containers.length > 1`. Also added an e2e test that verifies the button hides and shows correctly based on container count.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?