### PR TITLE
docs: add README for the Local Storage plugin

### DIFF
--- a/src/plugins/localStorage/README.md
+++ b/src/plugins/localStorage/README.md
@@ -1,0 +1,27 @@
+# Local Storage plugin
+Provides browser `localStorage` backed persistence for Open MCT domain objects. Installing this plugin registers an object provider that stores domain objects in the browser's `localStorage`, which is useful for development, demos, and deployments without a server side persistence store such as CouchDB.
+
+## Installation
+```js
+openmct.install(openmct.plugins.LocalStorage());
+```
+
+## Options
+When installing, the plugin can take two options:
+
+- `namespace`: The namespace the object provider is registered under. Defaults to the empty string `''`
+  - Example: `'local-namespace'`
+
+- `storageSpace`: The `localStorage` key under which all objects are persisted. Defaults to `'mct'`
+  - Example: `'my-mct-space'`
+
+E.g., to install with a custom namespace and storage key, you could use:
+
+```js
+openmct.install(openmct.plugins.LocalStorage('local-namespace', 'my-mct-space'));
+```
+
+## Notes
+- Every object in a storage space is serialized into a single `localStorage` entry, so total capacity is bound by the browser's `localStorage` quota.
+- Objects are editable. The provider reports `isReadOnly()` as `false`.
+- For shared, multi user, or larger deployments, use a server backed provider such as the CouchDB persistence plugin instead.


### PR DESCRIPTION
Closes #8099

### Describe your changes:

The Local Storage plugin under `src/plugins/localStorage` shipped without a README, even though most sibling plugins in `src/plugins` include one (for example `myItems`, `plan`, and `persistence/couch`). Local Storage is one of the first persistence providers people reach for during development and demos, so the missing doc was a real gap for anyone browsing the source.

This adds `src/plugins/localStorage/README.md` in the same format as the existing plugin READMEs. It documents what the plugin does, how to install it, and the two options its factory accepts. The content comes straight from the source: the factory in `plugin.js` accepts `namespace` (defaults to the empty string `''`) and `storageSpace` (defaults to `'mct'`), and `LocalStorageObjectProvider` serializes every object in a space into a single `localStorage` entry and is writable, with `isReadOnly()` returning `false`.

Docs only, no code or behavior changes. The layout and tone mirror the `myItems` and CouchDB persistence READMEs so it reads consistently with the rest of the plugins directory.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins? No, this only adds documentation.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes? N/A, this is a documentation-only change with no code to test.
* [ ] Has this been smoke tested? N/A, documentation only. I verified the file renders and matches the format of the existing plugin READMEs.
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue. Happy for a maintainer to apply `type: documentation`.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change? N/A, documentation only.

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
