### PR TITLE
[Docs] Document limit evaluator return objects

### DIFF
--- a/API.md
+++ b/API.md
@@ -540,6 +540,7 @@ A telemetry provider is a javascript object with up to four methods:
 - `getMetadata(domainObject)` required if `supportsMetadata` is implemented.  Must return a valid telemetry metadata definition that includes at least one valueMetadata definition.
 - `supportsLimits(domainObject)` optional.  Implement and return `true` for domain objects that you want to provide a limit evaluator for.
 - `getLimitEvaluator(domainObject)` required if `supportsLimits` is implemented.  Must return a valid LimitEvaluator for a given domain object.
+- `getLimits(domainObject, options)` optional.  Return an object with a `limits()` method that resolves to limit definitions for display components that render limit lines or limit columns.
 
 Telemetry providers are registered by calling `openmct.telemetry.addProvider(provider)`, e.g.
 
@@ -782,9 +783,49 @@ section.
 Limit evaluators allow a telemetry integrator to define which limits exist for a
 telemetry endpoint and how limits should be applied to telemetry from a given domain object.
 
-A limit evaluator can implement the `evaluate` method which is used to define how limits
-should be applied to telemetry and the `getLimits` method which is used to specify
-what the limit values are for different limit levels.
+A limit evaluator is the object returned by `getLimitEvaluator(domainObject)`.
+It must provide an `evaluate(datum, valueMetadata)` method.  `datum` is the
+telemetry datum being displayed, and `valueMetadata` is the telemetry value
+metadata for the column or series being evaluated.  `evaluate` should return
+`undefined` when the value is nominal, or a limit result object when a value
+should be styled:
+
+```javascript
+{
+    cssClass: 'is-limit--upr is-limit--red',
+    name: 'Red High',
+    low: 0.9,
+    high: Number.POSITIVE_INFINITY
+}
+```
+
+The returned object should include the CSS class or classes to apply in
+`cssClass`, a human-readable `name`, and optional `low` and `high` bounds when
+the violation is threshold-based.
+
+To define the limit values for visualizations, a telemetry provider can also
+implement `getLimits(domainObject, options)`.  It should return an object with a
+`limits()` method.  `limits()` must return a promise that resolves to an object
+keyed by limit level:
+
+```javascript
+{
+    WARNING: {
+        low: {
+            color: 'yellow',
+            value: -0.5
+        },
+        high: {
+            color: 'yellow',
+            value: 0.5
+        }
+    }
+}
+```
+
+If a telemetry object has multiple range values, the `low` and `high` objects
+can include numeric properties keyed by telemetry value metadata keys instead of
+`value`, as shown in the sine wave example.
 
 Limit levels can be mapped to one of 5 colors for visualization:
 `purple`, `red`, `orange`, `yellow` and `cyan`.

--- a/src/api/telemetry/TelemetryAPI.js
+++ b/src/api/telemetry/TelemetryAPI.js
@@ -1020,6 +1020,9 @@ export default class TelemetryAPI {
  * A LimitEvaluator may be used to detect when telemetry values
  * have exceeded nominal conditions.
  *
+ * This is the object returned by a telemetry provider's
+ * `getLimitEvaluator(domainObject)` method.
+ *
  * @interface LimitEvaluator
  */
 
@@ -1027,24 +1030,26 @@ export default class TelemetryAPI {
  * Check for any limit violations associated with a telemetry datum.
  * @method evaluate
  * @param {*} datum the telemetry datum to evaluate
- * @param {TelemetryProperty} the property to check for limit violations
- * @returns {LimitViolation} metadata about
+ * @param {TelemetryProperty} valueMetadata the property to check for limit violations
+ * @returns {LimitViolation|undefined} metadata about
  *          the limit violation, or undefined if a value is within limits
  */
 
 /**
  * A violation of limits defined for a telemetry property.
  * @typedef LimitViolation
- * @property {string} cssClass the class (or space-separated classes) to
+ * @property {string} [cssClass] the class (or space-separated classes) to
  *           apply to display elements for values which violate this limit
- * @property {string} name the human-readable name for the limit violation
- * @property {number} low a lower limit for violation
- * @property {number} high a higher limit violation
+ * @property {string} [name] the human-readable name for the limit violation
+ * @property {number} [low] a lower limit for violation
+ * @property {number} [high] a higher limit violation
  */
 
 /**
- * @typedef {Object} LimitsResponseObject
- * @property {LimitDefinition} limitLevel the level name and it's limit definition
+ * Limit definitions keyed by limit level name. This is the object resolved by
+ * a telemetry provider's `getLimits(domainObject, options).limits()` method.
+ *
+ * @typedef {Object.<string, LimitDefinition>} LimitsResponseObject
  * @example {
  *  [limitLevel]: {
  *    low: {
@@ -1070,7 +1075,9 @@ export default class TelemetryAPI {
  * Limit definition for a Limit of a telemetry property.
  * @typedef LimitDefinitionValue
  * @property {string} color color to represent this limit
- * @property {number} value the limit value
+ * @property {number} [value] the limit value for single-value definitions
+ * Additional numeric properties may be keyed by telemetry value metadata keys
+ * for multi-value definitions.
  */
 
 /**


### PR DESCRIPTION
Closes #8165

### Describe your changes:

- Document the object returned by `getLimitEvaluator(domainObject)` and its `evaluate(datum, valueMetadata)` method.
- Clarify the separate `getLimits(domainObject, options).limits()` response shape used for limit lines and limit columns.
- Update the TelemetryAPI TSDoc typedefs for limit violations and limit definitions.

### Validation

- `npx cspell API.md src/api/telemetry/TelemetryAPI.js --show-context --quiet`
- `npx prettier --check API.md src/api/telemetry/TelemetryAPI.js`
- ESLint for `src/api/telemetry/TelemetryAPI.js` with zero warnings
- `git diff --check`

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there are no other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change? Older overlapping PR #8336 was discovered after this PR was opened.
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? No, this is docs-only.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes? Docs-only validation listed above.
* [x] Has this been smoke tested? Docs-only validation listed above.
* [ ] Have you associated this PR with a `type:` label? I do not have permission to add labels.
* [ ] Have you associated a milestone with this PR? Leaving blank unless maintainers prefer one.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change? Validation listed above.

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?