### PR TITLE
Hide Notebook snapshot button when no notebook plugin is installed (#7733)

### DIFF
--- a/src/ui/components/ObjectFrame.vue
+++ b/src/ui/components/ObjectFrame.vue
@@ -160,7 +160,9 @@ export default {
       cssClass,
       widthClass: '',
       complexContent,
-      notebookEnabled: this.openmct.types.get('notebook'),
+      notebookEnabled:
+        this.openmct.types.listKeys().includes('notebook') ||
+        this.openmct.types.listKeys().includes('restricted-notebook'),
       statusBarItems: [],
       status: '',
       supportsIndependentTime: false

--- a/src/ui/layout/BrowseBar.vue
+++ b/src/ui/layout/BrowseBar.vue
@@ -185,7 +185,9 @@ export default {
       domainObject: undefined,
       viewKey: undefined,
       isEditing: this.openmct.editor.isEditing(),
-      notebookEnabled: this.openmct.types.get('notebook'),
+      notebookEnabled:
+        this.openmct.types.listKeys().includes('notebook') ||
+        this.openmct.types.listKeys().includes('restricted-notebook'),
       statusBarItems: [],
       status: ''
     };

--- a/src/ui/preview/PreviewHeader.vue
+++ b/src/ui/preview/PreviewHeader.vue
@@ -32,6 +32,7 @@
     <div class="l-browse-bar__end">
       <ViewSwitcher :v-if="!hideViewSwitcher" :views="views" :current-view="currentView" />
       <NotebookMenuSwitcher
+        v-if="notebookEnabled"
         :domain-object="domainObject"
         :object-path="objectPath"
         :is-preview="true"
@@ -106,6 +107,9 @@ export default {
   data() {
     return {
       type: this.openmct.types.get(this.domainObject.type),
+      notebookEnabled:
+        this.openmct.types.listKeys().includes('notebook') ||
+        this.openmct.types.listKeys().includes('restricted-notebook'),
       statusBarItems: [],
       menuActionItems: []
     };


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #7733

### Describe your changes:

The Snapshot button rendered even when no notebook plugin was installed, despite a `v-if="notebookEnabled"` guard that was supposed to hide it. The guard checked `openmct.types.get('notebook')`, which looks correct but never works as a boolean: `TypeRegistry.get()` falls back to the truthy `UNKNOWN_TYPE` instance for unregistered types instead of returning `undefined`. So `notebookEnabled` was always `true`, the `v-if` had no effect and the button was always visible.

Use `types.listKeys().includes(...)` instead, which reflects what is actually registered, and checks for both `'notebook'` and `'restricted-notebook'`.

Applied in `BrowseBar.vue`, `ObjectFrame.vue` and `PreviewHeader.vue`.

Before adding `openmct.install(openmct.plugins.Notebook());`:
<img width="2146" height="480" alt="CleanShot 2026-06-30 at 00 14 13@2x" src="https://github.com/user-attachments/assets/aea04f26-6366-4495-8559-7d6bbefabc94" />

After adding `openmct.install(openmct.plugins.Notebook());`:
<img width="2148" height="506" alt="CleanShot 2026-06-30 at 00 13 49@2x" src="https://github.com/user-attachments/assets/26fa4989-68c5-4972-ad82-fa771549e423" />


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
