### PR TITLE
feat(example): add verification telemetry timeline example

### DIFF
--- a/example/verificationTelemetry/README.md
+++ b/example/verificationTelemetry/README.md
@@ -1,0 +1,81 @@
+# Verification Telemetry Example
+
+This example plugin visualizes verification and provenance event streams in Open MCT.
+
+It treats proof reports, replay reports, lineage events, semantic packet binding, witness
+receipts, and mutation rejection as telemetry. The included fixture is static sample data;
+the plugin does not verify artifacts cryptographically and does not add any proof-system
+runtime dependency.
+
+## Install In A Local Open MCT App
+
+```js
+openmct.install(openmct.plugins.example.VerificationTelemetryPlugin());
+```
+
+The plugin adds a `Verification Telemetry` root object with a sample capsule and an event
+stream. Open the `Verification Timeline` view to inspect the events.
+
+## Data Boundary
+
+The example displays verification reports as telemetry. It distinguishes:
+
+- core verification state;
+- replay state;
+- lineage events;
+- semantic packet binding;
+- witness observations;
+- mutation rejection;
+- display-only scope notes.
+
+Semantic packet data can explain a verified core state, but it does not alter core proof identity.
+
+## Fixture Schema
+
+Each event includes:
+
+```json
+{
+  "timestamp": 1780000000000,
+  "event_id": "evt_000001",
+  "event_type": "core_verified",
+  "layer": "core",
+  "status": "valid",
+  "artifact": "sample.phm",
+  "artifact_digest": "sha256:...",
+  "capsule_id": "phm_sample",
+  "branch_id": "branch_main",
+  "replay_fingerprint": "sha256:...",
+  "packet_digest": null,
+  "witness_id": null,
+  "mutation_id": null,
+  "summary": "Core verification report completed.",
+  "details": {},
+  "severity": "nominal"
+}
+```
+
+The adapter exposes both human-readable fields and numeric fields for plotting:
+
+- `status_code`
+- `layer_code`
+- `severity_code`
+
+## Current Validation Commands
+
+Use the current Open MCT scripts:
+
+```bash
+npm test
+npm run test:e2e:ci
+npm run test:e2e:visual:ci
+npm run test:perf:contract
+```
+
+For a smaller local check during development:
+
+```bash
+npm run lint:js
+npm run lint:vue
+npm run lint:spelling
+```

--- a/example/verificationTelemetry/VerificationCompositionProvider.js
+++ b/example/verificationTelemetry/VerificationCompositionProvider.js
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import {
+  CAPSULE_IDENTIFIER,
+  CAPSULE_KEY,
+  ROOT_KEY,
+  STREAM_IDENTIFIER,
+  VERIFICATION_NAMESPACE
+} from './constants.js';
+
+export default class VerificationCompositionProvider {
+  appliesTo(domainObject) {
+    return (
+      domainObject.identifier?.namespace === VERIFICATION_NAMESPACE &&
+      [ROOT_KEY, CAPSULE_KEY].includes(domainObject.identifier.key)
+    );
+  }
+
+  load(domainObject) {
+    if (domainObject.identifier.key === ROOT_KEY) {
+      return Promise.resolve([CAPSULE_IDENTIFIER]);
+    }
+
+    if (domainObject.identifier.key === CAPSULE_KEY) {
+      return Promise.resolve([STREAM_IDENTIFIER]);
+    }
+
+    return Promise.resolve([]);
+  }
+}

--- a/example/verificationTelemetry/VerificationObjectProvider.js
+++ b/example/verificationTelemetry/VerificationObjectProvider.js
@@ -1,0 +1,79 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import {
+  CAPSULE_IDENTIFIER,
+  CAPSULE_KEY,
+  CAPSULE_TYPE,
+  ROOT_IDENTIFIER,
+  ROOT_KEY,
+  STREAM_IDENTIFIER,
+  STREAM_KEY,
+  STREAM_TYPE,
+  TELEMETRY_VALUES,
+  VERIFICATION_NAMESPACE
+} from './constants.js';
+
+export default class VerificationObjectProvider {
+  constructor() {
+    this.objects = new Map([
+      [
+        ROOT_KEY,
+        {
+          identifier: ROOT_IDENTIFIER,
+          name: 'Verification Telemetry',
+          type: 'folder',
+          location: 'ROOT'
+        }
+      ],
+      [
+        CAPSULE_KEY,
+        {
+          identifier: CAPSULE_IDENTIFIER,
+          name: 'Sample Verification Capsule',
+          type: CAPSULE_TYPE,
+          location: `${VERIFICATION_NAMESPACE}:${ROOT_KEY}`
+        }
+      ],
+      [
+        STREAM_KEY,
+        {
+          identifier: STREAM_IDENTIFIER,
+          name: 'Sample Verification Events',
+          type: STREAM_TYPE,
+          location: `${VERIFICATION_NAMESPACE}:${CAPSULE_KEY}`,
+          telemetry: {
+            values: TELEMETRY_VALUES
+          }
+        }
+      ]
+    ]);
+  }
+
+  get(identifier) {
+    return Promise.resolve(this.objects.get(identifier.key));
+  }
+
+  search() {
+    return Promise.resolve([]);
+  }
+}

--- a/example/verificationTelemetry/VerificationTelemetryMetadataProvider.js
+++ b/example/verificationTelemetry/VerificationTelemetryMetadataProvider.js
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { STREAM_TYPE, TELEMETRY_VALUES } from './constants.js';
+
+export default class VerificationTelemetryMetadataProvider {
+  supportsMetadata(domainObject) {
+    return domainObject.type === STREAM_TYPE;
+  }
+
+  getMetadata(domainObject) {
+    return {
+      ...(domainObject.telemetry || {}),
+      values: TELEMETRY_VALUES
+    };
+  }
+}

