### PR TITLE
Fix telemetry table in-place update precedence

### DIFF
--- a/src/plugins/telemetryTable/collections/TableRowCollection.js
+++ b/src/plugins/telemetryTable/collections/TableRowCollection.js
@@ -138,9 +138,15 @@ export default class TableRowCollection extends EventEmitter {
    * @param {number} index of the existing row in the collection to update
    */
   updateRowInPlace(incomingRow, index) {
-    // Update the incoming row, not the existing row
     const existingRow = this.rows[index];
-    incomingRow.updateWithDatum(existingRow);
+    incomingRow.datum = {
+      ...existingRow.datum,
+      ...incomingRow.datum
+    };
+    incomingRow.fullDatum = {
+      ...existingRow.fullDatum,
+      ...incomingRow.fullDatum
+    };
 
     // Replacing the existing row with the updated, incoming row will trigger Vue reactivity
     // because the reference to the row has changed

--- a/src/plugins/telemetryTable/pluginSpec.js
+++ b/src/plugins/telemetryTable/pluginSpec.js
@@ -276,21 +276,27 @@ describe('the plugin', () => {
       expect(rows.length).toBe(3);
     });
 
-    it('Adds a row in place when updating with existing telemetry', async () => {
+    it('Updates a row in place with the latest telemetry', async () => {
       let rows = element.querySelectorAll('table.c-telemetry-table__body tr');
       await nextTick();
       expect(rows.length).toBe(3);
+      const existingRow = tableInstance.tableRows.rows[1];
+
       // fire some telemetry
       const newTelemetry = {
         utc: 2,
-        'some-key': 'some-value 2',
         'some-other-key': 'spacecraft'
       };
       spyOn(tableInstance.tableRows, 'getInPlaceUpdateIndex').and.returnValue(1);
       spyOn(tableInstance.tableRows, 'updateRowInPlace').and.callThrough();
       telemetryCallback(newTelemetry);
+      await nextTick();
 
       expect(tableInstance.tableRows.updateRowInPlace.calls.count()).toBeGreaterThan(0);
+      const updatedRow = tableInstance.tableRows.rows[1];
+      expect(updatedRow).not.toBe(existingRow);
+      expect(updatedRow.datum['some-key']).toBe('some-value 2');
+      expect(updatedRow.datum['some-other-key']).toBe('spacecraft');
     });
 
     it('Renders a column for every item in telemetry metadata', () => {


### PR DESCRIPTION
Closes #8377

### Describe your changes:

In-place telemetry table updates now merge existing row data first and incoming row data second, so the latest values take precedence while fields omitted from a partial update are retained. The collection still replaces the row with the incoming object reference to preserve Vue reactivity.

The existing integration test now verifies all three invariants: the row reference changes, existing fields survive partial updates, and incoming values overwrite stale values.

### Testing:

- `npm run build`
- `npm test` - 975 successful, 67 skipped
- `npm run lint`

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? No, this is a focused bug fix with no API change.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?