### PR TITLE
Fix View Switcher label not populating in Preview container (#8310)

### DIFF
--- a/src/ui/preview/PreviewHeader.vue
+++ b/src/ui/preview/PreviewHeader.vue
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="l-browse-bar__end">
-      <ViewSwitcher :v-if="!hideViewSwitcher" :views="views" :current-view="currentView" />
+      <ViewSwitcher v-if="!hideViewSwitcher" :views="views" :current-view="currentViewProvider" />
       <NotebookMenuSwitcher
         :domain-object="domainObject"
         :object-path="objectPath"
@@ -109,6 +109,14 @@ export default {
       statusBarItems: [],
       menuActionItems: []
     };
+  },
+  computed: {
+    currentViewProvider() {
+      // `currentView` is the active view instance (used for actions and the
+      // notebook menu). The ViewSwitcher needs the matching view provider,
+      // which carries the human-readable `name` and `cssClass` for its label.
+      return this.views.find((view) => view.key === this.currentView.key) ?? {};
+    }
   },
   watch: {
     currentView: {


### PR DESCRIPTION
Closes #8310

### Describe your changes:

The View Switcher in the **Preview container** rendered without a label for the current view (Main View and View Large were unaffected).

**Root cause:** `PreviewContainer.vue` passes the active view *instance* to `PreviewHeader` as `current-view`. Because the `ViewRegistry` only attaches `key` (and the view exposes `getViewContext()`) to the instance, the instance has **no `name`/`cssClass`** — which is exactly what `ViewSwitcher.vue` renders as its label. So the label came out empty.

The instance can't simply be swapped for the view *provider*, because `PreviewHeader` also uses `current-view` to build the action collection (`appliesTo` reads `view.getViewContext()`) and for the notebook menu (`view.key`). Replacing it with the provider would regress those (e.g. Save Image As / Copy to Notebook actions would disappear from Preview).

**Fix:** keep `current-view` as the instance, and derive the matching view **provider** from the `views` list by key inside `PreviewHeader` — mirroring how `BrowseBar.vue` already does it — then pass that provider to `ViewSwitcher` for its label.

Also corrected a malformed `:v-if="!hideViewSwitcher"` (i.e. `v-bind:v-if`, a dead attribute) on the `ViewSwitcher` to a real `v-if` directive.

```js
currentViewProvider() {
  return this.views.find((view) => view.key === this.currentView.key) ?? {};
}
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Is this a notable change that will require a special callout in the release notes? — No, visual bug fix only.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? — Not yet; happy to add a unit/e2e test if desired.
* [x] Has this been smoke tested? — Compiles cleanly + lint/prettier pass; full UI smoke test still pending (reason this PR is in draft).
* [x] Have you associated this PR with a `type:` label? — type:bug
* [ ] Have you associated a milestone with this PR?
* [x] Testing instructions included in associated issue.