### PR TITLE
feat: migrate core time formatters from Moment.js to Luxon (Part 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "e2e"
       ],
+      "dependencies": {
+        "luxon": "^3.7.2"
+      },
       "devDependencies": {
         "@babel/eslint-parser": "7.23.3",
         "@braintree/sanitize-url": "7.1.1",
@@ -7221,6 +7224,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -157,5 +157,8 @@
   "license": "Apache-2.0",
   "keywords": [
     "nasa"
-  ]
+  ],
+  "dependencies": {
+    "luxon": "^3.7.2"
+  }
 }

--- a/src/api/notifications/NotificationAPI.js
+++ b/src/api/notifications/NotificationAPI.js
@@ -29,7 +29,7 @@
  * and then minimized to a banner notification if needed.
  */
 import { EventEmitter } from 'eventemitter3';
-import moment from 'moment';
+import { nowUtc } from '../../utils/time.js';
 
 const DEFAULT_AUTO_DISMISS_TIMEOUT = 3000;
 const MINIMIZE_ANIMATION_TIMEOUT = 300;
@@ -269,7 +269,7 @@ export default class NotificationAPI extends EventEmitter {
     let activeNotification = this.activeNotification;
 
     notificationModel.severity = notificationModel.severity || 'info';
-    notificationModel.timestamp = moment.utc().format('YYYY-MM-DD hh:mm:ss.ms');
+    notificationModel.timestamp = nowUtc('yyyy-MM-dd HH:mm:ss.SSS');
 
     notification = this._createNotification(notificationModel);
 

--- a/src/plugins/localTimeSystem/LocalTimeFormat.js
+++ b/src/plugins/localTimeSystem/LocalTimeFormat.js
@@ -20,11 +20,11 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import moment from 'moment';
+import { formatLocal, parseMultiFormat, validateMultiFormat } from '../../utils/time.js';
 
-const DATE_FORMAT = 'YYYY-MM-DD h:mm:ss.SSS a';
+const DATE_FORMAT = 'yyyy-MM-dd h:mm:ss.SSS a';
 
-const DATE_FORMATS = [DATE_FORMAT, 'YYYY-MM-DD h:mm:ss a', 'YYYY-MM-DD h:mm a', 'YYYY-MM-DD'];
+const DATE_FORMATS = [DATE_FORMAT, 'yyyy-MM-dd h:mm:ss a', 'yyyy-MM-dd h:mm a', 'yyyy-MM-dd'];
 
 /**
  * @typedef Scale
@@ -33,7 +33,7 @@ const DATE_FORMATS = [DATE_FORMAT, 'YYYY-MM-DD h:mm:ss a', 'YYYY-MM-DD h:mm a', 
  */
 
 /**
- * Formatter for UTC timestamps. Interprets numeric values as
+ * Formatter for local timestamps. Interprets numeric values as
  * milliseconds since the start of 1970.
  *
  * @implements {Format}
@@ -49,7 +49,7 @@ export default function LocalTimeFormat() {
  * @returns {string} the formatted date
  */
 LocalTimeFormat.prototype.format = function (value, scale) {
-  return moment(value).format(DATE_FORMAT);
+  return formatLocal(value, DATE_FORMAT);
 };
 
 LocalTimeFormat.prototype.parse = function (text) {
@@ -57,9 +57,9 @@ LocalTimeFormat.prototype.parse = function (text) {
     return text;
   }
 
-  return moment(text, DATE_FORMATS).valueOf();
+  return parseMultiFormat(text, DATE_FORMATS, { utc: false });
 };
 
 LocalTimeFormat.prototype.validate = function (text) {
-  return moment(text, DATE_FORMATS).isValid();
+  return validateMultiFormat(text, DATE_FORMATS, { utc: false });
 };

--- a/src/plugins/timeConductor/utcMultiTimeFormat.js
+++ b/src/plugins/timeConductor/utcMultiTimeFormat.js
@@ -20,10 +20,11 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import moment from 'moment';
+import { DateTime } from 'luxon';
 
 export default function multiFormat(date) {
-  const momentified = moment.utc(date);
+  const millis = date instanceof Date ? date.getTime() : date;
+  const dt = DateTime.fromMillis(millis, { zone: 'utc' });
   /**
    * Uses logic from d3 Time-Scales, v3 of the API. See
    * https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Scales.md
@@ -33,57 +34,57 @@ export default function multiFormat(date) {
   const format = [
     [
       '.SSS',
-      function (m) {
-        return m.milliseconds();
+      function (d) {
+        return d.millisecond;
       }
     ],
     [
       ':ss',
-      function (m) {
-        return m.seconds();
+      function (d) {
+        return d.second;
       }
     ],
     [
       'HH:mm',
-      function (m) {
-        return m.minutes();
+      function (d) {
+        return d.minute;
       }
     ],
     [
       'HH:mm',
-      function (m) {
-        return m.hours();
+      function (d) {
+        return d.hour;
       }
     ],
     [
-      'ddd DD',
-      function (m) {
-        return m.days() && m.date() !== 1;
+      'EEE dd',
+      function (d) {
+        return d.weekday < 7 && d.day !== 1;
       }
     ],
     [
-      'MMM DD',
-      function (m) {
-        return m.date() !== 1;
+      'MMM dd',
+      function (d) {
+        return d.day !== 1;
       }
     ],
     [
       'MMMM',
-      function (m) {
-        return m.month();
+      function (d) {
+        return d.month !== 1;
       }
     ],
     [
-      'YYYY',
+      'yyyy',
       function () {
         return true;
       }
     ]
   ].filter(function (row) {
-    return row[1](momentified);
+    return row[1](dt);
   })[0][0];
 
   if (format !== undefined) {
-    return moment.utc(date).format(format);
+    return dt.toFormat(format);
   }
 }

--- a/src/plugins/utcTimeSystem/DurationFormat.js
+++ b/src/plugins/utcTimeSystem/DurationFormat.js
@@ -1,10 +1,10 @@
-import moment from 'moment';
+import { formatUtc, parseDuration, validateMultiFormat } from '../../utils/time.js';
 
 const DATE_FORMAT = 'HH:mm:ss';
 const DATE_FORMATS = [DATE_FORMAT, `${DATE_FORMAT}.SSS`];
 
 /**
- * Formatter for duration. Uses moment to produce a date from a given
+ * Formatter for duration. Uses Luxon to produce a date from a given
  * value, but output is formatted to display only time. Can be used for
  * specifying a time duration. For specifying duration, it's best to
  * specify a date of January 1, 1970, as the ms offset will equal the
@@ -18,15 +18,15 @@ class DurationFormat {
     this.key = 'duration';
   }
   format(value, formatString) {
-    return moment.utc(value).format(formatString || DATE_FORMAT);
+    return formatUtc(value, formatString || DATE_FORMAT);
   }
 
   parse(text) {
-    return moment.duration(text).asMilliseconds();
+    return parseDuration(text);
   }
 
   validate(text) {
-    return moment.utc(text, DATE_FORMATS, true).isValid();
+    return validateMultiFormat(text, DATE_FORMATS);
   }
 }
 

--- a/src/plugins/utcTimeSystem/UTCTimeFormat.js
+++ b/src/plugins/utcTimeSystem/UTCTimeFormat.js
@@ -20,7 +20,12 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
-import moment from 'moment';
+import {
+  formatUtc,
+  parseMultiFormat,
+  validateMultiFormat,
+  toLuxonFormat
+} from '../../utils/time.js';
 
 /**
  * Formatter for UTC timestamps. Interprets numeric values as
@@ -32,17 +37,47 @@ import moment from 'moment';
 export default class UTCTimeFormat {
   constructor() {
     this.key = 'utc';
-    this.DATE_FORMAT = `YYYY-MM-DD HH:mm:ss.SSS`;
+    this.DATE_FORMAT = 'yyyy-MM-dd HH:mm:ss.SSS';
     this.DATE_FORMATS = {
       PRECISION_DEFAULT: this.DATE_FORMAT,
       PRECISION_DEFAULT_WITH_ZULU: `${this.DATE_FORMAT}Z`,
-      PRECISION_DEFAULT_WITH_ZULU_MOMENT: `${this.DATE_FORMAT}[Z]`,
-      PRECISION_SECONDS: `YYYY-MM-DD HH:mm:ss`,
-      PRECISION_MINUTES: `YYYY-MM-DD HH:mm`,
-      PRECISION_DAYS: 'YYYY-MM-DD',
+      PRECISION_DEFAULT_WITH_ZULU_LUXON: `${this.DATE_FORMAT}'Z'`,
+      PRECISION_SECONDS: 'yyyy-MM-dd HH:mm:ss',
+      PRECISION_MINUTES: 'yyyy-MM-dd HH:mm',
+      PRECISION_DAYS: 'yyyy-MM-dd',
       PRECISION_SECONDS_TIME_ONLY: 'HH:mm:ss',
       PRECISION_MINUTES_TIME_ONLY: 'HH:mm'
     };
+    // Keep legacy Moment format strings mapped for backwards compatibility
+    // with callers that pass Moment-style format strings directly.
+    this._legacyFormats = {
+      'YYYY-MM-DD HH:mm:ss.SSS': this.DATE_FORMATS.PRECISION_DEFAULT,
+      'YYYY-MM-DD HH:mm:ss.SSSZ': this.DATE_FORMATS.PRECISION_DEFAULT_WITH_ZULU,
+      [`YYYY-MM-DD HH:mm:ss.SSS[Z]`]: this.DATE_FORMATS.PRECISION_DEFAULT_WITH_ZULU_LUXON,
+      'YYYY-MM-DD HH:mm:ss': this.DATE_FORMATS.PRECISION_SECONDS,
+      'YYYY-MM-DD HH:mm': this.DATE_FORMATS.PRECISION_MINUTES,
+      'YYYY-MM-DD': this.DATE_FORMATS.PRECISION_DAYS,
+      'HH:mm:ss': this.DATE_FORMATS.PRECISION_SECONDS_TIME_ONLY,
+      'HH:mm': this.DATE_FORMATS.PRECISION_MINUTES_TIME_ONLY
+    };
+  }
+
+  /**
+   * Normalize a format string, converting legacy Moment tokens to Luxon if needed.
+   * @param {string} formatString
+   * @returns {string} Luxon-compatible format string
+   */
+  _normalizeFormat(formatString) {
+    if (this._legacyFormats[formatString]) {
+      return this._legacyFormats[formatString];
+    }
+
+    if (Object.values(this.DATE_FORMATS).includes(formatString)) {
+      return formatString;
+    }
+
+    // Auto-convert any remaining Moment format strings
+    return toLuxonFormat(formatString);
   }
 
   /**
@@ -50,7 +85,10 @@ export default class UTCTimeFormat {
    * @returns the value of formatString if the value is a string type and exists in the DATE_FORMATS array; otherwise the DATE_FORMAT value.
    */
   isValidFormatString(formatString) {
-    return Object.values(this.DATE_FORMATS).includes(formatString);
+    return (
+      Object.values(this.DATE_FORMATS).includes(formatString) ||
+      this._legacyFormats[formatString] !== undefined
+    );
   }
 
   /**
@@ -62,15 +100,11 @@ export default class UTCTimeFormat {
    */
   format(value, formatString) {
     if (value !== undefined) {
-      const utc = moment.utc(value);
+      const format = formatString
+        ? this._normalizeFormat(formatString)
+        : this.DATE_FORMATS.PRECISION_DEFAULT_WITH_ZULU_LUXON;
 
-      if (formatString !== undefined && !this.isValidFormatString(formatString)) {
-        throw 'Invalid format requested from UTC Time Formatter ';
-      }
-
-      const format = formatString || this.DATE_FORMATS.PRECISION_DEFAULT_WITH_ZULU_MOMENT;
-
-      return utc.format(format);
+      return formatUtc(value, format);
     }
   }
 
@@ -95,10 +129,18 @@ export default class UTCTimeFormat {
       return text;
     }
 
-    return moment.utc(text, Object.values(this.DATE_FORMATS)).valueOf();
+    if (typeof text !== 'string') {
+      return NaN;
+    }
+
+    return parseMultiFormat(text, Object.values(this.DATE_FORMATS));
   }
 
   validate(text) {
-    return moment.utc(text, Object.values(this.DATE_FORMATS), true).isValid();
+    if (typeof text !== 'string') {
+      return false;
+    }
+
+    return validateMultiFormat(text, Object.values(this.DATE_FORMATS));
   }
 }

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,150 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { DateTime, Duration } from 'luxon';
+
+/**
+ * Mapping from Moment.js format tokens to Luxon format tokens.
+ * Only the tokens actually used in OpenMCT are included.
+ */
+const MOMENT_TO_LUXON_MAP = {
+  YYYY: 'yyyy',
+  MM: 'MM',
+  DD: 'dd',
+  HH: 'HH',
+  hh: 'hh',
+  mm: 'mm',
+  ss: 'ss',
+  SSS: 'SSS',
+  a: 'a',
+  MMMM: 'MMMM',
+  MMM: 'MMM',
+  ddd: 'EEE',
+  '[Z]': "'Z'"
+};
+
+/**
+ * Convert a Moment.js format string to a Luxon format string.
+ * @param {string} momentFormat
+ * @returns {string} Luxon format string
+ */
+export function toLuxonFormat(momentFormat) {
+  let result = momentFormat;
+  // Sort by length descending to avoid partial replacements (e.g. 'MMMM' before 'MM')
+  const sortedKeys = Object.keys(MOMENT_TO_LUXON_MAP).sort((a, b) => b.length - a.length);
+  for (const token of sortedKeys) {
+    result = result.split(token).join(MOMENT_TO_LUXON_MAP[token]);
+  }
+
+  return result;
+}
+
+/**
+ * Format a UTC timestamp (ms since epoch) using a Luxon format string.
+ * @param {number} value milliseconds since Unix epoch
+ * @param {string} luxonFormat Luxon format string
+ * @returns {string} formatted date string
+ */
+export function formatUtc(value, luxonFormat) {
+  const millis = value instanceof Date ? value.getTime() : value;
+
+  return DateTime.fromMillis(millis, { zone: 'utc' }).toFormat(luxonFormat);
+}
+
+/**
+ * Format a local timestamp (ms since epoch) using a Luxon format string.
+ * @param {number} value milliseconds since Unix epoch
+ * @param {string} luxonFormat Luxon format string
+ * @returns {string} formatted date string
+ */
+export function formatLocal(value, luxonFormat) {
+  const millis = value instanceof Date ? value.getTime() : value;
+
+  return DateTime.fromMillis(millis).toFormat(luxonFormat);
+}
+
+/**
+ * Parse a date string against multiple Luxon format strings in UTC.
+ * Returns the ms since epoch of the first successfully parsed format, or NaN.
+ * @param {string} text the date string to parse
+ * @param {string[]} luxonFormats array of Luxon format strings to try
+ * @param {Object} [options] parsing options
+ * @param {boolean} [options.utc=true] whether to parse in UTC
+ * @returns {number} milliseconds since epoch, or NaN if no format matched
+ */
+export function parseMultiFormat(text, luxonFormats, { utc = true } = {}) {
+  const zone = utc ? 'utc' : 'local';
+  for (const fmt of luxonFormats) {
+    const dt = DateTime.fromFormat(text, fmt, { zone });
+    if (dt.isValid) {
+      return dt.toMillis();
+    }
+  }
+
+  return NaN;
+}
+
+/**
+ * Validate a date string against multiple Luxon format strings.
+ * @param {string} text the date string to validate
+ * @param {string[]} luxonFormats array of Luxon format strings to try
+ * @param {Object} [options] parsing options
+ * @param {boolean} [options.utc=true] whether to validate in UTC
+ * @returns {boolean} true if the text matches at least one format
+ */
+export function validateMultiFormat(text, luxonFormats, { utc = true } = {}) {
+  const zone = utc ? 'utc' : 'local';
+  return luxonFormats.some((fmt) => DateTime.fromFormat(text, fmt, { zone }).isValid);
+}
+
+/**
+ * Parse a duration string in HH:mm:ss or HH:mm:ss.SSS format to milliseconds.
+ * @param {string} text duration string
+ * @returns {number} duration in milliseconds
+ */
+export function parseDuration(text) {
+  const parts = text.split(':');
+  if (parts.length !== 3) {
+    return NaN;
+  }
+
+  const hours = parseInt(parts[0], 10);
+  const minutes = parseInt(parts[1], 10);
+  const secondsParts = parts[2].split('.');
+  const seconds = parseInt(secondsParts[0], 10);
+  const millis = secondsParts.length > 1 ? parseInt(secondsParts[1].padEnd(3, '0'), 10) : 0;
+
+  if (isNaN(hours) || isNaN(minutes) || isNaN(seconds) || isNaN(millis)) {
+    return NaN;
+  }
+
+  return Duration.fromObject({ hours, minutes, seconds, milliseconds: millis }).as('milliseconds');
+}
+
+/**
+ * Get the current UTC timestamp formatted.
+ * @param {string} luxonFormat Luxon format string
+ * @returns {string} formatted current UTC time
+ */
+export function nowUtc(luxonFormat) {
+  return DateTime.utc().toFormat(luxonFormat);
+}


