### PR TITLE
Include visible view name in View Switcher accessible name (#8249)

### DIFF
--- a/src/ui/layout/ViewSwitcher.vue
+++ b/src/ui/layout/ViewSwitcher.vue
@@ -54,7 +54,13 @@ export default {
   emits: ['set-view'],
   computed: {
     viewSwitcherLabel() {
-      return 'Open the View Switcher Menu';
+      // Include the visible label (the current view's name) in the accessible
+      // name so that the accessible name contains the visible label text.
+      // See https://www.w3.org/TR/accname-1.2/ and IBM Equal Access rule
+      // "Accessible name must match or contain the visible label text".
+      return this.currentView.name
+        ? `${this.currentView.name} - Open the View Switcher Menu`
+        : 'Open the View Switcher Menu';
     }
   },
   methods: {


### PR DESCRIPTION
Closes #8249

### Describe your changes:

The View Switcher button rendered the current view's name (e.g. "List/Grid View") as its visible label, while its `aria-label`/`title` was the static string "Open the View Switcher Menu". Because the accessible name neither matches nor contains the visible label text, this fails the WCAG / IBM Equal Access rule *"Accessible name must match or contain the visible label text"*, and can confuse screen-reader and speech-input users (who navigate by speaking the visible label).

**Fix:** prefix the accessible name with the current view's name so it contains the visible label text, falling back to the original string when no name is available:

```js
return this.currentView.name
  ? `${this.currentView.name} - Open the View Switcher Menu`
  : 'Open the View Switcher Menu';
```

### Author Checklist
* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? — can add if desired
* [ ] Has this been smoke tested? — compiles + lint/prettier pass; UI smoke test pending (draft)
* [x] Have you associated this PR with a `type:` label? — type:bug