### PR TITLE
docs: fix broken links in TESTING.md and docs index

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -63,7 +63,7 @@ Once the file is generated, it can be published to codecov with
 ### e2e
 The e2e line coverage is a bit more complex than the karma implementation. This is the general sequence of events:
 
-1. Each e2e suite will start webpack with the ```npm run start:coverage``` command with config `webpack.coverage.mjs` and the `babel-plugin-istanbul` plugin to generate code coverage during e2e test execution using our custom [baseFixture](./baseFixtures.js). 
+1. Each e2e suite will start webpack with the ```npm run start:coverage``` command with config `webpack.coverage.mjs` and the `babel-plugin-istanbul` plugin to generate code coverage during e2e test execution using our custom [baseFixture](./e2e/baseFixtures.js). 
 1. During testcase execution, each e2e shard will generate its piece of the larger coverage suite. **This coverage file is not merged**. The raw coverage file is stored in a `.nyc_report` directory.
 1. [nyc](https://github.com/istanbuljs/nyc) converts this directory into a `lcov` file with the following command `npm run cov:e2e:report`
 1. Most of the tests focus on chrome/ubuntu at a single resolution. This coverage is published to codecov with `npm run cov:e2e:ci:publish`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@
 
 ## Sections
 
-* The [API](api/) uses inline documentation.
+* The [API](../../src/api/) uses inline documentation.
  using [TypeScript](https://www.typescriptlang.org) and some legacy [JSDoc](https://jsdoc.app/). It describes the JavaScript objects and
  functions that make up the software platform.
 


### PR DESCRIPTION
Fixes two broken links (mechanical link audit; targets verified to exist):

- `TESTING.md` — `[baseFixture](./baseFixtures.js)` → `./e2e/baseFixtures.js` (the fixture lives in the e2e directory)
- `docs/src/index.md` — `[API](api/)` resolves to `docs/src/api`, which doesn't exist; the inline-documented API sources are at `src/api/` → `../../src/api/`

Also found but **not** fixed (no verifiable successor in-repo — flagging for maintainers):
- `docs/src/process/testing/plan.md` links `procedures.md` (2×), which no longer exists anywhere in the repo
- `src/plugins/staticRootPlugin/README.md` links `platform/import-export/README.md`; the `platform/` tree has been removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)