### PR TITLE
[Fix] Apply Time Conductor mode changes on submit

### DIFF
--- a/e2e/appActions.js
+++ b/e2e/appActions.js
@@ -452,13 +452,13 @@ async function _setTimeConductorMode(page, isFixedTimespan = true) {
   // Switch time conductor mode. Note, need to wait here for URL to update as the router is debounced.
   if (isFixedTimespan) {
     await page.getByRole('menuitem', { name: /Fixed Timespan/ }).click();
+    await page.getByLabel('Submit time bounds').click();
     await page.waitForURL(/tc\.mode=fixed/);
   } else {
     await page.getByRole('menuitem', { name: /Real-Time/ }).click();
+    await page.getByLabel('Submit time offsets').click();
     await page.waitForURL(/tc\.mode=local/);
   }
-  //dismiss the time conductor popup
-  await page.getByLabel('Discard changes and close time popup').click();
 }
 
 /**

--- a/e2e/tests/functional/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/functional/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -225,6 +225,27 @@ test.describe('Time conductor operations', () => {
     await expect(page.getByLabel('Start bounds')).toHaveText(`${DAY} ${ONE_O_CLOCK}.000Z`);
     await expect(page.getByLabel('End bounds')).toHaveText(`${DAY_AFTER} ${ONE_O_CLOCK}.000Z`);
   });
+
+  test('cancelling a mode change keeps the active time conductor mode', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/8258'
+    });
+
+    const globalTimeConductor = page.getByLabel('Global Time Conductor');
+    const activeMode = globalTimeConductor.getByLabel('Time Conductor Mode');
+
+    await expect(activeMode).toHaveText('Fixed Timespan');
+    await activeMode.click();
+    await page.getByRole('button', { name: 'Time Conductor Mode Menu' }).click();
+    await page.getByRole('menuitem', { name: /Real-Time/ }).click();
+
+    await expect(page.getByLabel('Submit time offsets')).toBeVisible();
+    await page.getByLabel('Discard changes and close time popup').click();
+
+    await expect(activeMode).toHaveText('Fixed Timespan');
+    await expect(page).not.toHaveURL(/tc\.mode=local/);
+  });
 });
 
 test.describe('Global Time Conductor', () => {

--- a/e2e/tests/functional/plugins/timeConductor/timeConductor.e2e.spec.js
+++ b/e2e/tests/functional/plugins/timeConductor/timeConductor.e2e.spec.js
@@ -245,6 +245,18 @@ test.describe('Time conductor operations', () => {
 
     await expect(activeMode).toHaveText('Fixed Timespan');
     await expect(page).not.toHaveURL(/tc\.mode=local/);
+
+    await setRealTimeMode(page);
+    await expect(activeMode).toHaveText('Real-Time');
+    await activeMode.click();
+    await page.getByRole('button', { name: 'Time Conductor Mode Menu' }).click();
+    await page.getByRole('menuitem', { name: /Fixed Timespan/ }).click();
+
+    await expect(page.getByLabel('Submit time bounds')).toBeVisible();
+    await page.getByLabel('Discard changes and close time popup').click();
+
+    await expect(activeMode).toHaveText('Real-Time');
+    await expect(page).toHaveURL(/tc\.mode=local/);
   });
 });
 

--- a/src/plugins/timeConductor/ConductorInputsFixed.vue
+++ b/src/plugins/timeConductor/ConductorInputsFixed.vue
@@ -24,8 +24,14 @@
     v-if="shouldUseSplitDateTimeInputs && !readOnly"
     @focus="$event.target.select()"
     @dismiss="dismiss"
+    @submit="submit"
   />
-  <TimePopupFixed v-else-if="!readOnly" @focus="$event.target.select()" @dismiss="dismiss" />
+  <TimePopupFixed
+    v-else-if="!readOnly"
+    @focus="$event.target.select()"
+    @dismiss="dismiss"
+    @submit="submit"
+  />
   <div v-else class="c-compact-tc__setting-wrapper">
     <div
       class="c-compact-tc__setting-value u-fade-truncate--lg --no-sep"
@@ -69,7 +75,7 @@ export default {
       }
     }
   },
-  emits: ['dismiss-inputs-fixed'],
+  emits: ['dismiss-inputs-fixed', 'submit'],
   computed: {
     shouldUseSplitDateTimeInputs() {
       return Boolean(this.timeSystemFormatter.formatDate);
@@ -82,6 +88,9 @@ export default {
     }
   },
   methods: {
+    submit() {
+      this.$emit('submit');
+    },
     dismiss() {
       this.$emit('dismiss-inputs-fixed');
     }

--- a/src/plugins/timeConductor/ConductorInputsRealtime.vue
+++ b/src/plugins/timeConductor/ConductorInputsRealtime.vue
@@ -25,6 +25,7 @@
     :offsets="formattedOffsets"
     @focus="$event.target.select()"
     @dismiss="dismiss"
+    @submit="submit"
   />
   <div v-else class="c-compact-tc__setting-wrapper">
     <div
@@ -86,7 +87,7 @@ export default {
       }
     }
   },
-  emits: ['dismiss-inputs-realtime'],
+  emits: ['dismiss-inputs-realtime', 'submit'],
   computed: {
     formattedOffsets() {
       return {
@@ -99,6 +100,9 @@ export default {
     }
   },
   methods: {
+    submit() {
+      this.$emit('submit');
+    },
     dismiss() {
       this.$emit('dismiss-inputs-realtime');
     }

--- a/src/plugins/timeConductor/ConductorMode.vue
+++ b/src/plugins/timeConductor/ConductorMode.vue
@@ -51,8 +51,15 @@ export default {
       default() {
         return false;
       }
+    },
+    deferChanges: {
+      type: Boolean,
+      default() {
+        return false;
+      }
     }
   },
+  emits: ['mode-selected'],
   data() {
     return {
       selectedMode: this.getModeMetadata(this.timeMode)
@@ -67,6 +74,12 @@ export default {
   },
   mounted() {
     this.modes = this.getAllModeMetadata();
+    if (this.deferChanges) {
+      this.modes = this.modes.map((mode) => ({
+        ...mode,
+        onItemClicked: () => this.selectMode(mode)
+      }));
+    }
   },
   methods: {
     showModesMenu() {
@@ -80,6 +93,10 @@ export default {
       };
 
       this.dismiss = this.openmct.menus.showSuperMenu(x, y, this.modes, menuOptions);
+    },
+    selectMode(mode) {
+      this.selectedMode = mode;
+      this.$emit('mode-selected', mode.key);
     },
     setView() {
       this.selectedMode = this.getModeMetadata(this.timeMode);

--- a/src/plugins/timeConductor/ConductorPopUp.vue
+++ b/src/plugins/timeConductor/ConductorPopUp.vue
@@ -10,6 +10,8 @@
         v-else
         class="c-conductor__mode-select"
         title="Sets the Time Conductor's mode."
+        :defer-changes="true"
+        @mode-selected="setPendingTimeMode"
       />
       <IndependentClock
         v-if="isIndependent"
@@ -28,14 +30,23 @@
         title="Sets the Time Conductor's time system."
       />
     </div>
-    <ConductorInputsFixed v-if="isFixedTimeMode" @dismiss-inputs-fixed="dismiss" />
-    <ConductorInputsRealtime v-else @dismiss-inputs-realtime="dismiss" />
+    <ConductorInputsFixed
+      v-if="isDisplayedFixedTimeMode"
+      @dismiss-inputs-fixed="dismiss"
+      @submit="commitPendingTimeMode"
+    />
+    <ConductorInputsRealtime
+      v-else
+      @dismiss-inputs-realtime="dismiss"
+      @submit="commitPendingTimeMode"
+    />
   </div>
 </template>
 
 <script>
 import { ref } from 'vue';
 
+import { FIXED_MODE_KEY } from '../../api/time/constants.js';
 import ConductorClock from './ConductorClock.vue';
 import ConductorInputsFixed from './ConductorInputsFixed.vue';
 import ConductorInputsRealtime from './ConductorInputsRealtime.vue';
@@ -54,7 +65,7 @@ export default {
     ConductorInputsFixed,
     ConductorInputsRealtime
   },
-  inject: ['openmct', 'isFixedTimeMode'],
+  inject: ['openmct', 'isFixedTimeMode', 'timeContext', 'timeMode'],
   props: {
     positionX: {
       type: Number,
@@ -84,7 +95,15 @@ export default {
       conductorPopupElement
     };
   },
+  data() {
+    return {
+      pendingTimeMode: this.timeMode
+    };
+  },
   computed: {
+    isDisplayedFixedTimeMode() {
+      return this.isIndependent ? this.isFixedTimeMode : this.pendingTimeMode === FIXED_MODE_KEY;
+    },
     position() {
       const position = {
         left: `${this.positionX}px`
@@ -98,7 +117,7 @@ export default {
     },
     popupClasses() {
       const value = this.bottom ? 'c-tc-input-popup--bottom ' : '';
-      const mode = this.isFixedTimeMode ? 'fixed-mode' : 'realtime-mode';
+      const mode = this.isDisplayedFixedTimeMode ? 'fixed-mode' : 'realtime-mode';
       const independentClass = this.isIndependent ? 'itc-popout ' : '';
 
       return `${independentClass}${value}c-tc-input-popup--${mode}`;
@@ -108,6 +127,14 @@ export default {
     this.$emit('popup-loaded');
   },
   methods: {
+    setPendingTimeMode(mode) {
+      this.pendingTimeMode = mode;
+    },
+    commitPendingTimeMode() {
+      if (!this.isIndependent && this.pendingTimeMode !== this.timeMode) {
+        this.timeContext.setMode(this.pendingTimeMode);
+      }
+    },
     dismiss() {
       this.$emit('dismiss');
     }

--- a/src/plugins/timeConductor/DateTimePopupFixed.vue
+++ b/src/plugins/timeConductor/DateTimePopupFixed.vue
@@ -142,7 +142,7 @@ export default {
     'timeSystemDurationFormatter',
     'bounds'
   ],
-  emits: ['update', 'dismiss'],
+  emits: ['update', 'dismiss', 'submit'],
   data() {
     return {
       formattedBounds: {},
@@ -298,6 +298,7 @@ export default {
         return;
       }
 
+      this.$emit('submit');
       this.setBoundsFromView(shouldDismiss);
     },
     validateInput(refNames) {

--- a/src/plugins/timeConductor/TimePopupFixed.vue
+++ b/src/plugins/timeConductor/TimePopupFixed.vue
@@ -104,7 +104,7 @@ export default {
     'timeSystemDurationFormatter',
     'bounds'
   ],
-  emits: ['update', 'dismiss'],
+  emits: ['update', 'dismiss', 'submit'],
   data() {
     return {
       formattedBounds: {},
@@ -214,6 +214,7 @@ export default {
       this.reportValidity('bounds');
 
       if (this.isValid) {
+        this.$emit('submit');
         this.setBoundsFromView(shouldDismiss);
       }
     },

--- a/src/plugins/timeConductor/TimePopupRealtime.vue
+++ b/src/plugins/timeConductor/TimePopupRealtime.vue
@@ -174,7 +174,7 @@ export default {
       required: true
     }
   },
-  emits: ['dismiss'],
+  emits: ['dismiss', 'submit'],
   data() {
     return {
       startInputHrs: '00',
@@ -231,6 +231,8 @@ export default {
       this.isDisabled = disabled;
     },
     submit() {
+      this.$emit('submit');
+
       const formattedStartOffset = [
         this.startInputHrs,
         this.startInputMins,

--- a/src/plugins/timeConductor/pluginSpec.js
+++ b/src/plugins/timeConductor/pluginSpec.js
@@ -129,6 +129,10 @@ describe('time conductor', () => {
       const clickEvent2 = createMouseEvent('click');
       clockItem.dispatchEvent(clickEvent2);
       await nextTick();
+      const submitButton = appHolder.querySelector('[aria-label="Submit time offsets"]');
+      const clickEvent3 = createMouseEvent('click');
+      submitButton.dispatchEvent(clickEvent3);
+      await nextTick();
       await nextTick();
     });
 


### PR DESCRIPTION
Closes #8258

### Describe your changes:

- Keep global Time Conductor mode selections local to the open popup.
- Commit the pending mode only when the user submits the fixed bounds or realtime offsets.
- Leave the active mode and URL unchanged when the popup is discarded.
- Update the shared e2e mode helper and add regression coverage for discarding pending Fixed-to-Real-Time and Real-Time-to-Fixed changes.

### Validation

- Time Conductor e2e spec: 8 passed, 4 existing `fixme` tests skipped.
- Unit suite: 975 passed, 67 skipped.
- Production build and TypeScript compilation passed.
- ESLint, Prettier check, CSpell, and `git diff --check` passed for the changed files.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? No, this restores the existing discard behavior for a popup setting.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? I do not have permission to add labels.
* [ ] Have you associated a milestone with this PR? Leaving this for maintainers.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
