### PR TITLE
Fix Preview View Switcher to receive good currentView

### DIFF
--- a/src/ui/preview/PreviewContainer.vue
+++ b/src/ui/preview/PreviewContainer.vue
@@ -23,7 +23,7 @@
   <div role="dialog" aria-label="Preview Container" class="l-preview-window js-preview-window">
     <PreviewHeader
       ref="previewHeader"
-      :current-view="view"
+      :current-view="currentView"
       :domain-object="domainObject"
       :views="viewProviders"
     />
@@ -65,13 +65,19 @@ export default {
       domainObject: domainObject,
       viewKey: null,
       view: null,
-      viewProviders: [],
       currentViewProvider: {},
       existingViewIndex: 0
     };
   },
+  computed: {
+    viewProviders() {
+      return this.openmct.objectViews.get(this.domainObject, this.objectPath) || [];
+    },
+    currentView() {
+      return this.viewProviders?.find((provider) => provider.key === this.viewKey) || {};
+    }
+  },
   mounted() {
-    this.viewProviders = this.openmct.objectViews.get(this.domainObject, this.objectPath);
     this.viewProviders.forEach((provider, index) => {
       provider.onItemClicked = () => {
         if (this.existingView && provider.key === this.existingView.key) {


### PR DESCRIPTION
- Closes #8310
- Format and pass properly constructed current-view to ViewSwitcher, based on BrowseBar.vue.

### Describe your changes:
Updated the currentView computed property to return the view provider object from the viewProviders array instead of the actual view instance. This matches what ViewSwitcher expects - an object with properties like cssClass and name rather than the view instance with methods like show and destroy.

The computed property now:
- Finds the provider in viewProviders that matches the current viewKey
- Returns that provider object (which has the expected structure)
- Falls back to an empty object if no match is found
- This aligns with how BrowseBar.vue handles the same situation.

### All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [X] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [X] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [X] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