--- a/example/verificationTelemetry/VerificationTelemetryProvider.js
+++ b/example/verificationTelemetry/VerificationTelemetryProvider.js
@@ -1,0 +1,69 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { STREAM_TYPE } from './constants.js';
+import sampleEvents from './fixtures/earth-001.events.json';
+import { normalizeEvents } from './verificationEventsAdapter.js';
+
+export default class VerificationTelemetryProvider {
+  constructor(options = {}) {
+    this.events = normalizeEvents(options.events || sampleEvents);
+    this.subscribeInterval = Number(options.subscribeInterval || 1000);
+  }
+
+  supportsRequest(domainObject) {
+    return domainObject.type === STREAM_TYPE;
+  }
+
+  request(domainObject, options = {}) {
+    const start = Number(options.start ?? Number.MIN_SAFE_INTEGER);
+    const end = Number(options.end ?? Number.MAX_SAFE_INTEGER);
+    const size = Number(options.size || this.events.length);
+    const filtered = this.events.filter((event) => event.utc >= start && event.utc <= end);
+
+    if (options.strategy === 'latest' || options.size === 1) {
+      return Promise.resolve(filtered.length ? [filtered[filtered.length - 1]] : []);
+    }
+
+    return Promise.resolve(filtered.slice(0, size));
+  }
+
+  supportsSubscribe(domainObject) {
+    return domainObject.type === STREAM_TYPE;
+  }
+
+  subscribe(domainObject, callback) {
+    if (!this.events.length) {
+      return function unsubscribe() {};
+    }
+
+    let index = 0;
+    const interval = setInterval(() => {
+      callback(this.events[index]);
+      index = (index + 1) % this.events.length;
+    }, this.subscribeInterval);
+
+    return function unsubscribe() {
+      clearInterval(interval);
+    };
+  }
+}

--- a/example/verificationTelemetry/VerificationTelemetryProviderSpec.js
+++ b/example/verificationTelemetry/VerificationTelemetryProviderSpec.js
@@ -1,0 +1,116 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import {
+  CAPSULE_IDENTIFIER,
+  CAPSULE_KEY,
+  CAPSULE_TYPE,
+  ROOT_IDENTIFIER,
+  ROOT_KEY,
+  STREAM_IDENTIFIER,
+  STREAM_TYPE
+} from './constants.js';
+import VerificationCompositionProvider from './VerificationCompositionProvider.js';
+import VerificationObjectProvider from './VerificationObjectProvider.js';
+import VerificationTelemetryMetadataProvider from './VerificationTelemetryMetadataProvider.js';
+import VerificationTelemetryProvider from './VerificationTelemetryProvider.js';
+
+describe('verification telemetry providers', () => {
+  const streamObject = {
+    identifier: STREAM_IDENTIFIER,
+    type: STREAM_TYPE
+  };
+
+  it('provides root, capsule, and event stream objects', async () => {
+    const provider = new VerificationObjectProvider();
+
+    const root = await provider.get(ROOT_IDENTIFIER);
+    const capsule = await provider.get(CAPSULE_IDENTIFIER);
+    const stream = await provider.get(STREAM_IDENTIFIER);
+
+    expect(root.type).toBe('folder');
+    expect(root.identifier.key).toBe(ROOT_KEY);
+    expect(capsule.type).toBe(CAPSULE_TYPE);
+    expect(capsule.identifier.key).toBe(CAPSULE_KEY);
+    expect(stream.type).toBe(STREAM_TYPE);
+    expect(stream.telemetry.values.length).toBeGreaterThan(0);
+  });
+
+  it('loads object composition', async () => {
+    const provider = new VerificationCompositionProvider();
+
+    expect(provider.appliesTo({ identifier: ROOT_IDENTIFIER })).toBeTrue();
+    expect(provider.appliesTo({ identifier: CAPSULE_IDENTIFIER })).toBeTrue();
+    expect(provider.appliesTo(streamObject)).toBeFalse();
+    expect(await provider.load({ identifier: ROOT_IDENTIFIER })).toEqual([CAPSULE_IDENTIFIER]);
+    expect(await provider.load({ identifier: CAPSULE_IDENTIFIER })).toEqual([STREAM_IDENTIFIER]);
+  });
+
+  it('provides telemetry metadata for event streams', () => {
+    const provider = new VerificationTelemetryMetadataProvider();
+
+    expect(provider.supportsMetadata(streamObject)).toBeTrue();
+    expect(provider.getMetadata(streamObject).values.map((value) => value.key)).toContain(
+      'status_code'
+    );
+  });
+
+  it('requests historical events by time range', async () => {
+    const provider = new VerificationTelemetryProvider();
+
+    expect(provider.supportsRequest(streamObject)).toBeTrue();
+
+    const events = await provider.request(streamObject, {
+      start: 1780000006000,
+      end: 1780000009000
+    });
+
+    expect(events.length).toBe(4);
+    expect(events[0].event_type).toBe('semantic_packet_bound');
+    expect(events[events.length - 1].event_type).toBe('challenge_started');
+  });
+
+  it('supports latest request strategy', async () => {
+    const provider = new VerificationTelemetryProvider();
+    const events = await provider.request(streamObject, {
+      start: Number.MIN_SAFE_INTEGER,
+      end: Number.MAX_SAFE_INTEGER,
+      strategy: 'latest'
+    });
+
+    expect(events).toHaveSize(1);
+    expect(events[0].event_type).toBe('report_exported');
+  });
+
+  it('supports realtime subscription and cleanup', (done) => {
+    const provider = new VerificationTelemetryProvider({
+      subscribeInterval: 1
+    });
+
+    expect(provider.supportsSubscribe(streamObject)).toBeTrue();
+    const unsubscribe = provider.subscribe(streamObject, (event) => {
+      expect(event.event_id).toBeDefined();
+      unsubscribe();
+      done();
+    });
+  });
+});

