### PR TITLE
[Tests] Cover plan activity metadata inspector

### DIFF
--- a/e2e/tests/functional/planning/plan.e2e.spec.js
+++ b/e2e/tests/functional/planning/plan.e2e.spec.js
@@ -58,6 +58,14 @@ test.describe('Plan', () => {
 
   test('Displays all plan events', async ({ page }) => {
     await assertPlanActivities(page, testPlan1, plan.url);
+
+    const planContents = page.locator('.c-plan__contents');
+    for (const [groupName, activities] of Object.entries(testPlan1)) {
+      await expect(planContents.getByText(groupName, { exact: true })).toBeVisible();
+      for (const activity of activities) {
+        await expect(planContents.getByText(activity.name, { exact: true })).toBeVisible();
+      }
+    }
   });
 
   test('Displays plans with ordered swim lanes configuration', async ({ page }) => {

--- a/e2e/tests/functional/planning/plan.e2e.spec.js
+++ b/e2e/tests/functional/planning/plan.e2e.spec.js
@@ -35,6 +35,12 @@ const testPlan1 = JSON.parse(
   )
 );
 
+const testPlanWithActivityMetadata = JSON.parse(JSON.stringify(testPlan1));
+testPlanWithActivityMetadata['Group 1'][0].version = '1.2.3';
+testPlanWithActivityMetadata['Group 1'][0].displayProperties = {
+  version: 'Version'
+};
+
 const testPlanWithOrderedLanes = JSON.parse(
   fs.readFileSync(
     new URL('../../../test-data/examplePlans/ExamplePlanWithOrderedLanes.json', import.meta.url)
@@ -62,6 +68,29 @@ test.describe('Plan', () => {
       json: testPlanWithOrderedLanes
     });
     await assertPlanOrderedSwimLanes(page, testPlanWithOrderedLanes, planWithSwimLanes.url);
+  });
+
+  test('Displays activity metadata in the inspector when available', async ({ page }) => {
+    const planWithMetadata = await createPlanFromJSON(page, {
+      json: testPlanWithActivityMetadata
+    });
+    const activity = testPlanWithActivityMetadata['Group 1'][0];
+
+    await navigateToObjectWithFixedTimeBounds(
+      page,
+      planWithMetadata.url,
+      activity.start,
+      activity.end
+    );
+    await page.getByText(activity.name).click();
+    await page.getByRole('tab', { name: 'Activity' }).click();
+
+    const versionProperty = page
+      .locator('.c-inspect-properties__row')
+      .filter({ hasText: 'Version' });
+    await expect(versionProperty.locator('.c-inspect-properties__value')).toHaveText(
+      activity.version
+    );
   });
 
   test('Allows setting the state of an activity when selected.', async ({ page }) => {


### PR DESCRIPTION
Closes #8349

### Describe your changes:

Completes the remaining plan e2e coverage requested by the issue:

- the existing plan event test now verifies the rendered group label and every activity label in addition to activity counts;
- the new metadata test creates an activity with `displayProperties`, opens the Activity inspector, and verifies the configured version label and value.

Existing planning e2e coverage already exercises plan activities inside a Time Strip and the draft status indicator.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? No.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? I do not have permission to add labels from the fork.
* [ ] Have you associated a milestone with this PR? Leaving this for maintainers.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Validation

- Chromium: `Displays all plan events` passed with explicit group/activity-label assertions.
- Chromium: `Displays activity metadata in the inspector when available` passed.
- ESLint, Prettier, and CSpell passed for the changed e2e file.
- `git diff --check` passed.
