### PR TITLE
VIPERGC-1030 telemetry stopped flowing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1201,7 +1201,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2573,7 +2572,6 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3265,7 +3263,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3322,7 +3319,6 @@
       "version": "6.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3661,7 +3657,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5258,7 +5253,6 @@
       "version": "8.56.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5313,7 +5307,6 @@
       "version": "9.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7391,7 +7384,6 @@
       "version": "6.4.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8817,7 +8809,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8935,7 +8926,6 @@
       "version": "3.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9465,7 +9455,6 @@
       "version": "1.71.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -9539,7 +9528,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10316,7 +10304,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10385,8 +10372,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10444,7 +10430,6 @@
       "version": "5.3.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10840,7 +10825,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10888,7 +10872,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.0",
@@ -11157,7 +11140,6 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/src/api/telemetry/BatchingWebSocket.js
+++ b/src/api/telemetry/BatchingWebSocket.js
@@ -29,32 +29,6 @@ import installWorker from './WebSocketWorker.js';
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
  */
 
-/**
- * Mocks requestIdleCallback for Safari using setTimeout. Functionality will be
- * identical to setTimeout in Safari, which is to fire the callback function
- * after the provided timeout period.
- *
- * In browsers that support requestIdleCallback, this const is just a
- * pointer to the native function.
- *
- * @param {Function} callback a callback to be invoked during the next idle period, or
- * after the specified timeout
- * @param {RequestIdleCallbackOptions} options
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
- *
- */
-function requestIdleCallbackPolyfill(callback, options) {
-  return (
-    // eslint-disable-next-line compat/compat
-    window.requestIdleCallback ??
-    ((fn, { timeout }) =>
-      setTimeout(() => {
-        fn({ didTimeout: false });
-      }, timeout))
-  );
-}
-const requestIdleCallback = requestIdleCallbackPolyfill();
-
 const ONE_SECOND = 1000;
 
 /**
@@ -199,6 +173,11 @@ class BatchingWebSocket extends EventTarget {
     if (message.data.type === 'batch') {
       const batch = message.data.batch;
       const now = performance.now();
+      const processingTime = now - this.#lastBatchReceived;
+
+      if (processingTime > this.#processingTimeWarningThreshold) {
+        console.warning(`Warning: Batch processing took ${processingTime}`);
+      }
 
       let currentBufferLength = message.data.currentBufferLength;
       let maxBufferSize = message.data.maxBufferSize;
@@ -226,11 +205,10 @@ class BatchingWebSocket extends EventTarget {
         );
       }
 
-      this.start = Date.now();
       const dropped = message.data.dropped;
       if (dropped === true && !this.#showingRateLimitNotification) {
         const notification = this.#openmct.notifications.alert(
-          'Telemetry dropped due to client rate limiting.',
+          'Telemetry dropped due to buffer overflow.',
           { hint: 'Refresh individual telemetry views to retrieve dropped telemetry if needed.' }
         );
         this.#showingRateLimitNotification = true;
@@ -240,7 +218,6 @@ class BatchingWebSocket extends EventTarget {
       }
 
       this.dispatchEvent(new CustomEvent('batch', { detail: batch }));
-      this.#waitUntilIdleAndRequestNextBatch(batch);
     } else if (message.data.type === 'message') {
       this.dispatchEvent(new CustomEvent('message', { detail: message.data.message }));
     } else if (message.data.type === 'reconnected') {
@@ -250,25 +227,8 @@ class BatchingWebSocket extends EventTarget {
     }
   }
 
-  #waitUntilIdleAndRequestNextBatch(batch) {
-    requestIdleCallback(
-      (state) => {
-        if (this.#firstBatchReceived === false) {
-          this.#firstBatchReceived = true;
-        }
-        const now = Date.now();
-        const waitedFor = now - this.start;
-        if (waitedFor > this.#throttleRate) {
-          console.warn(`Warning, batch processing took ${waitedFor}ms`);
-        }
-        this.#readyForNextBatch();
-      },
-      { timeout: this.#forcedUpdateTimeout }
-    );
-  }
-
-  get #forcedUpdateTimeout() {
-    return this.#throttleRate * 2;
+  get #processingTimeWarningThreshold() {
+    return this.#throttleRate * 1.1;
   }
 }
 

--- a/src/api/telemetry/BatchingWebSocket.js
+++ b/src/api/telemetry/BatchingWebSocket.js
@@ -258,22 +258,17 @@ class BatchingWebSocket extends EventTarget {
         }
         const now = Date.now();
         const waitedFor = now - this.start;
-        if (state.didTimeout === true) {
-          if (document.visibilityState === 'visible') {
-            console.warn(`Event loop is too busy to process batch.`);
-            this.#waitUntilIdleAndRequestNextBatch(batch);
-          } else {
-            this.#readyForNextBatch();
-          }
-        } else {
-          if (waitedFor > this.#throttleRate) {
-            console.warn(`Warning, batch processing took ${waitedFor}ms`);
-          }
-          this.#readyForNextBatch();
+        if (waitedFor > this.#throttleRate) {
+          console.warn(`Warning, batch processing took ${waitedFor}ms`);
         }
+        this.#readyForNextBatch();
       },
-      { timeout: this.#throttleRate }
+      { timeout: this.#forcedUpdateTimeout }
     );
+  }
+
+  get #forcedUpdateTimeout() {
+    return this.#throttleRate * 2;
   }
 }
 

--- a/src/api/telemetry/BatchingWebSocket.js
+++ b/src/api/telemetry/BatchingWebSocket.js
@@ -166,11 +166,6 @@ class BatchingWebSocket extends EventTarget {
     if (message.data.type === 'batch') {
       const batch = message.data.batch;
       const now = performance.now();
-      const processingTime = now - this.#lastBatchReceived;
-
-      if (processingTime > this.#processingTimeWarningThreshold) {
-        console.warning(`Warning: Batch processing took ${processingTime}`);
-      }
 
       let currentBufferLength = message.data.currentBufferLength;
       let maxBufferSize = message.data.maxBufferSize;

--- a/src/api/telemetry/BatchingWebSocket.js
+++ b/src/api/telemetry/BatchingWebSocket.js
@@ -89,15 +89,8 @@ class BatchingWebSocket extends EventTarget {
   connect(url) {
     this.#worker.postMessage({
       type: 'connect',
-      url
-    });
-
-    this.#readyForNextBatch();
-  }
-
-  #readyForNextBatch() {
-    this.#worker.postMessage({
-      type: 'readyForNextBatch'
+      url,
+      throttleRate: this.#throttleRate
     });
   }
 

--- a/src/api/telemetry/WebSocketWorker.js
+++ b/src/api/telemetry/WebSocketWorker.js
@@ -225,8 +225,9 @@ export default function installWorker() {
       }
     }
     connect(message) {
-      const { url } = message.data;
+      const { url, throttleRate } = message.data;
       this.#websocket.connect(url);
+      this.#messageBatcher.setThrottleRate(throttleRate);
     }
     disconnect() {
       this.#websocket.disconnect();
@@ -296,8 +297,6 @@ export default function installWorker() {
 
     #sendNextBatch() {
       if (this.#currentBufferLength > 0) {
-        this.#resetBatch();
-
         this.#worker.postMessage({
           type: 'batch',
           dropped: this.#dropped,
@@ -305,6 +304,7 @@ export default function installWorker() {
           maxBufferSize: this.#maxBufferSize,
           batch: this.#buffer
         });
+        this.#resetBatch();
       }
     }
 

--- a/src/api/telemetry/WebSocketWorker.js
+++ b/src/api/telemetry/WebSocketWorker.js
@@ -211,9 +211,6 @@ export default function installWorker() {
         case 'message':
           this.#websocket.enqueueMessage(message.data.message);
           break;
-        case 'readyForNextBatch':
-          this.#messageBatcher.readyForNextBatch();
-          break;
         case 'setMaxBufferSize':
           this.#messageBatcher.setMaxBufferSize(message.data.maxBufferSize);
           break;
@@ -244,15 +241,14 @@ export default function installWorker() {
     #currentBufferLength;
     #dropped;
     #maxBufferSize;
-    #readyForNextBatch;
     #worker;
     #throttledSendNextBatch;
     #throttleMessagePattern;
+    #interval;
 
     constructor(worker) {
       // No dropping telemetry unless we're explicitly told to.
       this.#maxBufferSize = Number.POSITIVE_INFINITY;
-      this.#readyForNextBatch = false;
       this.#worker = worker;
       this.#resetBatch();
       this.setThrottleRate(ONE_SECOND);
@@ -280,10 +276,6 @@ export default function installWorker() {
           this.#dropped = true;
         }
       }
-
-      if (this.#readyForNextBatch) {
-        this.#throttledSendNextBatch();
-      }
     }
 
     #shouldThrottle(message) {
@@ -296,70 +288,33 @@ export default function installWorker() {
       this.#maxBufferSize = maxBufferSize;
     }
     setThrottleRate(throttleRate) {
-      this.#throttledSendNextBatch = throttle(this.#sendNextBatch.bind(this), throttleRate);
+      clearInterval(this.#interval);
+      this.#interval = setInterval(() => {
+        this.#sendNextBatch();
+      }, throttleRate);
     }
-    /**
-     * Indicates that client code is ready to receive the next batch of
-     * messages. If a batch is available, it will be immediately sent.
-     * Otherwise a flag will be set to send the next batch as soon as
-     * any new data is available.
-     */
-    readyForNextBatch() {
-      if (this.#hasData()) {
-        this.#throttledSendNextBatch();
-      } else {
-        this.#readyForNextBatch = true;
+
+    #sendNextBatch() {
+      if (this.#currentBufferLength > 0) {
+        this.#resetBatch();
+
+        this.#worker.postMessage({
+          type: 'batch',
+          dropped: this.#dropped,
+          currentBufferLength: this.#currentBufferLength,
+          maxBufferSize: this.#maxBufferSize,
+          batch: this.#buffer
+        });
       }
     }