--- a/example/verificationTelemetry/VerificationTimelineViewProvider.js
+++ b/example/verificationTelemetry/VerificationTimelineViewProvider.js
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import mount from 'utils/mount';
+
+import VerificationTimelineView from './components/VerificationTimelineView.vue';
+import { STREAM_TYPE } from './constants.js';
+
+export default class VerificationTimelineViewProvider {
+  constructor(openmct) {
+    this.openmct = openmct;
+  }
+
+  key = 'verification.telemetry.timeline';
+  name = 'Verification Timeline';
+  cssClass = 'icon-telemetry';
+
+  canView(domainObject) {
+    return domainObject.type === STREAM_TYPE;
+  }
+
+  view(domainObject) {
+    let destroy = null;
+
+    return {
+      show: (element) => {
+        const mounted = mount(
+          {
+            el: element,
+            components: {
+              VerificationTimelineView
+            },
+            provide: {
+              openmct: this.openmct,
+              domainObject
+            },
+            template: '<verification-timeline-view></verification-timeline-view>'
+          },
+          {
+            app: this.openmct.app,
+            element
+          }
+        );
+        destroy = mounted.destroy;
+      },
+      destroy: () => {
+        if (destroy) {
+          destroy();
+        }
+      }
+    };
+  }
+}

--- a/example/verificationTelemetry/components/VerificationTimelineView.vue
+++ b/example/verificationTelemetry/components/VerificationTimelineView.vue
@@ -1,0 +1,459 @@
+<!--
+ Open MCT, Copyright (c) 2014-2024, United States Government
+ as represented by the Administrator of the National Aeronautics and Space
+ Administration. All rights reserved.
+
+ Open MCT is licensed under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+
+ Open MCT includes source code licensed under additional open source
+ licenses. See the Open Source Licenses file (LICENSES.md) included with
+ this source code distribution or the Licensing information page available
+ at runtime from the About dialog for additional information.
+-->
+
+<template>
+  <section class="c-verification-telemetry">
+    <header class="c-verification-telemetry__header">
+      <div>
+        <span>Verification Telemetry</span>
+        <h1>Provenance and Replay Event Stream</h1>
+      </div>
+      <div class="c-verification-telemetry__summary" aria-label="Verification summary">
+        <div>
+          <span>Core</span>
+          <b>{{ summary.core }}</b>
+        </div>
+        <div>
+          <span>Replay</span>
+          <b>{{ summary.replay }}</b>
+        </div>
+        <div>
+          <span>Semantic Binding</span>
+          <b>{{ summary.semantic }}</b>
+        </div>
+        <div>
+          <span>Challenges</span>
+          <b>{{ summary.challenge }}</b>
+        </div>
+      </div>
+    </header>
+
+    <section class="c-verification-telemetry__boundary">
+      <b>Truth boundary</b>
+      <p>
+        Displayed verification reports are telemetry. Semantic packet data can explain a verified
+        core state, but it does not alter core proof identity.
+      </p>
+    </section>
+
+    <div class="c-verification-telemetry__filters">
+      <label>
+        <span>Layer</span>
+        <select v-model="layerFilter">
+          <option value="all">All</option>
+          <option v-for="layer in layers" :key="layer" :value="layer">{{ layer }}</option>
+        </select>
+      </label>
+      <label>
+        <span>Status</span>
+        <select v-model="statusFilter">
+          <option value="all">All</option>
+          <option v-for="status in statuses" :key="status" :value="status">{{ status }}</option>
+        </select>
+      </label>
+      <label class="c-verification-telemetry__search">
+        <span>Search</span>
+        <input
+          v-model.trim="query"
+          type="search"
+          placeholder="Digest, branch, mutation, event"
+          aria-label="Search verification events"
+        />
+      </label>
+    </div>
+
+    <div class="c-verification-telemetry__body">
+      <div class="c-verification-telemetry__table-wrap">
+        <table class="c-table c-verification-telemetry__table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Layer</th>
+              <th>Event</th>
+              <th>Status</th>
+              <th>Summary</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="event in filteredEvents"
+              :key="event.event_id"
+              :class="eventClass(event)"
+              @click="selected = event"
+            >
+              <td>{{ formatTime(event.utc) }}</td>
+              <td>{{ event.layer }}</td>
+              <td>{{ event.event_type }}</td>
+              <td>{{ event.status }}</td>
+              <td>{{ event.summary }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <aside class="c-verification-telemetry__details" aria-live="polite">
+        <template v-if="selected">
+          <span>Event Details</span>
+          <h2>{{ selected.event_type }}</h2>
+          <dl>
+            <div>
+              <dt>Layer</dt>
+              <dd>{{ selected.layer }}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{{ selected.status }}</dd>
+            </div>
+            <div>
+              <dt>Artifact</dt>
+              <dd>{{ selected.artifact || 'Not applicable' }}</dd>
+            </div>
+            <div>
+              <dt>Digest</dt>
+              <dd>{{ selected.artifact_digest || 'Not applicable' }}</dd>
+            </div>
+            <div>
+              <dt>Branch</dt>
+              <dd>{{ selected.branch_id || 'Not applicable' }}</dd>
+            </div>
+            <div>
+              <dt>Replay</dt>
+              <dd>{{ selected.replay_fingerprint || 'Not applicable' }}</dd>
+            </div>
+            <div>
+              <dt>Packet</dt>
+              <dd>{{ selected.packet_digest || 'Not applicable' }}</dd>
+            </div>
+            <div>
+              <dt>Mutation</dt>
+              <dd>{{ selected.mutation_id || 'Not applicable' }}</dd>
+            </div>
+          </dl>
+          <pre>{{ selectedJson }}</pre>
+        </template>
+        <template v-else>
+          <span>Event Details</span>
+          <h2>Select an event</h2>
+          <p>
+            Choose a telemetry row to inspect digests, branch identifiers, and rejection traces.
+          </p>
+        </template>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script>
+const EVENT_STATUSES = ['valid', 'warning', 'invalid', 'rejected', 'expected_failure'];
+
+export default {
+  inject: ['openmct', 'domainObject'],
+  data() {
+    return {
+      events: [],
+      selected: null,
+      unsubscribe: null,
+      layerFilter: 'all',
+      statusFilter: 'all',
+      query: ''
+    };
+  },
+  computed: {
+    layers() {
+      return [...new Set(this.events.map((event) => event.layer).filter(Boolean))].sort();
+    },
+    statuses() {
+      return [...new Set([...EVENT_STATUSES, ...this.events.map((event) => event.status)])].filter(
+        Boolean
+      );
+    },
+    filteredEvents() {
+      const query = this.query.toLowerCase();
+      return this.events.filter((event) => {
+        const matchesLayer = this.layerFilter === 'all' || event.layer === this.layerFilter;
+        const matchesStatus = this.statusFilter === 'all' || event.status === this.statusFilter;
+        const haystack = [
+          event.event_type,
+          event.summary,
+          event.artifact_digest,
+          event.branch_id,
+          event.replay_fingerprint,
+          event.packet_digest,
+          event.mutation_id
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+
+        return matchesLayer && matchesStatus && (!query || haystack.includes(query));
+      });
+    },
+    summary() {
+      return {
+        core: this.stateForLayer('core'),
+        replay: this.stateForLayer('replay'),
+        semantic: this.stateForLayer('semantic'),
+        challenge: this.challengeSummary()
+      };
+    },
+    selectedJson() {
+      return JSON.stringify(this.selected?.raw || this.selected, null, 2);
+    }
+  },
+  async mounted() {
+    this.events = await this.openmct.telemetry.request(this.domainObject, {
+      start: Number.MIN_SAFE_INTEGER,
+      end: Number.MAX_SAFE_INTEGER
+    });
+    this.selected = this.events[0] || null;
+    this.unsubscribe = this.openmct.telemetry.subscribe(this.domainObject, (event) => {
+      this.events = [...this.events.filter((item) => item.event_id !== event.event_id), event].sort(
+        (left, right) => left.utc - right.utc || left.event_id.localeCompare(right.event_id)
+      );
+    });
+  },
+  unmounted() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+  },
+  methods: {
+    formatTime(value) {
+      return new Date(value).toISOString();
+    },
+    eventClass(event) {
+      return {
+        'is-warning': event.status === 'warning',
+        'is-invalid': ['invalid', 'rejected', 'unexpected_failure'].includes(event.status),
+        'is-expected-failure': event.status === 'expected_failure'
+      };
+    },
+    stateForLayer(layer) {
+      const event = [...this.events].reverse().find((item) => item.layer === layer);
+      return event ? event.status.replaceAll('_', ' ').toUpperCase() : 'NO DATA';
+    },
+    challengeSummary() {
+      const rejected = this.events.filter(
+        (event) => event.layer === 'challenge' && event.status === 'expected_failure'
+      ).length;
+      const unexpected = this.events.filter(
+        (event) => event.layer === 'challenge' && event.status === 'unexpected_failure'
+      ).length;
+
+      if (unexpected > 0) {
+        return `${unexpected} UNEXPECTED`;
+      }
+
+      return `${rejected} EXPECTED REJECTIONS`;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.c-verification-telemetry {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+  padding: 16px;
+  gap: 12px;
+}
+
+.c-verification-telemetry__header {
+  display: flex;
+  gap: 16px;
+  align-items: end;
+  justify-content: space-between;
+}
+
+.c-verification-telemetry__header span,
+.c-verification-telemetry__boundary b,
+.c-verification-telemetry__details > span,
+.c-verification-telemetry__filters span,
+.c-verification-telemetry__summary span {
+  color: var(--colorItemTreeFg, #9aa);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.c-verification-telemetry__header h1,
+.c-verification-telemetry__details h2 {
+  margin: 4px 0 0;
+  font-size: 1.25rem;
+}
+
+.c-verification-telemetry__summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(90px, 1fr));
+  border: 1px solid var(--colorInteriorBorder, #2b3034);
+}
+
+.c-verification-telemetry__summary div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 8px 10px;
+  border-right: 1px solid var(--colorInteriorBorder, #2b3034);
+}
+
+.c-verification-telemetry__summary div:last-child {
+  border-right: 0;
+}
+
+.c-verification-telemetry__summary b {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c-verification-telemetry__boundary {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--colorKey, #00bcd4);
+  background: var(--colorBodyBg, rgba(255, 255, 255, 0.03));
+}
+
+.c-verification-telemetry__boundary p {
+  margin: 0;
+}
+
+.c-verification-telemetry__filters {
+  display: grid;
+  grid-template-columns: 160px 180px minmax(220px, 1fr);
+  gap: 10px;
+}
+
+.c-verification-telemetry__filters label {
+  display: grid;
+  gap: 4px;
+}
+
+.c-verification-telemetry__filters select,
+.c-verification-telemetry__filters input {
+  width: 100%;
+}
+
+.c-verification-telemetry__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.38fr);
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--colorInteriorBorder, #2b3034);
+}
+
+.c-verification-telemetry__table-wrap {
+  min-width: 0;
+  overflow: auto;
+}
+
+.c-verification-telemetry__table {
+  min-width: 760px;
+}
+
+.c-verification-telemetry__table tbody tr {
+  cursor: pointer;
+}
+
+.c-verification-telemetry__table tbody tr:hover {
+  background: var(--colorItemTreeHoverBg, rgba(255, 255, 255, 0.06));
+}
+
+.c-verification-telemetry__table td {
+  vertical-align: top;
+}
+
+.c-verification-telemetry__table .is-warning td {
+  color: var(--colorStatusAlert, #e3b341);
+}
+
+.c-verification-telemetry__table .is-invalid td {
+  color: var(--colorStatusError, #ff5f56);
+}
+
+.c-verification-telemetry__table .is-expected-failure td {
+  color: var(--colorStatusAvailable, #60d394);
+}
+
+.c-verification-telemetry__details {
+  min-width: 0;
+  overflow: auto;
+  padding: 12px;
+  border-left: 1px solid var(--colorInteriorBorder, #2b3034);
+}
+
+.c-verification-telemetry__details dl {
+  display: grid;
+  gap: 6px;
+  margin: 12px 0;
+}
+
+.c-verification-telemetry__details div {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1fr);
+  gap: 8px;
+}
+
+.c-verification-telemetry__details dt {
+  color: var(--colorItemTreeFg, #9aa);
+}
+
+.c-verification-telemetry__details dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.c-verification-telemetry__details pre {
+  max-height: 320px;
+  overflow: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+  border: 1px solid var(--colorInteriorBorder, #2b3034);
+}
+
+@media (max-width: 900px) {
+  .c-verification-telemetry__header,
+  .c-verification-telemetry__body {
+    grid-template-columns: 1fr;
+  }
+
+  .c-verification-telemetry__header {
+    align-items: stretch;
+  }
+
+  .c-verification-telemetry__summary,
+  .c-verification-telemetry__filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .c-verification-telemetry__search {
+    grid-column: 1 / -1;
+  }
+
+  .c-verification-telemetry__details {
+    border-top: 1px solid var(--colorInteriorBorder, #2b3034);
+    border-left: 0;
+  }
+}
+</style>

--- a/example/verificationTelemetry/constants.js
+++ b/example/verificationTelemetry/constants.js
@@ -1,0 +1,128 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+export const VERIFICATION_NAMESPACE = 'example.verificationTelemetry';
+export const ROOT_KEY = 'root';
+export const CAPSULE_KEY = 'sample-verification-capsule';
+export const STREAM_KEY = 'sample-verification-events';
+
+export const CAPSULE_TYPE = `${VERIFICATION_NAMESPACE}.capsule`;
+export const STREAM_TYPE = `${VERIFICATION_NAMESPACE}.stream`;
+
+export const ROOT_IDENTIFIER = {
+  namespace: VERIFICATION_NAMESPACE,
+  key: ROOT_KEY
+};
+
+export const CAPSULE_IDENTIFIER = {
+  namespace: VERIFICATION_NAMESPACE,
+  key: CAPSULE_KEY
+};
+
+export const STREAM_IDENTIFIER = {
+  namespace: VERIFICATION_NAMESPACE,
+  key: STREAM_KEY
+};
+
+export const LAYER_CODES = {
+  capsule: 0,
+  core: 1,
+  lineage: 2,
+  replay: 3,
+  sidecar: 4,
+  semantic: 5,
+  witness: 6,
+  challenge: 7,
+  display: 8,
+  external: 9
+};
+
+export const STATUS_CODES = {
+  valid: 1,
+  warning: 0,
+  invalid: -1,
+  rejected: -2,
+  expected_failure: -3,
+  unexpected_failure: -4,
+  unknown: -9,
+  not_applicable: -10
+};
+
+export const SEVERITY_CODES = {
+  nominal: 1,
+  info: 0,
+  caution: -1,
+  warning: -2,
+  critical: -3
+};
+
+export const TELEMETRY_VALUES = [
+  {
+    key: 'utc',
+    name: 'Event Time',
+    format: 'utc',
+    hints: {
+      domain: 1
+    }
+  },
+  {
+    key: 'status_code',
+    name: 'Status Code',
+    format: 'integer',
+    hints: {
+      range: 1
+    }
+  },
+  {
+    key: 'layer_code',
+    name: 'Layer Code',
+    format: 'integer'
+  },
+  {
+    key: 'severity_code',
+    name: 'Severity Code',
+    format: 'integer'
+  },
+  {
+    key: 'event_type',
+    name: 'Event Type',
+    format: 'string'
+  },
+  {
+    key: 'layer',
+    name: 'Layer',
+    format: 'string'
+  },
+  {
+    key: 'status',
+    name: 'Status',
+    format: 'string'
+  },
+  {
+    key: 'summary',
+    name: 'Summary',
+    format: 'string',
+    hints: {
+      label: 0
+    }
+  }
+];

--- a/example/verificationTelemetry/fixtures/earth-001.events.json
+++ b/example/verificationTelemetry/fixtures/earth-001.events.json
@@ -1,0 +1,317 @@
+[
+  {
+    "timestamp": 1780000000000,
+    "event_id": "evt_000001",
+    "event_type": "capsule_loaded",
+    "layer": "capsule",
+    "status": "valid",
+    "artifact": "earth-001.phm",
+    "artifact_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "capsule_id": "phm_earth_001",
+    "branch_id": null,
+    "replay_fingerprint": null,
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Memory capsule loaded and canonical digest matched.",
+    "details": {
+      "schema": "verification/memory-capsule/v1",
+      "local_only": true
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000001000,
+    "event_id": "evt_000002",
+    "event_type": "core_verified",
+    "layer": "core",
+    "status": "valid",
+    "artifact": "earth-001.phm",
+    "artifact_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_core",
+    "replay_fingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Core verification report completed with deterministic proof identity intact.",
+    "details": {
+      "expanded_table_allocated": false,
+      "verification_profile": "deterministic-conformance-replay"
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000002000,
+    "event_id": "evt_000003",
+    "event_type": "branch_created",
+    "layer": "lineage",
+    "status": "valid",
+    "artifact": "earth-001.lineage.json",
+    "artifact_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_ai_trace",
+    "replay_fingerprint": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "AI trace branch entered the provenance graph.",
+    "details": {
+      "operation": "create",
+      "parents": []
+    },
+    "severity": "info"
+  },
+  {
+    "timestamp": 1780000003000,
+    "event_id": "evt_000004",
+    "event_type": "branch_forked",
+    "layer": "lineage",
+    "status": "valid",
+    "artifact": "earth-001.lineage.json",
+    "artifact_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_science_pipeline",
+    "replay_fingerprint": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Scientific pipeline branch forked from the verified core branch.",
+    "details": {
+      "operation": "fork",
+      "parents": ["branch_core"]
+    },
+    "severity": "info"
+  },
+  {
+    "timestamp": 1780000004000,
+    "event_id": "evt_000005",
+    "event_type": "branch_merged",
+    "layer": "lineage",
+    "status": "valid",
+    "artifact": "earth-001.lineage.json",
+    "artifact_digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Lineage branches merged into the final memory state.",
+    "details": {
+      "operation": "merge",
+      "parents": ["branch_ai_trace", "branch_science_pipeline", "branch_build", "branch_audit"]
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000005000,
+    "event_id": "evt_000006",
+    "event_type": "lineage_replayed",
+    "layer": "replay",
+    "status": "valid",
+    "artifact": "earth-001.replay.report.json",
+    "artifact_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Replay reconstructed the expected final state fingerprint.",
+    "details": {
+      "network_required": false,
+      "deterministic": true
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000006000,
+    "event_id": "evt_000007",
+    "event_type": "semantic_packet_bound",
+    "layer": "semantic",
+    "status": "valid",
+    "artifact": "earth-001.semantic.packet.json",
+    "artifact_digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Semantic packet bound to the verified replay fingerprint.",
+    "details": {
+      "semantic_changes_affect_core": false,
+      "authoritative_layer": "core"
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000007000,
+    "event_id": "evt_000008",
+    "event_type": "sidecar_validated",
+    "layer": "sidecar",
+    "status": "valid",
+    "artifact": "earth-001.sidecar.json",
+    "artifact_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Sidecar binding matched branch, packet digest, and replay fingerprint.",
+    "details": {
+      "binding_count": 1
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000008000,
+    "event_id": "evt_000009",
+    "event_type": "witness_observed",
+    "layer": "witness",
+    "status": "valid",
+    "artifact": "earth-001.witness.json",
+    "artifact_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": null,
+    "witness_id": "witness_local_browser",
+    "mutation_id": null,
+    "summary": "Local witness receipt observed matching capsule and core digests.",
+    "details": {
+      "witness_kind": "browser",
+      "trust_policy": "informational"
+    },
+    "severity": "info"
+  },
+  {
+    "timestamp": 1780000009000,
+    "event_id": "evt_000010",
+    "event_type": "challenge_started",
+    "layer": "challenge",
+    "status": "valid",
+    "artifact": "earth-001.challenge.report.json",
+    "artifact_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Mutation challenge suite started against copied artifacts.",
+    "details": {
+      "mutation_count": 42
+    },
+    "severity": "info"
+  },
+  {
+    "timestamp": 1780000010000,
+    "event_id": "evt_000011",
+    "event_type": "mutation_applied",
+    "layer": "challenge",
+    "status": "warning",
+    "artifact": "earth-001-mut-semantic.phm",
+    "artifact_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+    "witness_id": null,
+    "mutation_id": "mut_semantic_note_001",
+    "summary": "Semantic note tamper was applied to a throwaway challenge copy.",
+    "details": {
+      "target_layer": "semantic",
+      "core_source_mutated": false
+    },
+    "severity": "caution"
+  },
+  {
+    "timestamp": 1780000011000,
+    "event_id": "evt_000012",
+    "event_type": "mutation_rejected",
+    "layer": "challenge",
+    "status": "expected_failure",
+    "artifact": "earth-001-mut-semantic.phm",
+    "artifact_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999",
+    "witness_id": null,
+    "mutation_id": "mut_semantic_note_001",
+    "summary": "Tampered semantic packet rejected; core verification remained unchanged.",
+    "details": {
+      "expected_layer": "semantic",
+      "actual_layer": "semantic",
+      "core_unchanged": true,
+      "rejection_code": "PACKET_DIGEST_MISMATCH"
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000012000,
+    "event_id": "evt_000013",
+    "event_type": "mutation_rejected",
+    "layer": "challenge",
+    "status": "expected_failure",
+    "artifact": "earth-001-mut-core.phm",
+    "artifact_digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "capsule_id": "phm_earth_001",
+    "branch_id": "branch_final_merge",
+    "replay_fingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": "mut_core_byte_001",
+    "summary": "Tampered core proof byte rejected at the core layer.",
+    "details": {
+      "expected_layer": "core",
+      "actual_layer": "core",
+      "core_unchanged": false,
+      "rejection_code": "CORE_DIGEST_MISMATCH"
+    },
+    "severity": "nominal"
+  },
+  {
+    "timestamp": 1780000013000,
+    "event_id": "evt_000014",
+    "event_type": "scope_warning",
+    "layer": "display",
+    "status": "warning",
+    "artifact": "earth-001.summary.md",
+    "artifact_digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    "capsule_id": "phm_earth_001",
+    "branch_id": null,
+    "replay_fingerprint": null,
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Displayed explanations are not proof claims unless backed by a verified core event.",
+    "details": {
+      "truth_boundary": "display_is_not_verification"
+    },
+    "severity": "caution"
+  },
+  {
+    "timestamp": 1780000014000,
+    "event_id": "evt_000015",
+    "event_type": "report_exported",
+    "layer": "display",
+    "status": "valid",
+    "artifact": "earth-001.verify.report.json",
+    "artifact_digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+    "capsule_id": "phm_earth_001",
+    "branch_id": null,
+    "replay_fingerprint": null,
+    "packet_digest": null,
+    "witness_id": null,
+    "mutation_id": null,
+    "summary": "Verification report exported for offline review.",
+    "details": {
+      "format": "json"
+    },
+    "severity": "info"
+  }
+]

--- a/example/verificationTelemetry/plugin.js
+++ b/example/verificationTelemetry/plugin.js
@@ -1,0 +1,51 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { CAPSULE_TYPE, ROOT_IDENTIFIER, STREAM_TYPE, VERIFICATION_NAMESPACE } from './constants.js';
+import VerificationCompositionProvider from './VerificationCompositionProvider.js';
+import VerificationObjectProvider from './VerificationObjectProvider.js';
+import VerificationTelemetryMetadataProvider from './VerificationTelemetryMetadataProvider.js';
+import VerificationTelemetryProvider from './VerificationTelemetryProvider.js';
+import VerificationTimelineViewProvider from './VerificationTimelineViewProvider.js';
+
+export default function VerificationTelemetryPlugin(options = {}) {
+  return function install(openmct) {
+    openmct.types.addType(CAPSULE_TYPE, {
+      name: 'Verification Capsule',
+      description: 'A verification and provenance report represented as event telemetry.',
+      cssClass: 'icon-telemetry'
+    });
+
+    openmct.types.addType(STREAM_TYPE, {
+      name: 'Verification Event Stream',
+      description: 'Verification, replay, lineage, semantic binding, witness, and mutation events.',
+      cssClass: 'icon-generator-events'
+    });
+
+    openmct.objects.addRoot(ROOT_IDENTIFIER);
+    openmct.objects.addProvider(VERIFICATION_NAMESPACE, new VerificationObjectProvider());
+    openmct.composition.addProvider(new VerificationCompositionProvider());
+    openmct.telemetry.addProvider(new VerificationTelemetryMetadataProvider());
+    openmct.telemetry.addProvider(new VerificationTelemetryProvider(options));
+    openmct.objectViews.addProvider(new VerificationTimelineViewProvider(openmct));
+  };
+}

--- a/example/verificationTelemetry/pluginSpec.js
+++ b/example/verificationTelemetry/pluginSpec.js
@@ -1,0 +1,59 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { createOpenMct, resetApplicationState } from '../../src/utils/testing.js';
+import { ROOT_IDENTIFIER, STREAM_IDENTIFIER } from './constants.js';
+import VerificationTelemetryPlugin from './plugin.js';
+
+describe('verification telemetry plugin', () => {
+  let openmct;
+
+  beforeEach((done) => {
+    openmct = createOpenMct();
+    openmct.install(VerificationTelemetryPlugin({ subscribeInterval: 1 }));
+    openmct.on('start', done);
+    openmct.startHeadless();
+  });
+
+  afterEach(async () => {
+    await resetApplicationState(openmct);
+  });
+
+  it('registers a root object and sample event stream', async () => {
+    const root = await openmct.objects.get(ROOT_IDENTIFIER);
+    const stream = await openmct.objects.get(STREAM_IDENTIFIER);
+
+    expect(root.name).toBe('Verification Telemetry');
+    expect(stream.name).toBe('Sample Verification Events');
+  });
+
+  it('serves verification telemetry through the Open MCT telemetry API', async () => {
+    const stream = await openmct.objects.get(STREAM_IDENTIFIER);
+    const events = await openmct.telemetry.request(stream, {
+      start: Number.MIN_SAFE_INTEGER,
+      end: Number.MAX_SAFE_INTEGER
+    });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.map((event) => event.event_type)).toContain('mutation_rejected');
+  });
+});

--- a/example/verificationTelemetry/verificationEventsAdapter.js
+++ b/example/verificationTelemetry/verificationEventsAdapter.js
@@ -1,0 +1,93 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import { LAYER_CODES, SEVERITY_CODES, STATUS_CODES } from './constants.js';
+
+const MAX_TEXT_LENGTH = 4096;
+
+export function sanitizeText(value, limit = MAX_TEXT_LENGTH) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value
+    .replace(/[&<>]/g, (character) => {
+      return {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;'
+      }[character];
+    })
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, limit);
+}
+
+export function statusToCode(status) {
+  return STATUS_CODES[status] ?? STATUS_CODES.unknown;
+}
+
+export function layerToCode(layer) {
+  return LAYER_CODES[layer] ?? LAYER_CODES.external;
+}
+
+export function severityToCode(severity) {
+  return SEVERITY_CODES[severity] ?? SEVERITY_CODES.info;
+}
+
+export function toOpenMctDatum(event) {
+  const timestamp = Number(event.timestamp);
+  const safeTimestamp = Number.isFinite(timestamp) ? timestamp : 0;
+
+  return {
+    utc: safeTimestamp,
+    timestamp: safeTimestamp,
+    status_code: statusToCode(event.status),
+    layer_code: layerToCode(event.layer),
+    severity_code: severityToCode(event.severity),
+    event_id: sanitizeText(event.event_id, 256),
+    event_type: sanitizeText(event.event_type, 256),
+    layer: sanitizeText(event.layer, 128),
+    status: sanitizeText(event.status, 128),
+    severity: sanitizeText(event.severity, 128),
+    artifact: sanitizeText(event.artifact, 512),
+    artifact_digest: sanitizeText(event.artifact_digest, 256),
+    capsule_id: sanitizeText(event.capsule_id, 256),
+    branch_id: sanitizeText(event.branch_id, 256),
+    replay_fingerprint: sanitizeText(event.replay_fingerprint, 256),
+    packet_digest: sanitizeText(event.packet_digest, 256),
+    witness_id: sanitizeText(event.witness_id, 256),
+    mutation_id: sanitizeText(event.mutation_id, 256),
+    summary: sanitizeText(event.summary),
+    raw: event
+  };
+}
+
+export function normalizeEvents(events) {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  return events
+    .map(toOpenMctDatum)
+    .sort((left, right) => left.utc - right.utc || left.event_id.localeCompare(right.event_id));
+}

--- a/example/verificationTelemetry/verificationEventsAdapterSpec.js
+++ b/example/verificationTelemetry/verificationEventsAdapterSpec.js
@@ -1,0 +1,85 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+import {
+  layerToCode,
+  normalizeEvents,
+  sanitizeText,
+  severityToCode,
+  statusToCode,
+  toOpenMctDatum
+} from './verificationEventsAdapter.js';
+
+describe('verification telemetry event adapter', () => {
+  it('maps known values to numeric telemetry codes', () => {
+    expect(statusToCode('valid')).toBe(1);
+    expect(statusToCode('expected_failure')).toBe(-3);
+    expect(layerToCode('core')).toBe(1);
+    expect(layerToCode('challenge')).toBe(7);
+    expect(severityToCode('critical')).toBe(-3);
+  });
+
+  it('maps unknown values to stable fallbacks', () => {
+    expect(statusToCode('not-a-status')).toBe(-9);
+    expect(layerToCode('not-a-layer')).toBe(9);
+    expect(severityToCode('not-a-severity')).toBe(0);
+  });
+
+  it('sanitizes text fields without rendering markup', () => {
+    expect(sanitizeText('  <img src=x onerror=alert(1)>  ')).toBe(
+      '&lt;img src=x onerror=alert(1)&gt;'
+    );
+    expect(sanitizeText('x'.repeat(5000))).toHaveSize(4096);
+    expect(sanitizeText(null)).toBe('');
+  });
+
+  it('normalizes event telemetry for Open MCT', () => {
+    const datum = toOpenMctDatum({
+      timestamp: 1780000000000,
+      event_id: 'evt_1',
+      event_type: 'core_verified',
+      layer: 'core',
+      status: 'valid',
+      severity: 'nominal',
+      summary: 'Core valid',
+      branch_id: 'branch_main'
+    });
+
+    expect(datum.utc).toBe(1780000000000);
+    expect(datum.status_code).toBe(1);
+    expect(datum.layer_code).toBe(1);
+    expect(datum.severity_code).toBe(1);
+    expect(datum.branch_id).toBe('branch_main');
+    expect(datum.summary).toBe('Core valid');
+    expect(datum.raw.event_id).toBe('evt_1');
+  });
+
+  it('sorts normalized events by time and event identifier', () => {
+    const events = normalizeEvents([
+      { timestamp: 2, event_id: 'evt_b', status: 'valid', layer: 'core' },
+      { timestamp: 1, event_id: 'evt_a', status: 'valid', layer: 'core' },
+      { timestamp: 2, event_id: 'evt_a', status: 'valid', layer: 'core' }
+    ]);
+
+    expect(events.map((event) => event.event_id)).toEqual(['evt_a', 'evt_a', 'evt_b']);
+  });
+});

--- a/src/plugins/plugins.js
+++ b/src/plugins/plugins.js
@@ -28,6 +28,7 @@ import ExampleUser from '../../example/exampleUser/plugin.js';
 import ExampleFaultSource from '../../example/faultManagement/exampleFaultSource.js';
 import GeneratorPlugin from '../../example/generator/plugin.js';
 import ExampleImagery from '../../example/imagery/plugin.js';
+import VerificationTelemetryPlugin from '../../example/verificationTelemetry/plugin.js';
 import AutoflowPlugin from './autoflow/AutoflowTabularPlugin.js';
 import BarChartPlugin from './charts/bar/plugin.js';
 import ScatterPlotPlugin from './charts/scatter/plugin.js';
@@ -105,6 +106,7 @@ plugins.example.ExampleDataVisualizationSourcePlugin = ExampleDataVisualizationS
 plugins.example.ExampleTags = ExampleTags;
 plugins.example.Generator = () => GeneratorPlugin;
 plugins.example.ExampleStaleness = ExampleStaleness;
+plugins.example.VerificationTelemetryPlugin = VerificationTelemetryPlugin;
 
 plugins.UTCTimeSystem = UTCTimeSystem;
 plugins.LocalTimeSystem = LocalTimeSystem;


### PR DESCRIPTION
## Summary

- Add a generic Verification Telemetry example plugin under `example/verificationTelemetry`.
- Represent verification, provenance, replay, semantic binding, witness, and mutation rejection events as Open MCT telemetry.
- Register a sample root object, event stream object, telemetry metadata, historical/realtime telemetry provider, and timeline view.
- Include static fixture data and focused unit coverage for provider behavior, adapter normalization, sanitization, and plugin installation.

## Rationale

Verification and provenance systems often emit report/event streams that fit Open MCT’s telemetry model. This example shows one way to inspect those reports using existing Open MCT concepts without adding a proof-system runtime dependency.

The included fixture is sample data from a Power House/slbit-style memory capsule workflow, but the plugin is intentionally generic. It displays verification reports as telemetry; it does not cryptographically verify artifacts inside Open MCT.

## Maintainer Feedback Path

I also opened a Show and Tell discussion to ask whether maintainers prefer this as an upstream example, docs/tutorial contribution, external community plugin, or smaller schema-first change:

https://github.com/nasa/openmct/discussions/8363

## Safety Boundary

- Static fixture only; no remote service calls.
- No Rust, WASM, Power House, or slbit runtime dependency.
- Report text is treated as untrusted display content and sanitized before timeline rendering.
- The view explicitly states that semantic packet data may explain verified core state but does not alter proof identity.

## Review Hygiene

- Changed files audit as regular ASCII text / JSON text.
- Direct non-ASCII scan returned no output.
- Direct bidirectional-control character scan returned no output.
- Rendered PR files page checked in headless Chromium after scrolling every file: 0 visible hidden-character banners and 0 visible flagged lines.
- Remote raw branch check: `example/verificationTelemetry/plugin.js` has 51 lines and `src/plugins/plugins.js` has 190 lines.
- `git diff --check` returned clean.
- Long prose lines in the README were wrapped to reduce review noise.

## Validation

- `npm run build:dev`
- `npm run lint:js`
- `npm run lint:vue`
- `npm run lint:spelling`
- `CHROME_BIN=/usr/bin/chromium npm test` -> 988 success, 67 skipped