### PR TITLE
Fix play action erroneously using c-button CSS

### DIFF
--- a/src/plugins/telemetryTable/ViewActions.js
+++ b/src/plugins/telemetryTable/ViewActions.js
@@ -70,7 +70,7 @@ const play = {
   name: 'Play',
   key: 'play-data',
   description: 'Continue real-time data flow',
-  cssClass: 'c-button pause-play is-paused',
+  cssClass: 'icon-play',
   invoke: (objectPath, view) => {
     view.getViewContext().togglePauseByButton();
   },


### PR DESCRIPTION
Closes #8303
 
### Describe your changes:
The `play` action in `ViewActions.js` had `cssClass: 'c-button pause-play is-paused'` which renders it as a button widget in the context menu instead of a normal icon item. Changed to `icon-play` to match the `pause` action.
 
### All Submissions:
- [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
- [ ] Is this a [notable change](https://github.com/nasa/openmct/docs/src/process/release.md)?
 
### Author Checklist
- [x] Changes address original issue?
- [ ] Tests included and/or updated with changes?
- [x] Has this been smoke tested?
- [x] Have you associated this PR with a type: label?