### PR TITLE
[UI] Fix status area bubble clipping in single-line mode

### DIFF
--- a/src/ui/layout/layout.scss
+++ b/src/ui/layout/layout.scss
@@ -289,7 +289,7 @@
     .l-shell__head--indicators-single-line & {
       flex-wrap: nowrap;
       justify-content: flex-start; // Overflow detection doesn't work with flex-end.
-      overflow: hidden;
+      clip-path: inset(-20px 0 -500px -500px);
 
       > *:first-child {
         margin-left: auto; // Mimics justify-content: flex-end when in single line mode.


### PR DESCRIPTION
Replaced overflow: hidden with clip-path: inset() to prevent absolute positioned hover bubbles from getting clipped while still hiding the overflowing horizontal elements.

Closes #8316

<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