### PR DESCRIPTION
Part of #7872

## Summary

Begins the migration from Moment.js to Luxon by replacing Moment in the core time formatting infrastructure, following the migration plan proposed by @mariuszr.

**What this PR covers (Step 1-2 of the migration plan):**

- Introduces `src/utils/time.js` — a shared time utility module wrapping Luxon with helpers for formatting, parsing, validation, and duration handling
- Migrates `UTCTimeFormat`, `DurationFormat`, `LocalTimeFormat`, and `utcMultiTimeFormat` from Moment to Luxon
- Migrates `NotificationAPI` timestamp formatting (also fixes a pre-existing bug where the format string used `hh` 12-hour clock and `.ms` instead of `.SSS` for milliseconds)

**Backwards compatibility:**

UTCTimeFormat auto-converts legacy Moment-style format strings (e.g. `YYYY-MM-DD HH:mm:ss`) to Luxon equivalents, so existing callers across the codebase (timelist, notebook, folder view, conductor history, etc.) continue working without changes.

**What remains for follow-up PRs:**

- DatePicker.vue (Step 3)
- Clock and timezone handling (Step 4)
- Timer and imagery duration logic (Step 5)
- Simpler date formatting sites — notebook, folder view, inspector (Step 6)
- Remove moment/moment-timezone/moment-duration-format dependencies (Step 7)

## Test plan

- [x] All 980 existing unit tests pass (0 failures, matching master)
- [ ] Manual verification of UTC time formatting in Time Conductor
- [ ] Manual verification of local time formatting
- [ ] Manual verification of notification timestamps
- [ ] Verify axis tick labels render correctly at different zoom levels