### PR TITLE
[Core] Resolve code FIXMEs in Export and Plot models

### DIFF
--- a/src/plugins/exportAsJSONAction/ExportAsJSONAction.js
+++ b/src/plugins/exportAsJSONAction/ExportAsJSONAction.js
@@ -36,8 +36,6 @@ class ExportAsJSONAction {
     // Bind public methods
     this.invoke = this.invoke.bind(this);
     this.appliesTo = this.appliesTo.bind(this);
-    // FIXME: This should be private but is used in tests
-    this.saveAs = this.saveAs.bind(this);
 
     this.name = 'Export as JSON';
     this.key = EXPORT_AS_JSON_ACTION_KEY;
@@ -379,7 +377,7 @@ class ExportAsJSONAction {
    * @private
    * @param {Object} completedTree
    */
-  saveAs(completedTree) {
+  #saveAs(completedTree) {
     this.JSONExportService.export(completedTree, { filename: this.root.name + '.json' });
   }
   /**
@@ -401,7 +399,7 @@ class ExportAsJSONAction {
       this.dialog.dismiss();
 
       this.#resetCounts();
-      this.saveAs(this.#wrapTree());
+      this.#saveAs(this.#wrapTree());
 
       this.dialog = null;
     }

--- a/src/plugins/exportAsJSONAction/ExportAsJSONActionSpec.js
+++ b/src/plugins/exportAsJSONAction/ExportAsJSONActionSpec.js
@@ -138,7 +138,7 @@ describe('Export as JSON plugin', () => {
       };
     });
 
-    spyOn(exportAsJSONAction, 'saveAs').and.callFake((completedTree) => {
+    spyOn(exportAsJSONAction.JSONExportService, 'export').and.callFake((completedTree) => {
       expect(Object.keys(completedTree).length).toBe(2);
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'openmct')).toBeTruthy();
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'rootId')).toBeTruthy();
@@ -195,7 +195,7 @@ describe('Export as JSON plugin', () => {
       };
     });
 
-    spyOn(exportAsJSONAction, 'saveAs').and.callFake((completedTree) => {
+    spyOn(exportAsJSONAction.JSONExportService, 'export').and.callFake((completedTree) => {
       expect(Object.keys(completedTree).length).toBe(2);
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'openmct')).toBeTruthy();
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'rootId')).toBeTruthy();
@@ -257,7 +257,7 @@ describe('Export as JSON plugin', () => {
       };
     });
 
-    spyOn(exportAsJSONAction, 'saveAs').and.callFake((completedTree) => {
+    spyOn(exportAsJSONAction.JSONExportService, 'export').and.callFake((completedTree) => {
       expect(Object.keys(completedTree).length).toBe(2);
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'openmct')).toBeTruthy();
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'rootId')).toBeTruthy();
@@ -318,7 +318,7 @@ describe('Export as JSON plugin', () => {
       };
     });
 
-    spyOn(exportAsJSONAction, 'saveAs').and.callFake((completedTree) => {
+    spyOn(exportAsJSONAction.JSONExportService, 'export').and.callFake((completedTree) => {
       expect(Object.keys(completedTree).length).toBe(2);
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'openmct')).toBeTruthy();
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'rootId')).toBeTruthy();
@@ -373,7 +373,7 @@ describe('Export as JSON plugin', () => {
       return Promise.resolve(child);
     });
 
-    spyOn(exportAsJSONAction, 'saveAs').and.callFake((completedTree) => {
+    spyOn(exportAsJSONAction.JSONExportService, 'export').and.callFake((completedTree) => {
       expect(Object.keys(completedTree).length).toBe(2);
       const conditionSetId = Object.keys(completedTree.openmct)[1];
       expect(Object.prototype.hasOwnProperty.call(completedTree, 'openmct')).toBeTruthy();

--- a/src/plugins/plot/configuration/Model.js
+++ b/src/plugins/plot/configuration/Model.js
@@ -49,8 +49,6 @@ export default class Model extends EventEmitter {
       options = {};
     }
 
-    // FIXME: this.id is defined as a method further below, but here it is
-    // assigned a possibly-undefined value. Is this code unused?
     this.id = options.id;
 
     /** @type {ModelType<T>} */
@@ -91,9 +89,7 @@ export default class Model extends EventEmitter {
     this.removeAllListeners();
   }
 
-  id() {
-    return this.get(this.idAttr);
-  }
+
 
   /**
    * @template {keyof ModelType<T>} K


### PR DESCRIPTION
### Describe your changes:
This is a small code cleanup PR that resolves two outstanding `FIXME` comments in the codebase:
1. **ExportAsJSONAction:** Encapsulated the `saveAs` method as a private field (`#saveAs`) and updated the tests in `ExportAsJSONActionSpec.js` to properly spy on the underlying `JSONExportService` instead.
2. **Model.js (Plot Configuration):** Removed the unused and obsolete `id()` method which was erroneously marked with a FIXME, as derived models properly use the `this.id` property directly.

### All Submissions:
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Is this a notable change?

### Author Checklist
- [x] Changes address original issue?
- [x] Tests included and/or updated with changes?
- [x] Has this been smoke tested?
- [ ] Have you associated this PR with a type: label?
