### PR TITLE
fix(plot): implement robust WebGL context loss and recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,7 +1201,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2573,7 +2572,6 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3265,7 +3263,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3322,7 +3319,6 @@
       "version": "6.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3661,7 +3657,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5258,7 +5253,6 @@
       "version": "8.56.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5313,7 +5307,6 @@
       "version": "9.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7391,7 +7384,6 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8817,7 +8809,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8935,7 +8926,6 @@
       "version": "3.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9465,7 +9455,6 @@
       "version": "1.71.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -9539,7 +9528,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10316,7 +10304,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10385,8 +10372,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10444,7 +10430,6 @@
       "version": "5.3.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10840,7 +10825,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10888,7 +10872,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.0",
@@ -11157,7 +11140,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -552,6 +552,7 @@ export default {
       this.drawAPI = DrawLoader.getDrawAPI(mainCanvas, overlayCanvas);
       if (this.drawAPI?.on) {
         this.listenTo(this.drawAPI, 'error', this.fallbackToCanvas, this);
+        this.listenTo(this.drawAPI, 'restored', this.onDrawAPIRestored, this);
       }
 
       return Boolean(this.drawAPI);
@@ -575,6 +576,9 @@ export default {
       this.buildCanvasElements();
       this.drawAPI = DrawLoader.getFallbackDrawAPI(this.canvas, this.overlay);
       this.$emit('plot-reinitialize-canvas');
+    },
+    onDrawAPIRestored() {
+      this.scheduleDraw(true);
     },
     removeChartElement(series) {
       const elements = this.seriesElements.get(toRaw(series));

--- a/src/plugins/plot/draw/DrawWebGL.js
+++ b/src/plugins/plot/draw/DrawWebGL.js
@@ -95,15 +95,19 @@ class DrawWebGL extends EventEmitter {
     super();
     eventHelpers.extend(this);
     this.canvas = canvas;
-    this.gl =
-      this.canvas.getContext('webgl', { preserveDrawingBuffer: true }) ||
-      this.canvas.getContext('experimental-webgl', { preserveDrawingBuffer: true });
-
     this.overlay = overlay;
     this.c2d = overlay.getContext('2d');
     if (!this.c2d) {
       throw new Error('No canvas 2d!');
     }
+
+    this._isDestroyed = false;
+    this._isContextLost = false;
+    this._hasFallenBack = false;
+
+    this.gl =
+      this.canvas.getContext('webgl', { preserveDrawingBuffer: true }) ||
+      this.canvas.getContext('experimental-webgl', { preserveDrawingBuffer: true });
 
     // Ensure a context was actually available before proceeding
     if (!this.gl) {
@@ -113,14 +117,65 @@ class DrawWebGL extends EventEmitter {
     this.initContext();
 
     this.listenTo(this.canvas, 'webglcontextlost', this.onContextLost, this);
+    this.listenTo(this.canvas, 'webglcontextrestored', this.onContextRestored, this);
   }
   onContextLost(event) {
-    this.emit('error');
-    this.isContextLost = true;
-    this.destroy();
-    // TODO re-initialize and re-draw on context restored
+    if (this._isDestroyed || this._hasFallenBack) {
+      return;
+    }
+
+    event.preventDefault();
+    this._isContextLost = true;
+
+    console.log('[DrawWebGL] WebGL context lost detected.');
+    this.disposeResources();
+    this.emit('contextlost');
+
+    // Prevent multiple concurrent recovery timers
+    if (this.recoveryTimeout) {
+      clearTimeout(this.recoveryTimeout);
+    }
+
+    console.log('[DrawWebGL] Starting 5s recovery timeout...');
+    this.recoveryTimeout = setTimeout(() => {
+      this.recoveryTimeout = undefined;
+
+      if (this._isDestroyed || !this._isContextLost) {
+        return;
+      }
+
+      console.warn('[DrawWebGL] WebGL context restoration timed out. Falling back to 2D.');
+      this._hasFallenBack = true;
+      this.emit('error');
+    }, 5000);
+  }
+  onContextRestored(event) {
+    if (this._isDestroyed || this._hasFallenBack) {
+      console.log('[DrawWebGL] Context restored ignored: renderer is destroyed or already fallen back.');
+      return;
+    }
+
+    console.log('[DrawWebGL] WebGL context restored detected.');
+    if (this.recoveryTimeout) {
+      console.log('[DrawWebGL] Clearing pending recovery timeout.');
+      clearTimeout(this.recoveryTimeout);
+      this.recoveryTimeout = undefined;
+    }
+
+    // Re-acquire context if it has changed, though usually the same object is restored
+    this.gl =
+      this.canvas.getContext('webgl', { preserveDrawingBuffer: true }) ||
+      this.canvas.getContext('experimental-webgl', { preserveDrawingBuffer: true });
+
+    this.initContext();
+    this._isContextLost = false;
+    this.emit('restored');
   }
   initContext() {
+    if (this._isDestroyed) {
+      return;
+    }
+
     // Initialize shaders
     this.vertexShader = this.gl.createShader(this.gl.VERTEX_SHADER);
     this.gl.shaderSource(this.vertexShader, VERTEX_SHADER);
@@ -162,23 +217,53 @@ class DrawWebGL extends EventEmitter {
     // conceptually, color(RGBA) = (sourceColor * sfactor) + (destinationColor * dfactor)
     this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
   }
+  disposeResources() {
+    if (!this.gl) {
+      return;
+    }
+
+    if (this.buffer) {
+      this.gl.deleteBuffer(this.buffer);
+      this.buffer = undefined;
+    }
+
+    if (this.program) {
+      this.gl.deleteProgram(this.program);
+      this.program = undefined;
+    }
+
+    if (this.vertexShader) {
+      this.gl.deleteShader(this.vertexShader);
+      this.vertexShader = undefined;
+    }
+
+    if (this.fragmentShader) {
+      this.gl.deleteShader(this.fragmentShader);
+      this.fragmentShader = undefined;
+    }
+  }
   destroy() {
+    console.log('[DrawWebGL] Destroying renderer.');
+    this._isDestroyed = true;
+
+    if (this.recoveryTimeout) {
+      console.log('[DrawWebGL] Clearing pending recovery timeout during destruction.');
+      clearTimeout(this.recoveryTimeout);
+      this.recoveryTimeout = undefined;
+    }
+
     // Lose the context and delete all associated resources
     // https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#lose_contexts_eagerly
     this.gl?.getExtension('WEBGL_lose_context')?.loseContext();
-    this.gl?.deleteBuffer(this.buffer);
-    this.buffer = undefined;
-    this.gl?.deleteProgram(this.program);
-    this.program = undefined;
-    this.gl?.deleteShader(this.vertexShader);
-    this.vertexShader = undefined;
-    this.gl?.deleteShader(this.fragmentShader);
-    this.fragmentShader = undefined;
+    this.disposeResources();
     this.gl = undefined;
 
     this.stopListening();
     this.canvas = undefined;
     this.overlay = undefined;
+  }
+  get isContextLost() {
+    return this._isContextLost || this._hasFallenBack;
   }
   // Convert from logical to physical x coordinates
   x(v) {


### PR DESCRIPTION
## Overview
This PR implements a robust WebGL context loss and recovery mechanism for telemetry plots. It ensures that Open MCT dashboards—often left running for extended mission durations—can automatically recover from GPU resets, system sleep/wake events, or browser GPU process restarts without requiring a manual page refresh or permanently falling back to the slower 2D renderer.

## Root Cause Analysis
The previous implementation in `DrawWebGL.js` adopted an "all-or-nothing" approach to context loss. Upon receiving a `webglcontextlost` event:
1. It immediately called `destroy()`, which wiped all references to the canvas and the WebGL context.
2. It removed its own event listeners, making it impossible to detect the subsequent `webglcontextrestored` event.
3. It emitted a fatal `error`, triggering an immediate and permanent fallback to the 2D canvas in `MctChart.vue`.

This behavior was particularly problematic for long-running mission dashboards where temporary GPU interruptions (like a laptop closing/opening) would result in permanently degraded performance or blank charts.

## Implementation Summary
The renderer lifecycle has been refactored to prioritize recovery while maintaining a graceful fallback strategy.

### Architectural Improvements
- **Context Preservation**: The `DrawWebGL` instance now remains active during context loss, preserving the canvas reference and event listeners.
- **State-Aware Lifecycle**: Introduced internal state flags (`_isContextLost`, `_isDestroyed`, `_hasFallenBack`) to prevent race conditions and ensure predictable behavior during rapid loss/restore or destroy/create cycles.
- **Idempotent Reinitialization**: Refactored `initContext()` and introduced `disposeResources()` to allow the WebGL state to be safely wiped and recreated from scratch upon restoration.

### Recovery Flow
1. **Loss Detected**: `onContextLost` calls `event.preventDefault()` to allow restoration. It clears GPU resources and starts a **5-second recovery timeout**.
2. **Restoration**: If `webglcontextrestored` fires within the timeout, the renderer re-acquires the context, re-initializes shaders/buffers, and emits a `restored` event.
3. **Fallback**: If the timeout expires without restoration, the renderer finally emits an `error` to trigger the legacy 2D fallback, ensuring the chart does not remain blank indefinitely.

## Technical Change Breakdown

### `DrawWebGL.js`
- **Constructor**: Added listeners for both `webglcontextlost` and `webglcontextrestored`.
- **`onContextLost`**: Guards against redundant calls and starts the recovery timer.
- **`onContextRestored`**: Clears the pending timer and triggers a full resource re-initialization.
- **`disposeResources()`**: New explicit cleanup method for shaders, programs, and buffers.
- **`destroy()`**: Hardened to ensure all pending timers and listeners are cleared during unmount.

### `MctChart.vue`
- **Restoration Listener**: Added a listener for the `restored` event from the `drawAPI`.
- **Redraw Trigger**: Implemented `onDrawAPIRestored` to invoke `scheduleDraw(true)`, ensuring live telemetry resumes rendering immediately after GPU recovery.

## Reliability Benefits
- **Operational Stability**: Dashboards now survive system sleep/wake cycles and GPU driver updates.
- **Performance Preservation**: Users are no longer unnecessarily forced onto the 2D renderer for recoverable GPU events.
- **Lifecycle Correctness**: The implementation prevents stale GPU references, memory leaks, and duplicated render loops through explicit state tracking.

## Testing Section

### Manual Verification Steps
1. Open any plot (e.g., Sine Wave Generator).
2. Simulate context loss via the browser console:
   ```javascript
   const canvas = document.querySelector('.js-main-canvas');
   const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
   const ext = gl.getExtension('WEBGL_lose_context');
   ext.loseContext();
   ```
3. **Verify**: Plot stops rendering; no immediate 2D fallback occurs.
4. Restore the context within 5 seconds:
   ```javascript
   ext.restoreContext();
   ```
5. **Verify**: Plot resumes rendering live telemetry in WebGL mode.

### Fallback Verification
1. Lose context as above but wait >5 seconds.
2. **Verify**: Console warning appears (`WebGL context restoration timed out. Falling back to 2D.`) and the chart switches to the 2D renderer.

### Stress Testing
- Performed repeated `lose` -> `restore` cycles (3+ times consecutively) to verify no listener duplication or memory growth.
- Verified that navigating away from the plot immediately after context loss correctly clears the recovery timer and prevents delayed `error` emissions.

## Edge Cases Covered
- **Repeated Context Loss**: Handled via timer clearing and state resets.
- **Destruction during Recovery**: The `recoveryTimeout` is explicitly cleared in `destroy()`.
- **Stale GPU Resources**: `disposeResources()` ensures no orphaned shaders or buffers persist between context instances.
- **Late Restoration**: Restoration events after a fallback or destruction are safely ignored.

## Notes for Reviewers
- **Timeout Duration**: The 5-second window was chosen as a balance between user patience and typical GPU reset durations.
- **`isContextLost` Getter**: This remains the primary check for the draw loop, now returning `true` during both temporary loss and permanent fallback.

## Suggested Screenshots / Demo
- **Automatic Recovery**: A screen recording showing a laptop sleep/wake event or a manual `loseContext()` call followed by automatic resumption.
- **Console Logs**: Screenshots showing the diagnostic logs:
  - `[DrawWebGL] WebGL context lost detected.`
  - `[DrawWebGL] Starting 5s recovery timeout...`
  - `[DrawWebGL] WebGL context restored detected.`

## Commit Messages

### Squash Commit
`fix(plot): implement robust WebGL context loss and recovery (#XXXX)`

### Granular Commits
1. `refactor(plot): add state tracking and resource disposal to DrawWebGL`
2. `feat(plot): implement WebGL context recovery with 5s fallback timeout`
3. `fix(plot): trigger MctChart redraw on WebGL context restoration`
4. `chore(plot): add diagnostic logging and hardening for renderer lifecycle`