### PR TITLE
ci: pin third-party Actions to commit SHA (CWE-829)

### DIFF
--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm run cov:e2e:report
 
       - name: Publish Results to Codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/e2e/lcov.info

--- a/.github/workflows/prcop.yml
+++ b/.github/workflows/prcop.yml
@@ -22,7 +22,7 @@ jobs:
     name: Template Check
     steps:
       - name: Linting Pull Request
-        uses: makaroni4/prcop@v1.0.35
+        uses: makaroni4/prcop@5f76e0c9ed4f3a6bf580b1aa684cdf7d5b1031e0 # v1.0.35
         with:
           config-file: '.github/workflows/prcop-config.json'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pins two third-party GitHub Actions to immutable commit SHAs.

|  File | Was | Now |
|---|---|---|
| `.github/workflows/e2e-couchdb.yml:53` | `codecov/codecov-action@v5` | `@75cd1169…` # v5 |
| `.github/workflows/prcop.yml:25` | `makaroni4/prcop@v1.0.35` | `@5f76e0c9…` # v1.0.35 |

## Why this matters

A third-party Action pinned to a tag or branch executes whatever the upstream maintainer pushes there at run time. Tag rewrites and account takeovers are common attack vectors. The [tj-actions/changed-files supply-chain attack (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) compromised ~23,000 workflows because they pinned to `@v45` instead of a SHA.

SHA pinning freezes the action contents at exactly the bytes upstream maintainers reviewed. The trailing comment preserves the human-readable version so dependabot / manual review can still drive updates.

For openmct specifically, the `codecov-action` has access to `CODECOV_TOKEN` and the `prcop` action has `GITHUB_TOKEN` in scope — both worth protecting against tag-rewrite attacks.

## CLA status

I'm aware openmct requires a signed CLA before external PRs can be merged ([discussion #3821](https://github.com/nasa/openmct/discussions/3821)). This PR is filed as a candidate change for review; happy to follow the CLA process if the change is desired, or to close if the team prefers to apply the fix in-house from this writeup. The actual edits are trivial single-line replacements, so the diff itself should be uncontroversial regardless of who authors the final merge.

## Other findings (not in this PR)

KCode's audit on openmct also flagged 6 other items — none touched here:

- 1× ReDoS via user-controllable regex in WebSocketWorker.js
- 3× SSRF in scripts/views (fetch on user-controlled URLs)
- 2× MultiEdit in CouchDB-deletion script (CLI argument path)

These are security-class and will be reported privately via `arc-dl-openmct@mail.nasa.gov` per [SECURITY.md](https://github.com/nasa/openmct/blob/master/SECURITY.md), not as a public PR.

## Provenance

Findings discovered by [Kulvex Code (KCode)](https://github.com/AstrolexisAI/KCode), a deterministic SAST scanner with an LLM verifier. Audit on openmct: 669 source files, 281 candidates → 8 confirmed in 50.7 seconds.

Fixes applied by KCode's agentic mode (Claude Sonnet 4.5). Each edit is a single-line replacement that preserves indentation. SHA values were resolved via `gh api` at authoring time.

---

Signed-off-by: AstroLexis · Kulvex Code <contact@astrolexis.space>