### PR TITLE
fix(a11y): include current view name in View Switcher accessible name

### DIFF
--- a/e2e/tests/functional/plugins/conditionSet/conditionSet.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSet.e2e.spec.js
@@ -281,7 +281,7 @@ test.describe('Basic Condition Set Use', () => {
     await page.locator('button[title="Save"]').click();
     await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
 
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
 
     await expect(page.getByRole('menuitem', { name: /Lad Table/ })).toBeHidden();
     await expect(page.getByRole('menuitem', { name: /Conditions View/ })).toBeVisible();
@@ -291,10 +291,10 @@ test.describe('Basic Condition Set Use', () => {
     await expect(
       page.getByLabel('Plot Legend Collapsed').getByText('Test Condition Set')
     ).toBeVisible();
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByLabel('Telemetry Table').click();
     await expect(page.getByRole('searchbox', { name: 'value filter input' })).toBeVisible();
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByLabel('Conditions View').click();
     await expect(page.getByText('Current Output')).toBeVisible();
   });

--- a/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
+++ b/e2e/tests/functional/plugins/conditionSet/conditionSetOperations.e2e.spec.js
@@ -100,7 +100,7 @@ test.describe('Basic Condition Set Use', () => {
     await page.locator('button[title="Save"]').click();
     await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
 
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
 
     await expect(page.getByRole('menuitem', { name: /Lad Table/ })).toBeHidden();
     await expect(page.getByRole('menuitem', { name: /Conditions View/ })).toBeVisible();
@@ -110,10 +110,10 @@ test.describe('Basic Condition Set Use', () => {
     await expect(
       page.getByLabel('Plot Legend Collapsed').getByText('Test Condition Set')
     ).toBeVisible();
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByLabel('Telemetry Table').click();
     await expect(page.getByRole('searchbox', { name: 'value filter input' })).toBeVisible();
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByLabel('Conditions View').click();
     await expect(page.getByText('Current Output')).toBeVisible();
   });

--- a/e2e/tests/functional/plugins/correlationTelemetry/correlationTelemetry.e2e.spec.js
+++ b/e2e/tests/functional/plugins/correlationTelemetry/correlationTelemetry.e2e.spec.js
@@ -73,7 +73,7 @@ test.describe('Correlation Telemetry', () => {
 
     await setRealTimeMode(page);
 
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByLabel('Telemetry Table').click();
 
     const getSWG1ValuePromise = getNextSineValueFromSWG(page, sineWaveGenerator1.uuid, false);

--- a/e2e/tests/functional/plugins/folders/viewPersist.e2e.spec.js
+++ b/e2e/tests/functional/plugins/folders/viewPersist.e2e.spec.js
@@ -47,7 +47,7 @@ test.describe('Folder View Persistence', () => {
 
   test('Folder view persists when navigating away and back', async ({ page }) => {
     // Click the view switcher button to open the menu
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
 
     // Click the List View option from the dropdown menu
     await page.getByRole('menuitem', { name: /List View/ }).click();

--- a/e2e/tests/functional/plugins/telemetryTable/telemetryTable.e2e.spec.js
+++ b/e2e/tests/functional/plugins/telemetryTable/telemetryTable.e2e.spec.js
@@ -59,7 +59,7 @@ test.describe('Telemetry Table', () => {
 
     // verify in telemetry table view
     await page.goto(sineWaveGenerator.url);
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByText('Telemetry Table', { exact: true }).click();
 
     expect(await getScrollPosition(page)).toBe(0);

--- a/e2e/tests/visual-a11y/telemetryViews.visual.spec.js
+++ b/e2e/tests/visual-a11y/telemetryViews.visual.spec.js
@@ -53,7 +53,7 @@ test.describe('Visual - Telemetry Views', () => {
     await page.goto(telemetry.url, { waitUntil: 'domcontentloaded' });
 
     //Click this button to see telemetry display options
-    await page.getByLabel('Open the View Switcher Menu').click();
+    await page.getByLabel(/Open the View Switcher Menu/).click();
     await page.getByLabel('Telemetry Table').click();
 
     //Get Table View in place

--- a/src/ui/layout/ViewSwitcher.vue
+++ b/src/ui/layout/ViewSwitcher.vue
@@ -54,7 +54,7 @@ export default {
   emits: ['set-view'],
   computed: {
     viewSwitcherLabel() {
-      return 'Open the View Switcher Menu';
+      return `Open the View Switcher Menu for ${this.currentView.name}`;
     }
   },
   methods: {


### PR DESCRIPTION
Closes #8249

## Summary

- Update `ViewSwitcher.vue` computed `viewSwitcherLabel` to include the current view name in the accessible name, producing labels like **"Open the View Switcher Menu for List View"** instead of the static **"Open the View Switcher Menu"**
- Update 10 e2e test selectors from exact string match (`getByLabel('...')`) to regex match (`getByLabel(/.../)`) so they continue to work with the now-dynamic aria-label

## Why

The View Switcher button's `aria-label` was a static string that did not match or contain the visible label text (e.g. "List View", "Grid View"). This violates:

- **WCAG 2.1 SC 2.5.3 (Label in Name)** — the accessible name must match or contain the visible label
- Flagged by **IBM Equal Access Accessibility Checker**: *"Accessible name does not match or contain the visible label text"*

Speech-input users navigate by speaking the visible label. When the programmatic name differs, the button cannot be activated by voice.

## Changes

| File | Change |
|------|--------|
| `src/ui/layout/ViewSwitcher.vue` | Dynamic label: `` `Open the View Switcher Menu for ${this.currentView.name}` `` |
| `e2e/**/conditionSet.e2e.spec.js` | 3 selectors updated to regex |
| `e2e/**/conditionSetOperations.e2e.spec.js` | 3 selectors updated to regex |
| `e2e/**/correlationTelemetry.e2e.spec.js` | 1 selector updated to regex |
| `e2e/**/viewPersist.e2e.spec.js` | 1 selector updated to regex |
| `e2e/**/telemetryTable.e2e.spec.js` | 1 selector updated to regex |
| `e2e/**/telemetryViews.visual.spec.js` | 1 selector updated to regex |

## Test plan

- [x] Open MCT locally, navigate to a view with the View Switcher visible (e.g. a Condition Set)
- [x] Inspect the button — `aria-label` should now read "Open the View Switcher Menu for [View Name]"
- [x] Run IBM Equal Access checker — the SC 2.5.3 violation should be resolved
- [x] Run affected e2e tests to confirm regex selectors work with the dynamic label