### PR TITLE
Use plain play icon for Play table view action (#8303)

### DIFF
--- a/src/plugins/telemetryTable/ViewActions.js
+++ b/src/plugins/telemetryTable/ViewActions.js
@@ -70,7 +70,7 @@ const play = {
   name: 'Play',
   key: 'play-data',
   description: 'Continue real-time data flow',
-  cssClass: 'c-button pause-play is-paused',
+  cssClass: 'icon-play',
   invoke: (objectPath, view) => {
     view.getViewContext().togglePauseByButton();
   },


### PR DESCRIPTION
Closes #8303

### Describe your changes:

When a table view is paused, the **Play** option in the main view's context menu was visually broken: its `cssClass` was `c-button pause-play is-paused`, which leaked button styling — and a cross-plugin dependency on imagery's `.c-button.pause-play` rules — into a context-menu item.

**Fix:** replace it with `icon-play`, mirroring the **Pause** action's `icon-pause`. The action now renders as a plain icon consistently in both the status bar and the context menu, and no longer depends on imagery styles.

```diff
-  cssClass: 'c-button pause-play is-paused',
+  cssClass: 'icon-play',
```

### Author Checklist
* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested? — compiles + lint/prettier pass; UI smoke test pending (draft)
* [x] Have you associated this PR with a `type:` label? — type:bug