### PR TITLE
[Plot] Release axis listeners on unmount

### DIFF
--- a/src/plugins/plot/axis/XAxis.vue
+++ b/src/plugins/plot/axis/XAxis.vue
@@ -79,6 +79,7 @@ export default {
   },
   beforeUnmount() {
     this.openmct.time.off('timeSystemChanged', this.syncXAxisToTimeSystem);
+    this.stopListening();
   },
   methods: {
     isEnabledXKeyToggle() {

--- a/src/plugins/plot/axis/YAxis.vue
+++ b/src/plugins/plot/axis/YAxis.vue
@@ -158,6 +158,9 @@ export default {
     this.loaded = true;
     this.setUpYAxisOptions();
   },
+  beforeUnmount() {
+    this.stopListening();
+  },
   methods: {
     initAxisAndSeriesConfig() {
       const configId = this.openmct.objects.makeKeyString(this.domainObject.identifier);
@@ -173,7 +176,7 @@ export default {
 
         this.config = config;
         this.listenTo(this.config.series, 'add', this.addSeries, this);
-        this.listenTo(this.config.series, 'remove', this.removeSeries, this);
+        this.listenTo(this.config.series, 'remove', this.seriesRemovedFromPlot, this);
         this.listenTo(this.config.series, 'reorder', this.addOrRemoveSeries, this);
 
         this.config.series.models.forEach(this.addSeries, this);
@@ -201,6 +204,16 @@ export default {
 
       this.listenTo(series, 'change:yAxisId', this.addOrRemoveSeries.bind(this, series), this);
       this.listenTo(series, 'change:color', this.updateSeriesColors.bind(this, series), this);
+    },
+    /**
+     * The series is gone from the plot for good, so release the per-series
+     * listeners registered in addSeries. Distinct from removeSeries, which also
+     * runs when a series merely moves to another y-axis and must keep listening
+     * for it moving back.
+     */
+    seriesRemovedFromPlot(plotSeries) {
+      this.removeSeries(plotSeries);
+      this.stopListening(plotSeries);
     },
     removeSeries(plotSeries) {
       const seriesIndex = this.seriesModels.findIndex((model) =>

--- a/src/plugins/plot/axis/YAxisLeakSpec.js
+++ b/src/plugins/plot/axis/YAxisLeakSpec.js
@@ -1,0 +1,193 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+import mount from 'utils/mount';
+import { nextTick } from 'vue';
+
+import { createOpenMct, resetApplicationState } from '../../../utils/testing.js';
+import configStore from '../configuration/ConfigStore.js';
+import PlotConfigurationModel from '../configuration/PlotConfigurationModel.js';
+import YAxis from './YAxis.vue';
+
+const PLOT_KEY = 'y-axis-leak-plot';
+
+/**
+ * Count listeners registered per event name on an eventemitter3 emitter.
+ * @returns {Object<string, number>}
+ */
+function listenerCounts(emitter) {
+  const counts = {};
+  Object.keys(emitter._events ?? {}).forEach((event) => {
+    const handlers = emitter._events[event];
+    counts[event] = Array.isArray(handlers) ? handlers.length : 1;
+  });
+
+  return counts;
+}
+
+/**
+ * Minimal stand-in for PlotSeries: YAxis only reads a few keys off it and
+ * registers listeners on it.
+ * @param {number} yAxisId
+ */
+function makeFakeSeries(yAxisId) {
+  const values = {
+    yAxisId,
+    yKey: 'some-key',
+    identifier: { namespace: '', key: 'y-axis-leak-telemetry' },
+    color: { asHexString: () => '#ffffff' },
+    name: 'Test Telemetry'
+  };
+
+  return {
+    get: (key) => values[key],
+    set: (key, value) => {
+      values[key] = value;
+    },
+    on() {},
+    off() {}
+  };
+}
+
+describe('The YAxis component', () => {
+  let openmct;
+  let config;
+  let plotObject;
+  let telemetryObject;
+  let element;
+
+  beforeEach((done) => {
+    openmct = createOpenMct();
+
+    telemetryObject = {
+      identifier: { namespace: '', key: 'y-axis-leak-telemetry' },
+      type: 'test-object',
+      name: 'Test Telemetry',
+      telemetry: {
+        values: [
+          { key: 'utc', format: 'utc', name: 'Time', hints: { domain: 1 } },
+          { key: 'some-key', name: 'Some attribute', hints: { range: 1 } }
+        ]
+      }
+    };
+
+    plotObject = {
+      identifier: { namespace: '', key: PLOT_KEY },
+      type: 'telemetry.plot.overlay',
+      name: 'Leak Test Plot',
+      composition: [],
+      configuration: { series: [], yAxis: {}, xAxis: {} }
+    };
+
+    spyOn(openmct.telemetry, 'getMetadata').and.returnValue({
+      valuesForHints: () => [{ key: 'some-key', name: 'Some attribute', unit: 'm' }],
+      values: () => telemetryObject.telemetry.values
+    });
+    spyOn(openmct.telemetry, 'getFormatMap').and.returnValue({});
+
+    config = new PlotConfigurationModel({
+      id: PLOT_KEY,
+      domainObject: plotObject,
+      openmct
+    });
+    configStore.add(PLOT_KEY, config);
+
+    element = document.createElement('div');
+    document.body.appendChild(element);
+
+    openmct.on('start', done);
+    openmct.startHeadless();
+  });
+
+  afterEach(() => {
+    configStore.deleteStore(PLOT_KEY);
+    element.remove();
+
+    return resetApplicationState(openmct);
+  });
+
+  function mountYAxis() {
+    return mount(
+      {
+        components: { YAxis },
+        provide: { openmct, domainObject: plotObject, objectPath: [plotObject] },
+        template: '<YAxis :id="1" ref="root" />'
+      },
+      { element }
+    );
+  }
+
+  it('releases its series-collection listeners when unmounted', async () => {
+    const baseline = listenerCounts(config.series);
+
+    for (let i = 0; i < 3; i++) {
+      const { destroy } = mountYAxis();
+      await nextTick();
+      destroy();
+      await nextTick();
+    }
+
+    // Mounting and unmounting must not accumulate listeners on the
+    // long-lived SeriesCollection held by the ConfigStore.
+    expect(listenerCounts(config.series)).toEqual(baseline);
+  });
+
+  it('does not retain a series after it is removed from the plot', async () => {
+    const { vNode, destroy } = mountYAxis();
+    await nextTick();
+
+    const yAxisComponent = vNode.componentInstance.$refs.root;
+    const series = makeFakeSeries(1);
+
+    yAxisComponent.addSeries(series);
+    expect(yAxisComponent._listeningTo.some((l) => l.object === series)).toBe(true);
+
+    // A genuine removal from the plot must release the per-series listeners,
+    // otherwise the mounted axis retains the dead series forever.
+    yAxisComponent.seriesRemovedFromPlot(series);
+    expect(yAxisComponent._listeningTo.some((l) => l.object === series)).toBe(false);
+
+    destroy();
+  });
+
+  it('keeps listening to a series that only moved to another y-axis', async () => {
+    const { vNode, destroy } = mountYAxis();
+    await nextTick();
+
+    const yAxisComponent = vNode.componentInstance.$refs.root;
+    const series = makeFakeSeries(1);
+
+    yAxisComponent.addSeries(series);
+
+    // Move to y-axis 2. The axis must keep its change:yAxisId listener so it
+    // can learn if the series comes back.
+    series.set('yAxisId', 2);
+    yAxisComponent.addOrRemoveSeries(series);
+    expect(yAxisComponent._listeningTo.some((l) => l.object === series)).toBe(true);
+
+    // Move back to y-axis 1 - the axis must pick it up again.
+    series.set('yAxisId', 1);
+    yAxisComponent.addOrRemoveSeries(series);
+    expect(yAxisComponent.seriesModels).toContain(series);
+
+    destroy();
+  });
+});

--- a/src/plugins/plot/chart/MctChart.vue
+++ b/src/plugins/plot/chart/MctChart.vue
@@ -467,6 +467,7 @@ export default {
       this.scheduleDraw(true);
     },
     destroy() {
+      this.stopListening();
       this.destroyCanvas();
       this.isDestroyed = true;
       this.lines.forEach((line) => line.destroy());


### PR DESCRIPTION
Closes #8387

### Describe your changes:
Release axis listeners on unmount
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [x] Changes appear to address issue?
* [x] Reviewer has tested changes by following the provided instructions?
* [x] Changes appear not to be breaking changes?
* [x] Appropriate automated tests included?
* [x] Code style and in-line documentation are appropriate?

## Summary

Three plot components use the `eventHelpers` `listenTo`/`stopListening` pair but never released their listeners. The emitters they listen to (`config.series`, `config.xAxis`) live in the module-level `ConfigStore`, which outlives individual views.

`XAxis` and `YAxis` are gated on series count — `YAxis` via `yAxesIds` (filters `seriesCount > 0`), `XAxis` via `seriesModels.length` — so they **remount on every telemetry add/remove**. Each cycle orphaned one listener per emitter, and the bound callback retained the dead component, its `seriesModels`, and its DOM subtree.

| File | Problem |
| --- | --- |
| `src/plugins/plot/axis/YAxis.vue` | No unmount hook at all; leaked `add`/`remove`/`reorder` on `config.series`. Also never released the per-series listeners registered in `addSeries`. |
| `src/plugins/plot/axis/XAxis.vue` | `beforeUnmount` existed but only removed the time listener, not `xAxis` `'change'`. |
| `src/plugins/plot/chart/MctChart.vue` | `destroy()` omitted `stopListening()`. Stays mounted for the view's lifetime, so it leaks per plot-view navigation rather than per add/remove. |

Every other component in the plugin already calls `stopListening()` on teardown, so this brings these three in line with the existing convention.

## The one subtle part

`YAxis.removeSeries` has two callers, and only one of them means "this series is gone":

- the `config.series` `'remove'` event — the series really was removed from the plot
- `addOrRemoveSeries` — the series merely **moved to a different y-axis** and is still alive

Releasing the per-series listeners in `removeSeries` itself looks correct but breaks the second case: it drops the `change:yAxisId` listener, which is the axis's only way to learn the series came back. Moving a series from Y1 to Y2 and back then leaves it orphaned from both axes (reproducible on any plot with two or more series on an axis — with a single series the axis unmounts and remounts, which masks it).

So the cleanup lives in a new `seriesRemovedFromPlot` handler wired to the `'remove'` event, and `removeSeries` keeps listening.

## Verification

Reproduced with a scripted add/remove loop against an overlay plot, five cycles, comparing stock against this branch.

Listener counts on the long-lived emitters, per cycle:

| Listener | before | after |
| --- | --- | --- |
| `config.series` `'add'` | 9 → 14 (+1/cycle) | flat |
| `config.series` `'remove'` | 9 → 14 (+1/cycle) | flat |
| `config.series` `'reorder'` | 1 → 6 (+1/cycle) | flat |
| `config.xAxis` `'change'` | 2 → 7 (+1/cycle) | flat |

Reachable `PlotSeries` instances in a post-GC heap snapshot, measured on a clean page with no instrumentation installed. Identical scenario on both builds: two series live throughout, a third added and removed five times.

| Build | reachable `PlotSeries`, baseline → after 5 cycles |
| --- | --- |
| `master` | 2 → **7** (+1 per cycle) |
| this branch | 2 → **2** (flat) |

Retaining path on a stock orphan: `PlotSeries` ← `seriesModels` on a still-mounted component ← component `ctx` ← live DOM.

## Tests

`YAxisLeakSpec.js` adds three specs. I ran them against unmodified `master` with the spec file dropped in, to see what each one actually discriminates:

| Spec | on `master` | on this branch | What it guards |
| --- | --- | --- | --- |
| releases its series-collection listeners when unmounted | **fails** — `Expected object not to have properties: reorder: 3` | passes | The leak itself: three orphaned `reorder` listeners after three mount/unmount cycles, i.e. +1 per cycle. |
| does not retain a series after it is removed from the plot | fails — `TypeError: yAxisComponent.seriesRemovedFromPlot is not a function` | passes | The new handler. It cannot run on `master`, where that method does not exist, so this is a behavioural guard rather than evidence of the leak. |
| keeps listening to a series that only moved to another y-axis | passes | passes | The regression described above, which the naive fix would introduce. |

Worth being precise about: only the first is a discriminating leak test. The other two guard behaviour introduced by this PR.

Unit suite on this branch: **976 passing, 2 failing**. Both failures are pre-existing and unrelated to this change:

- `performanceIndicator` "calculates an fps value" — known flake, tracked in #8381 and fixed by #8382.
- `The Imagery View Layouts` "imagery view should show the clicked thumbnail as the main image" — arrives with #8333, this branch's parent commit, and fails there independently.