-    #sendNextBatch() {
-      const buffer = this.#buffer;
-      const dropped = this.#dropped;
-      const currentBufferLength = this.#currentBufferLength;
 
-      this.#resetBatch();
-      this.#worker.postMessage({
-        type: 'batch',
-        dropped,
-        currentBufferLength: currentBufferLength,
-        maxBufferSize: this.#maxBufferSize,
-        batch: buffer
-      });
-
-      this.#readyForNextBatch = false;
-    }
     #hasData() {
       return this.#currentBufferLength > 0;
     }
+
     setThrottleMessagePattern(priorityMessagePattern) {
       this.#throttleMessagePattern = new RegExp(priorityMessagePattern, 'm');
     }
-  }
-
-  function throttle(callback, wait) {
-    let last = 0;
-    let throttling = false;
-
-    return function (...args) {
-      if (throttling) {
-        return;
-      }
-
-      const now = performance.now();
-      const timeSinceLast = now - last;
-
-      if (timeSinceLast >= wait) {
-        last = now;
-        callback(...args);
-      } else if (!throttling) {
-        throttling = true;
-
-        setTimeout(() => {
-          last = performance.now();
-          throttling = false;
-          callback(...args);
-        }, wait - timeSinceLast);
-      }
-    };
   }
 
   const websocket = new ResilientWebSocket(self);


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes VIPERGC-1030

