### PR TITLE
Fix #8312: Add since=now to CouchDB changes feed to prevent replay of old changes

### DIFF
--- a/src/plugins/persistence/couch/CouchObjectProvider.js
+++ b/src/plugins/persistence/couch/CouchObjectProvider.js
@@ -616,6 +616,7 @@ class CouchObjectProvider {
     const sseURL = new URL(sseChangesPath);
     sseURL.searchParams.append('feed', 'eventsource');
     sseURL.searchParams.append('style', 'main_only');
+    sseURL.searchParams.append('since', 'now');
     sseURL.searchParams.append('heartbeat', HEARTBEAT);
 
     if (typeof SharedWorker === 'undefined') {


### PR DESCRIPTION
Closes #8312

- Added `since=now` parameter to CouchDB `_changes` feed subscription
- Prevents replay of old changes on initial connection and reconnection
- Reduces subscription time from minutes to milliseconds