### PR TITLE
Only request changes from couch that make sense... 'now' or most recent since reconnect

### DIFF
--- a/src/plugins/persistence/couch/CouchChangesFeed.js
+++ b/src/plugins/persistence/couch/CouchChangesFeed.js
@@ -3,6 +3,7 @@
   let connected = false;
   let couchEventSource;
   let changesFeedUrl;
+  let lastSequence = 'now';
   const keepAliveTime = 20 * 1000;
   let keepAliveTimer;
   const controller = new AbortController();
@@ -61,6 +62,7 @@
     console.debug('📩 Received message from CouchDB 📩');
 
     const objectChanges = JSON.parse(event.data);
+    lastSequence = objectChanges.seq !== undefined ? objectChanges.seq : lastSequence;
     connections.forEach(function (connection) {
       connection.postMessage({
         objectChanges
@@ -81,6 +83,9 @@
 
     if (!couchEventSource || couchEventSource.readyState === EventSource.CLOSED) {
       console.debug(`⇿ Opening CouchDB change feed connection for ${changesFeedUrl} ⇿`);
+      const sseURL = new URL(changesFeedUrl);
+      sseURL.searchParams.set('since', lastSequence);
+      changesFeedUrl = sseURL.toString();
       couchEventSource = new EventSource(changesFeedUrl);
       couchEventSource.onerror = self.onerror;
       couchEventSource.onopen = self.onopen;

--- a/src/plugins/persistence/couch/CouchObjectProvider.js
+++ b/src/plugins/persistence/couch/CouchObjectProvider.js
@@ -616,6 +616,7 @@ class CouchObjectProvider {
     const sseURL = new URL(sseChangesPath);
     sseURL.searchParams.append('feed', 'eventsource');
     sseURL.searchParams.append('style', 'main_only');
+    sseURL.searchParams.append('since', 'now');
     sseURL.searchParams.append('heartbeat', HEARTBEAT);
 
     if (typeof SharedWorker === 'undefined') {


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #8312 <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->
Initially set the "since" parameter to "now". In the shared worker we track the latest sequences as they come in with changes. If we have to reconnect, we request since the last tracked sequence.

If shared workers aren't supported, we still request "now" initially. There's not reconnect support there.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
