### PR TITLE
Skip prototype-related keys in DisplayLayoutToolbar path traversal (#8232)

### DIFF
--- a/src/plugins/displayLayout/DisplayLayoutToolbar.js
+++ b/src/plugins/displayLayout/DisplayLayoutToolbar.js
@@ -524,11 +524,18 @@ export default class DisplayLayoutToolbar {
   }
 
   #getPropertyFromPath(object, path) {
+    const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
     let splitPath = path.split('.');
     let property = Object.assign({}, object);
 
     while (splitPath.length && property) {
-      property = property[splitPath.shift()];
+      const key = splitPath.shift();
+      // Don't traverse into prototype-related keys to avoid reaching or
+      // mutating the object's prototype chain.
+      if (FORBIDDEN_KEYS.includes(key)) {
+        return undefined;
+      }
+      property = property[key];
     }
 
     return property;


### PR DESCRIPTION
Closes #8232

### Describe your changes:

`DisplayLayoutToolbar#getPropertyFromPath` walked a dot-delimited path and dereferenced each segment without validating the keys. A path segment of `__proto__`, `constructor`, or `prototype` could therefore reach the object's prototype chain.

**Fix:** bail out and return `undefined` when a forbidden key is encountered during traversal:

```js
const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
...
const key = splitPath.shift();
if (FORBIDDEN_KEYS.includes(key)) {
  return undefined;
}
property = property[key];
```

As the original report notes, no path to actual prototype *pollution* was identified; this hardens the traversal defensively (read access) and addresses the reported concern.

### Author Checklist
* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? — can add if desired
* [ ] Has this been smoke tested? — compiles + lint/prettier pass; UI smoke test pending (draft)
* [x] Have you associated this PR with a `type:` label? — type:bug