### Describe your changes:
Simplifies the code that supplies telemetry from the WebSocket worker to the main UI thread by removing the back-pressure mechanism that relied on requestIdleCallback.

We use two mechanisms to prevent the UI thread being overwhelmed -
1. A configurable "throttle rate" which was really an "update rate" that determined how often the worker thread sent data to the UI thread. Telemetry is collected in batches that are periodically released to the UI at the configured throttle rate (under ideal circumstances).
2. A back-pressure mechanism whereby the UI thread would tell the WebSocket thread when it is ready for a new batch. In theory this mechanism caused the WebSocket thread to hold onto batches until the UI thread was "ready" to process them. This meant that in reality the configured throttle rate was in fact a _minimum_ throttle rate, the period between batches could be much longer, or indeed indefinitely long.

The problem with 2. was that it relied on [requestIdleCallback](https://www.w3.org/TR/requestidlecallback/). In principle this API function invokes the callback function when the main thread has run out of tasks to do, so it would seem to be a good mechanism for determining when the UI thread is done processing a batch. In reality idle callbacks can be blocked by any number of things, including:

* Layerizing
* Mouse events
* setTimeouts
* requestAnimationFrames
* and others

In practice, the implementation details are opaque and browser-specific. Debugging _why_ an idle callback is not being invoked can be extremely difficult.

A "timeout" mechanism is provided for this purpose. This will forcibly invoke the idle callback in the event that the main thread is not determined to be "idle" within the timeout period.

I decided at that point to just abandon requestIdleCallback altogether and fall back on setInterval to release batches at the configured throttle rate. This hands control back to the developer and simplifies the data flow significantly.

In testing I discovered that as well as fixing the original bug, it seems to result in lower average CPU rates anyway. In the original implementation large CPU spikes could be observed that have gone away with the new implementation. My suspicion there is that regular, smaller batches smooths out the data flow and avoids the cost of serializing, deserializing, and processing large batches.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? Existing tests are sufficient here for regressions. This scenario is highly sensitive to workstation specs, display complexity, and other difficult-to-control-for factors. An automated test will just introduce flake.
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?
