### PR TITLE
[Search] Show the annotated object's type icon in annotation search results

### DIFF
--- a/src/ui/layout/search/AnnotationSearchResult.vue
+++ b/src/ui/layout/search/AnnotationSearchResult.vue
@@ -97,7 +97,7 @@ export default {
       }
     },
     resultTypeIcon() {
-      return this.openmct.types.get(this.result.type).definition.cssClass;
+      return this.openmct.types.get(this.domainObject.type).definition.cssClass;
     },
     tagBackgroundColor() {
       return this.result.fullTagModels[0].backgroundColor;

--- a/src/ui/layout/search/GrandSearchSpec.js
+++ b/src/ui/layout/search/GrandSearchSpec.js
@@ -36,6 +36,7 @@ describe('GrandSearch', () => {
   let sharedWorkerToRestore;
   let mockDomainObject;
   let mockAnnotationObject;
+  let mockLayoutAnnotationObject;
   let mockDisplayLayout;
   let mockFolderObject;
   let mockAnotherFolderObject;
@@ -108,6 +109,7 @@ describe('GrandSearch', () => {
       type: 'layout',
       name: 'Bar Layout',
       composition: [],
+      location: 'fooNameSpace:topObject',
       identifier: {
         key: 'some-layout',
         namespace: 'fooNameSpace'
@@ -130,6 +132,21 @@ describe('GrandSearch', () => {
         {
           keyString: 'fooNameSpace:some-object',
           entryId: 'fooBarEntry'
+        }
+      ]
+    };
+    mockLayoutAnnotationObject = {
+      type: 'annotation',
+      name: 'Some Layout Annotation',
+      annotationType: openmct.annotation.ANNOTATION_TYPES.PLOT_SPATIAL,
+      tags: [availableTags[2].id],
+      identifier: {
+        key: 'aLayoutAnnotationKey',
+        namespace: 'fooNameSpace'
+      },
+      targets: [
+        {
+          keyString: 'fooNameSpace:some-layout'
         }
       ]
     };
@@ -168,6 +185,8 @@ describe('GrandSearch', () => {
         return mockTopObject;
       } else if (identifier.key === mockNewObject.identifier.key) {
         return mockNewObject;
+      } else if (identifier.key === mockLayoutAnnotationObject.identifier.key) {
+        return mockLayoutAnnotationObject;
       } else {
         return null;
       }
@@ -283,6 +302,18 @@ describe('GrandSearch', () => {
     const annotationResults = document.querySelectorAll('[aria-label="Annotation Search Result"]');
     expect(annotationResults.length).toBe(1);
     expect(annotationResults[0].innerText).toContain('Driving');
+  });
+
+  it('should render an annotation search result with the icon of the annotated object type', async () => {
+    await openmct.objects.inMemorySearchProvider.index(mockLayoutAnnotationObject);
+    await grandSearchComponent.$refs.root.searchEverything('Drilling');
+    await nextTick();
+    const annotationResults = document.querySelectorAll('[aria-label="Annotation Search Result"]');
+    expect(annotationResults.length).toBe(1);
+    expect(annotationResults[0].innerText).toContain('Bar Layout');
+    const typeIcon = annotationResults[0].querySelector('.c-gsearch-result__type-icon');
+    expect(typeIcon.classList.contains('icon-layout')).toBeTrue();
+    expect(typeIcon.classList.contains('icon-notebook')).toBeFalse();
   });
 
   it('should render no annotation search results if no match', async () => {


### PR DESCRIPTION
Closes #8322

### Describe your changes:

Annotation search results always showed the notebook icon, no matter what kind of object the annotation was attached to, an annotation on an image, plot, or display layout still looked like a notebook entry (see the screenshot in #8322).

This happened because the search result row asked the annotation itself for its icon, and every annotation has the same registered type (`annotation`), whose icon is the notebook. The row now asks the annotated object (`targetModels[0]`) for its type icon instead, so each result shows the icon of the thing it actually points to. If the target's type isn't registered, the type registry already falls back to the generic "unknown object" icon, so nothing can break.

Changes:

* `src/ui/layout/search/AnnotationSearchResult.vue` - one line: derive the type icon from the annotated object instead of the annotation.
* `src/ui/layout/search/GrandSearchSpec.js` - new unit test: an annotation targeting a Display Layout must render the layout icon and must not render the notebook icon (this test fails on `master`).

How to test:

1. Add a tag to an annotation on any non-notebook object (e.g. annotate a region of an imagery view or a plot, or tag one via `openmct.annotation.create` with a Display Layout target).
2. Type the tag's name into the top search bar.
3. The annotation result now shows that object's type icon; before this change it always showed the notebook icon. Notebook entry annotations still show the notebook icon, as before.

Smoke tested locally against the dev server: an annotation on a Display Layout, found by tag search, renders the Display Layout icon with its tag chip.

### Screenshots

Searching the "Drilling" tag ; one annotation on a Display Layout, one on a Notebook entry.

**Before**  every annotation row shows the notebook icon regardless of the annotated object (the breadcrumb under the first row shows the icon it should have had):

<img width="1046" height="376" alt="Before: both annotation results show the notebook icon" src="https://github.com/user-attachments/assets/c49c63c8-718e-4131-ba2c-4dfb1e5d16db" />

**After**  the Display Layout annotation shows the layout icon; the notebook-entry annotation correctly keeps the notebook icon:

<img width="1046" height="376" alt="After: each annotation result shows its target object&#39;s type icon" src="https://github.com/user-attachments/assets/f50126a8-4280-4531-b81d-3d06ec48e985" />

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change? (Testing steps are in this description instead — the issue has none.)

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?

