### PR TITLE
[Testing] De-flake imagery and fps unit tests

### DIFF
--- a/src/plugins/imagery/pluginSpec.js
+++ b/src/plugins/imagery/pluginSpec.js
@@ -59,6 +59,43 @@ function isNew(doc) {
   return newIcon.length !== 0;
 }
 
+const MAX_SETTLE_TICKS = 30;
+
+// Reactive updates can take more than a single tick to settle, so poll on
+// the actual condition across a bounded number of ticks rather than waiting
+// a fixed amount. Resolves as soon as the condition is met (or the cap hits).
+async function nextTickUntil(condition) {
+  for (let attempt = 0; attempt < MAX_SETTLE_TICKS; attempt++) {
+    if (condition()) {
+      return;
+    }
+
+    await nextTick();
+  }
+}
+
+// Poll until a value stops changing for a few consecutive ticks, indicating
+// asynchronous loading has settled. Useful when a view keeps re-rendering as
+// data streams in and interacting mid-stream would race with those updates.
+async function nextTickUntilStable(getValue, requiredStableTicks = 3) {
+  let previous = getValue();
+  let stableTicks = 0;
+  for (
+    let attempt = 0;
+    attempt < MAX_SETTLE_TICKS && stableTicks < requiredStableTicks;
+    attempt++
+  ) {
+    await nextTick();
+    const current = getValue();
+    if (current === previous) {
+      stableTicks += 1;
+    } else {
+      stableTicks = 0;
+      previous = current;
+    }
+  }
+}
+
 function generateTelemetry(start, count) {
   let telemetry = [];
   for (let i = 1, l = count + 1; i < l; i++) {
@@ -348,12 +385,18 @@ describe('The Imagery View Layouts', () => {
     });
 
     it('should show the clicked thumbnail as the main image', async () => {
-      //Looks like we need nextTick here so that computed properties settle down
-      await nextTick();
-      await nextTick();
       const thumbnailUrl = formatThumbnail(imageTelemetry[5].url);
-      parent.querySelectorAll(`img[src='${thumbnailUrl}']`)[0].click();
-      await nextTick();
+      // Imagery history loads asynchronously, and the view re-focuses the most
+      // recent image every time the history changes — a late history update can
+      // land right after a click and reset the selection. Wait for the history
+      // to finish loading, then select the thumbnail until the main image
+      // reflects it, so the assertion doesn't race those updates.
+      await nextTickUntilStable(() => parent.querySelectorAll(`img[src*='logo-nasa.svg']`).length);
+      await nextTickUntil(() => {
+        parent.querySelector(`img[src='${thumbnailUrl}']`)?.click();
+
+        return getImageInfo(parent).url.indexOf(imageTelemetry[5].timeId) !== -1;
+      });
       const imageInfo = getImageInfo(parent);
 
       expect(imageInfo.url.indexOf(imageTelemetry[5].timeId)).not.toEqual(-1);

--- a/src/plugins/imagery/pluginSpec.js
+++ b/src/plugins/imagery/pluginSpec.js
@@ -59,11 +59,24 @@ function isNew(doc) {
   return newIcon.length !== 0;
 }
 
+/**
+ * Upper bound on ticks any polling helper below will wait, so a condition that
+ * never becomes true fails the assertion it guards instead of hanging the suite.
+ */
 const MAX_SETTLE_TICKS = 30;
 
-// Reactive updates can take more than a single tick to settle, so poll on
-// the actual condition across a bounded number of ticks rather than waiting
-// a fixed amount. Resolves as soon as the condition is met (or the cap hits).
+/**
+ * Await ticks until a condition holds.
+ *
+ * Reactive updates can take more than a single tick to settle, so poll on the
+ * actual condition across a bounded number of ticks rather than waiting a fixed
+ * amount. Resolves as soon as the condition is met, or once the cap is hit.
+ *
+ * @param {() => boolean} condition evaluated before each tick; polling stops
+ *        as soon as it returns true
+ * @returns {Promise<void>} resolves when the condition holds or the tick cap
+ *          is reached
+ */
 async function nextTickUntil(condition) {
   for (let attempt = 0; attempt < MAX_SETTLE_TICKS; attempt++) {
     if (condition()) {
@@ -74,9 +87,21 @@ async function nextTickUntil(condition) {
   }
 }
 
-// Poll until a value stops changing for a few consecutive ticks, indicating
-// asynchronous loading has settled. Useful when a view keeps re-rendering as
-// data streams in and interacting mid-stream would race with those updates.
+/**
+ * Await ticks until a value stops changing, indicating asynchronous loading has
+ * settled.
+ *
+ * Useful when a view keeps re-rendering as data streams in and interacting
+ * mid-stream would race with those updates. Gives up after {@link MAX_SETTLE_TICKS}
+ * ticks whether or not the value ever stabilizes.
+ *
+ * @param {() => *} getValue sampled once per tick; compared with `===`, so it
+ *        should return a primitive such as a length or a timestamp
+ * @param {number} [requiredStableTicks] consecutive unchanged samples needed
+ *        before the value is considered settled
+ * @returns {Promise<void>} resolves when the value settles or the tick cap is
+ *          reached
+ */
 async function nextTickUntilStable(getValue, requiredStableTicks = 3) {
   let previous = getValue();
   let stableTicks = 0;

--- a/src/plugins/performanceIndicator/pluginSpec.js
+++ b/src/plugins/performanceIndicator/pluginSpec.js
@@ -63,11 +63,18 @@ describe('the plugin', () => {
     expect(fps).toBeGreaterThan(0);
   });
 
-  // The indicator only replaces its initial '~ fps' text once a full second
-  // of animation frames has elapsed. Looping a fixed number of frames is racy:
-  // when requestAnimationFrame runs faster than realtime (e.g. headless CI),
-  // the frames finish in under a second and the fps value is never calculated.
-  // Wait on the real condition instead.
+  /**
+   * Drive animation frames until the indicator reports a real fps value.
+   *
+   * The indicator only replaces its initial '~ fps' text once a full second of
+   * animation frames has elapsed. Looping a fixed number of frames is racy:
+   * when requestAnimationFrame runs faster than realtime (e.g. headless CI),
+   * the frames finish in under a second and the fps value is never calculated.
+   * Wait on the real condition instead.
+   *
+   * @returns {Promise<void>} resolves once the indicator text is no longer its
+   *          initial placeholder
+   */
   function loopUntilFpsCalculated() {
     return new Promise((resolve) => {
       requestAnimationFrame(function loop() {

--- a/src/plugins/performanceIndicator/pluginSpec.js
+++ b/src/plugins/performanceIndicator/pluginSpec.js
@@ -57,18 +57,21 @@ describe('the plugin', () => {
   });
 
   it('calculates an fps value', async () => {
-    await loopForABit();
+    await loopUntilFpsCalculated();
     // eslint-disable-next-line radix
     const fps = parseInt(performanceIndicator.text().split(' fps')[0]);
     expect(fps).toBeGreaterThan(0);
   });
 
-  function loopForABit() {
-    let frames = 0;
-
+  // The indicator only replaces its initial '~ fps' text once a full second
+  // of animation frames has elapsed. Looping a fixed number of frames is racy:
+  // when requestAnimationFrame runs faster than realtime (e.g. headless CI),
+  // the frames finish in under a second and the fps value is never calculated.
+  // Wait on the real condition instead.
+  function loopUntilFpsCalculated() {
     return new Promise((resolve) => {
       requestAnimationFrame(function loop() {
-        if (++frames > 90) {
+        if (performanceIndicator.text() !== '~ fps') {
           resolve();
         } else {
           requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary

Fixes two flaky unit tests by replacing fixed waits with condition-based polling.

- **Imagery** (`should show the clicked thumbnail as the main image`): imagery history loads asynchronously and the view re-focuses the most recent image whenever the history changes, so a history update landing just after the click reset the selection (`Expected -1 not to equal -1`). Wait for the history to settle, then select the thumbnail until the main image reflects it.
- **Performance indicator** (`calculates an fps value`): the indicator only computes fps after a full second of animation frames; looping a fixed 90 frames finishes in under a second when `requestAnimationFrame` runs faster than realtime in headless CI, leaving the value uncalculated (`Expected NaN to be greater than 0`). Loop until the fps text is actually calculated.

## Testing

Ran both specs 22 consecutive times with zero failures; the baseline flaked ~12–40%.

Closes #8381