### PR TITLE
[a11y] LAD drop feedback + DropHint a11y

### DIFF
--- a/e2e/tests/functional/plugins/lad/lad.e2e.spec.js
+++ b/e2e/tests/functional/plugins/lad/lad.e2e.spec.js
@@ -262,7 +262,7 @@ test.describe('Testing LAD table', () => {
     // Expand the 'My Items' folder in the left tree
     await page.getByLabel('Expand My Items').click();
     // Add the Sine Wave Generator to the LAD table and save changes
-    await page.getByLabel('Preview Test Sine Wave').dragTo(page.locator('#lad-table-drop-area'));
+    await page.getByLabel('Preview Test Sine Wave').dragTo(page.locator('.js-lad-table'));
     await page.getByRole('button', { name: 'Save' }).click();
     await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
 
@@ -290,7 +290,7 @@ test.describe('Testing LAD table', () => {
     // Expand the 'My Items' folder in the left tree
     await page.getByLabel('Expand My Items').click();
     // Add the Sine Wave Generator to the LAD table and save changes
-    await page.getByLabel('Preview Test Sine Wave').dragTo(page.locator('#lad-table-drop-area'));
+    await page.getByLabel('Preview Test Sine Wave').dragTo(page.locator('.js-lad-table'));
     await page.getByRole('button', { name: 'Save' }).click();
     await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
 

--- a/src/plugins/LADTable/components/LadTable.vue
+++ b/src/plugins/LADTable/components/LadTable.vue
@@ -22,8 +22,7 @@
 
 <template>
   <div
-    id="lad-table-drop-area"
-    class="c-lad-table-wrapper u-style-receiver js-style-receiver"
+    class="c-lad-table-wrapper u-style-receiver js-style-receiver js-lad-table"
     :class="[staleClass, { 'is-dragging': isDragging, 'is-mouse-over': isMouseOver }]"
   >
     <div

--- a/src/plugins/LADTable/components/LadTable.vue
+++ b/src/plugins/LADTable/components/LadTable.vue
@@ -34,7 +34,7 @@
       @dragenter="dragenter"
       @dragleave="dragleave"
     ></div>
-    <div v-if="items.length === 0" class="c-lad-table__empty-message">
+    <div v-if="items.length === 0 && !domainObject.locked" class="c-lad-table__empty-message">
       Drag telemetry objects here to add them to this table.
     </div>
     <table class="c-table c-lad-table" :class="applyLayoutClass">

--- a/src/plugins/LADTable/components/LadTable.vue
+++ b/src/plugins/LADTable/components/LadTable.vue
@@ -24,8 +24,19 @@
   <div
     id="lad-table-drop-area"
     class="c-lad-table-wrapper u-style-receiver js-style-receiver"
-    :class="staleClass"
+    :class="[staleClass, { 'is-dragging': isDragging, 'is-mouse-over': isMouseOver }]"
   >
+    <div
+      class="c-drop-hint"
+      :role="isDragging ? 'region' : null"
+      :aria-label="isDragging ? 'Drop telemetry here to add it to this LAD table' : null"
+      :aria-hidden="isDragging ? null : 'true'"
+      @dragenter="dragenter"
+      @dragleave="dragleave"
+    ></div>
+    <div v-if="items.length === 0" class="c-lad-table__empty-message">
+      Drag telemetry objects here to add them to this table.
+    </div>
     <table class="c-table c-lad-table" :class="applyLayoutClass">
       <thead>
         <tr>
@@ -84,7 +95,9 @@ export default {
     return {
       items: [],
       viewContext: {},
-      configuration: this.ladTableConfiguration.getConfiguration()
+      configuration: this.ladTableConfiguration.getConfiguration(),
+      isDragging: false,
+      isMouseOver: false
     };
   },
   computed: {
@@ -166,6 +179,10 @@ export default {
     });
 
     this.initializeViewActions();
+
+    document.addEventListener('dragstart', this.dragstart);
+    document.addEventListener('dragend', this.dragend);
+    document.addEventListener('drop', this.dragend);
   },
   unmounted() {
     this.ladTableConfiguration.off('change', this.handleConfigurationChange);
@@ -173,8 +190,32 @@ export default {
     this.composition.off('add', this.addItem);
     this.composition.off('remove', this.removeItem);
     this.composition.off('reorder', this.reorder);
+
+    document.removeEventListener('dragstart', this.dragstart);
+    document.removeEventListener('dragend', this.dragend);
+    document.removeEventListener('drop', this.dragend);
   },
   methods: {
+    allowDrop(event) {
+      if (this.domainObject.locked) {
+        return false;
+      }
+
+      return event.dataTransfer.types.includes('openmct/composable-domain-object');
+    },
+    dragstart(event) {
+      this.isDragging = this.allowDrop(event);
+    },
+    dragend() {
+      this.isDragging = false;
+      this.isMouseOver = false;
+    },
+    dragenter() {
+      this.isMouseOver = true;
+    },
+    dragleave() {
+      this.isMouseOver = false;
+    },
     async addItem(domainObject) {
       let item = {};
       item.domainObject = domainObject;

--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -21,7 +21,22 @@
 -->
 
 <template>
-  <div class="c-lad-table-wrapper u-style-receiver js-style-receiver" :class="staleClass">
+  <div
+    id="lad-table-set-drop-area"
+    class="c-lad-table-wrapper u-style-receiver js-style-receiver"
+    :class="[staleClass, { 'is-dragging': isDragging, 'is-mouse-over': isMouseOver }]"
+  >
+    <div
+      class="c-drop-hint"
+      :role="isDragging ? 'region' : null"
+      :aria-label="isDragging ? 'Drop a LAD table here to add it to this LAD table set' : null"
+      :aria-hidden="isDragging ? null : 'true'"
+      @dragenter="dragenter"
+      @dragleave="dragleave"
+    ></div>
+    <div v-if="ladTableObjects.length === 0" class="c-lad-table__empty-message">
+      Drag LAD tables here to add them to this set.
+    </div>
     <table class="c-table c-lad-table">
       <thead>
         <tr>
@@ -80,7 +95,9 @@ export default {
       ladTelemetryObjects: {},
       viewContext: {},
       configuration: this.ladTableConfiguration.getConfiguration(),
-      subscribedObjects: {}
+      subscribedObjects: {},
+      isDragging: false,
+      isMouseOver: false
     };
   },
   computed: {
@@ -128,6 +145,10 @@ export default {
       this.triggerUnsubscribeFromStaleness(domainObject);
       this.subscribeToStaleness(domainObject);
     });
+
+    document.addEventListener('dragstart', this.dragstart);
+    document.addEventListener('dragend', this.dragend);
+    document.addEventListener('drop', this.dragend);
   },
   unmounted() {
     this.ladTableConfiguration.off('change', this.handleConfigurationChange);
@@ -138,8 +159,32 @@ export default {
       c.composition.off('add', c.addCallback);
       c.composition.off('remove', c.removeCallback);
     });
+
+    document.removeEventListener('dragstart', this.dragstart);
+    document.removeEventListener('dragend', this.dragend);
+    document.removeEventListener('drop', this.dragend);
   },
   methods: {
+    allowDrop(event) {
+      if (this.domainObject.locked) {
+        return false;
+      }
+
+      return event.dataTransfer.types.includes('openmct/composable-domain-object');
+    },
+    dragstart(event) {
+      this.isDragging = this.allowDrop(event);
+    },
+    dragend() {
+      this.isDragging = false;
+      this.isMouseOver = false;
+    },
+    dragenter() {
+      this.isMouseOver = true;
+    },
+    dragleave() {
+      this.isMouseOver = false;
+    },
     addLadTable(domainObject) {
       let ladTable = {};
       ladTable.domainObject = domainObject;

--- a/src/plugins/LADTable/components/LadTableSet.vue
+++ b/src/plugins/LADTable/components/LadTableSet.vue
@@ -22,8 +22,7 @@
 
 <template>
   <div
-    id="lad-table-set-drop-area"
-    class="c-lad-table-wrapper u-style-receiver js-style-receiver"
+    class="c-lad-table-wrapper u-style-receiver js-style-receiver js-lad-table-set"
     :class="[staleClass, { 'is-dragging': isDragging, 'is-mouse-over': isMouseOver }]"
   >
     <div
@@ -34,7 +33,10 @@
       @dragenter="dragenter"
       @dragleave="dragleave"
     ></div>
-    <div v-if="ladTableObjects.length === 0" class="c-lad-table__empty-message">
+    <div
+      v-if="ladTableObjects.length === 0 && !domainObject.locked"
+      class="c-lad-table__empty-message"
+    >
       Drag LAD tables here to add them to this set.
     </div>
     <table class="c-table c-lad-table">

--- a/src/plugins/LADTable/pluginSpec.js
+++ b/src/plugins/LADTable/pluginSpec.js
@@ -289,6 +289,41 @@ describe('The LAD Table', () => {
       expect(actualRangeValue).toBe(rangeValue);
       expect(actualDomainValue).toBe(domainValue);
     });
+
+    it('should include an accessible drop hint that appears for composable drags', async () => {
+      const dropHint = parent.querySelector('.c-drop-hint');
+      expect(dropHint).not.toBeNull();
+      expect(dropHint.getAttribute('aria-hidden')).toBe('true');
+      expect(parent.querySelector('.c-lad-table__empty-message')).toBeNull();
+      expect(parent.querySelector('#lad-table-drop-area').classList.contains('is-dragging')).toBe(
+        false
+      );
+
+      const event = new Event('dragstart', { bubbles: true });
+      Object.defineProperty(event, 'dataTransfer', {
+        value: {
+          types: ['openmct/composable-domain-object'],
+          getData: () => '',
+          setData: () => {}
+        }
+      });
+      document.dispatchEvent(event);
+      await nextTick();
+
+      expect(parent.querySelector('#lad-table-drop-area').classList.contains('is-dragging')).toBe(
+        true
+      );
+      expect(dropHint.getAttribute('role')).toBe('region');
+      expect(dropHint.getAttribute('aria-label')).toContain('LAD table');
+      expect(dropHint.getAttribute('aria-hidden')).toBeNull();
+
+      document.dispatchEvent(new Event('dragend'));
+      await nextTick();
+      expect(parent.querySelector('#lad-table-drop-area').classList.contains('is-dragging')).toBe(
+        false
+      );
+      expect(dropHint.getAttribute('aria-hidden')).toBe('true');
+    });
   });
 });
 
@@ -436,6 +471,37 @@ describe('The LAD Table Set', () => {
 
         expect(rowCount).toBe(mockObj.ladTableSet.composition.length);
       });
+    });
+
+    it('should include an accessible drop hint for composable LAD table drags', async () => {
+      const dropHint = parent.querySelector('.c-drop-hint');
+      expect(dropHint).not.toBeNull();
+      expect(dropHint.getAttribute('aria-hidden')).toBe('true');
+
+      const event = new Event('dragstart', { bubbles: true });
+      Object.defineProperty(event, 'dataTransfer', {
+        value: {
+          types: ['openmct/composable-domain-object'],
+          getData: () => '',
+          setData: () => {}
+        }
+      });
+      document.dispatchEvent(event);
+      await nextTick();
+
+      expect(
+        parent.querySelector('#lad-table-set-drop-area').classList.contains('is-dragging')
+      ).toBe(true);
+      expect(dropHint.getAttribute('role')).toBe('region');
+      expect(dropHint.getAttribute('aria-label')).toContain('LAD table set');
+      expect(dropHint.getAttribute('aria-hidden')).toBeNull();
+
+      document.dispatchEvent(new Event('dragend'));
+      await nextTick();
+      expect(
+        parent.querySelector('#lad-table-set-drop-area').classList.contains('is-dragging')
+      ).toBe(false);
+      expect(dropHint.getAttribute('aria-hidden')).toBe('true');
     });
   });
 });

--- a/src/plugins/LADTable/pluginSpec.js
+++ b/src/plugins/LADTable/pluginSpec.js
@@ -295,9 +295,7 @@ describe('The LAD Table', () => {
       expect(dropHint).not.toBeNull();
       expect(dropHint.getAttribute('aria-hidden')).toBe('true');
       expect(parent.querySelector('.c-lad-table__empty-message')).toBeNull();
-      expect(parent.querySelector('#lad-table-drop-area').classList.contains('is-dragging')).toBe(
-        false
-      );
+      expect(parent.querySelector('.js-lad-table').classList.contains('is-dragging')).toBe(false);
 
       const event = new Event('dragstart', { bubbles: true });
       Object.defineProperty(event, 'dataTransfer', {
@@ -310,18 +308,14 @@ describe('The LAD Table', () => {
       document.dispatchEvent(event);
       await nextTick();
 
-      expect(parent.querySelector('#lad-table-drop-area').classList.contains('is-dragging')).toBe(
-        true
-      );
+      expect(parent.querySelector('.js-lad-table').classList.contains('is-dragging')).toBe(true);
       expect(dropHint.getAttribute('role')).toBe('region');
       expect(dropHint.getAttribute('aria-label')).toContain('LAD table');
       expect(dropHint.getAttribute('aria-hidden')).toBeNull();
 
       document.dispatchEvent(new Event('dragend'));
       await nextTick();
-      expect(parent.querySelector('#lad-table-drop-area').classList.contains('is-dragging')).toBe(
-        false
-      );
+      expect(parent.querySelector('.js-lad-table').classList.contains('is-dragging')).toBe(false);
       expect(dropHint.getAttribute('aria-hidden')).toBe('true');
     });
   });
@@ -489,18 +483,18 @@ describe('The LAD Table Set', () => {
       document.dispatchEvent(event);
       await nextTick();
 
-      expect(
-        parent.querySelector('#lad-table-set-drop-area').classList.contains('is-dragging')
-      ).toBe(true);
+      expect(parent.querySelector('.js-lad-table-set').classList.contains('is-dragging')).toBe(
+        true
+      );
       expect(dropHint.getAttribute('role')).toBe('region');
       expect(dropHint.getAttribute('aria-label')).toContain('LAD table set');
       expect(dropHint.getAttribute('aria-hidden')).toBeNull();
 
       document.dispatchEvent(new Event('dragend'));
       await nextTick();
-      expect(
-        parent.querySelector('#lad-table-set-drop-area').classList.contains('is-dragging')
-      ).toBe(false);
+      expect(parent.querySelector('.js-lad-table-set').classList.contains('is-dragging')).toBe(
+        false
+      );
       expect(dropHint.getAttribute('aria-hidden')).toBe('true');
     });
   });

--- a/src/plugins/flexibleLayout/components/ContainerComponent.vue
+++ b/src/plugins/flexibleLayout/components/ContainerComponent.vue
@@ -42,6 +42,7 @@
       class="c-fl-frame__drop-hint"
       :index="-1"
       :allow-drop="allowDrop"
+      label="Drop here to insert into this container"
       @object-drop-to="moveOrCreateNewFrame"
     />
 
@@ -62,6 +63,7 @@
           class="c-fl-frame__drop-hint"
           :index="i"
           :allow-drop="allowDrop"
+          label="Drop here to insert into this container"
           @object-drop-to="moveOrCreateNewFrame"
         />
 
@@ -80,9 +82,9 @@
 </template>
 
 <script>
+import DropHint from '@/ui/components/DropHint.vue';
 import ResizeHandle from '@/ui/layout/ResizeHandle/ResizeHandle.vue';
 
-import DropHint from './DropHint.vue';
 import FrameComponent from './FrameComponent.vue';
 
 const MIN_FRAME_SIZE = 5;

--- a/src/plugins/flexibleLayout/components/FlexibleLayout.vue
+++ b/src/plugins/flexibleLayout/components/FlexibleLayout.vue
@@ -39,6 +39,7 @@
           class="c-fl-frame__drop-hint"
           :index="-1"
           :allow-drop="allowContainerDrop"
+          label="Drop here to reorder containers"
           @object-drop-to="moveContainer"
         />
 
@@ -69,6 +70,7 @@
           class="c-fl-frame__drop-hint"
           :index="index"
           :allow-drop="allowContainerDrop"
+          label="Drop here to reorder containers"
           @object-drop-to="moveContainer"
         />
       </template>
@@ -77,12 +79,12 @@
 </template>
 
 <script>
+import DropHint from '@/ui/components/DropHint.vue';
 import Container from '@/ui/layout/Container.js';
 import Frame from '@/ui/layout/Frame.js';
 import ResizeHandle from '@/ui/layout/ResizeHandle/ResizeHandle.vue';
 
 import ContainerComponent from './ContainerComponent.vue';
-import DropHint from './DropHint.vue';
 
 const MIN_CONTAINER_SIZE = 5;
 

--- a/src/styles/_controls.scss
+++ b/src/styles/_controls.scss
@@ -1212,7 +1212,7 @@ input[type='range'] {
 
 /***************************************************** DRAG AND DROP */
 .c-drop-hint {
-    // Used in Tabs View, Flexible Grid Layouts
+    // Used in Tabs View, Flexible Layouts, and LAD Tables
     @include abs();
     @include transition($prop: background-color, $dur: $transOutTime);
     background-color: $colorDropHintBg;

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -196,6 +196,7 @@ div.c-table {
 }
 
 .c-lad-table-wrapper {
+  position: relative;
   width: 100%;
   height: 100%;
   padding: $mainViewPad;
@@ -203,6 +204,16 @@ div.c-table {
   &.is-stale {
     @include isStaleHolder();
   }
+}
+
+.c-lad-table__empty-message {
+  background: rgba($colorBodyFg, 0.1);
+  color: rgba($colorBodyFg, 0.7);
+  font-style: italic;
+  text-align: center;
+  line-height: 2em;
+  width: 100%;
+  margin-bottom: $interiorMargin;
 }
 
 .c-lad-table {

--- a/src/ui/components/DropHint.vue
+++ b/src/ui/components/DropHint.vue
@@ -25,6 +25,8 @@
     <div
       class="c-drop-hint c-drop-hint--always-show"
       :class="{ 'is-mouse-over': isMouseOver }"
+      role="region"
+      :aria-label="label"
       @dragover.prevent
       @dragenter="dragenter"
       @dragleave="dragleave"
@@ -43,6 +45,10 @@ export default {
     allowDrop: {
       type: Function,
       required: true
+    },
+    label: {
+      type: String,
+      default: 'Drop here'
     }
   },
   emits: ['object-drop-to'],
@@ -72,12 +78,14 @@ export default {
     dropHandler(event) {
       this.$emit('object-drop-to', this.index, event);
       this.isValidTarget = false;
+      this.isMouseOver = false;
     },
     dragstart(event) {
       this.isValidTarget = this.allowDrop(event, this.index);
     },
     dragend() {
       this.isValidTarget = false;
+      this.isMouseOver = false;
     }
   }
 };

--- a/src/ui/components/DropHintSpec.js
+++ b/src/ui/components/DropHintSpec.js
@@ -1,0 +1,158 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+import mount from 'utils/mount';
+import { nextTick } from 'vue';
+
+import DropHint from './DropHint.vue';
+
+describe('DropHint', () => {
+  let destroy;
+  let parentElement;
+  let allowDrop;
+  let onDrop;
+
+  function mountDropHint({ label = 'Drop here to add', allowDropFn, onDropFn } = {}) {
+    allowDrop = allowDropFn || jasmine.createSpy('allowDrop').and.returnValue(true);
+    onDrop = onDropFn || jasmine.createSpy('onDrop');
+    parentElement = document.createElement('div');
+    document.body.appendChild(parentElement);
+
+    const result = mount(
+      {
+        components: {
+          DropHint
+        },
+        data() {
+          return {
+            label
+          };
+        },
+        methods: {
+          allowDrop,
+          onDrop
+        },
+        template: `<DropHint
+          :index="0"
+          :allow-drop="allowDrop"
+          :label="label"
+          @object-drop-to="onDrop"
+        />`
+      },
+      {
+        element: parentElement
+      }
+    );
+
+    destroy = result.destroy;
+
+    return result.vNode.componentInstance;
+  }
+
+  afterEach(() => {
+    if (destroy) {
+      destroy();
+      destroy = undefined;
+    }
+
+    if (parentElement?.parentNode) {
+      parentElement.parentNode.removeChild(parentElement);
+    }
+
+    parentElement = undefined;
+  });
+
+  function dispatchDragStart(types = ['openmct/composable-domain-object']) {
+    const event = new Event('dragstart', { bubbles: true });
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        types,
+        getData: () => '',
+        setData: () => {}
+      }
+    });
+    document.dispatchEvent(event);
+
+    return event;
+  }
+
+  it('is hidden until a valid drag starts', () => {
+    mountDropHint();
+
+    const dropHint = parentElement.querySelector('.c-drop-hint');
+    expect(dropHint).not.toBeNull();
+    expect(dropHint.offsetParent).toBeNull();
+  });
+
+  it('shows an accessible drop region when allowDrop returns true', async () => {
+    mountDropHint({
+      label: 'Drop telemetry here'
+    });
+
+    dispatchDragStart();
+    await nextTick();
+
+    const dropHint = parentElement.querySelector('.c-drop-hint');
+    expect(dropHint.offsetParent).not.toBeNull();
+    expect(dropHint.getAttribute('role')).toBe('region');
+    expect(dropHint.getAttribute('aria-label')).toBe('Drop telemetry here');
+  });
+
+  it('stays hidden when allowDrop returns false', async () => {
+    mountDropHint({
+      allowDropFn: jasmine.createSpy('allowDrop').and.returnValue(false)
+    });
+
+    dispatchDragStart(['openmct/domain-object-path']);
+    await nextTick();
+
+    const dropHint = parentElement.querySelector('.c-drop-hint');
+    expect(allowDrop).toHaveBeenCalled();
+    expect(dropHint.offsetParent).toBeNull();
+  });
+
+  it('emits object-drop-to and hides after a drop', async () => {
+    mountDropHint();
+
+    dispatchDragStart();
+    await nextTick();
+
+    const dropHint = parentElement.querySelector('.c-drop-hint');
+    dropHint.dispatchEvent(new Event('drop', { bubbles: true }));
+    await nextTick();
+
+    expect(onDrop).toHaveBeenCalled();
+    expect(dropHint.offsetParent).toBeNull();
+  });
+
+  it('hides when drag ends without a drop', async () => {
+    mountDropHint();
+
+    dispatchDragStart();
+    await nextTick();
+
+    document.dispatchEvent(new Event('dragend'));
+    await nextTick();
+
+    const dropHint = parentElement.querySelector('.c-drop-hint');
+    expect(dropHint.offsetParent).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #7773

### Describe your changes:
LAD tables never showed that you could drop telemetry on them, even though the drop itself already worked through ObjectView. Flexible Layouts and Tabs already give that feedback with `.c-drop-hint`, so I brought the same treatment over.

Also cleaned up `DropHint.vue` while I was in there — it was an empty div with no accessible name, which is rough for screen readers. Moved it under `src/ui/components/` since it's shared UI now, not Flexible Layout-specific.

**LAD Table / LAD Table Set**
- Show the shared drop hint overlay while dragging a composable object
- Empty-state copy so it's obvious what to drag in
- `role="region"` + label only while the hint is active; `aria-hidden` otherwise
- Kept `#lad-table-drop-area` so existing e2e stays happy

**DropHint**
- Accessible name via `role="region"` + `aria-label` (customizable `label` prop)
- Wired labels in Flexible Layout for insert/reorder zones
- Unit coverage for show/hide + a11y attrs

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue. (no permission from fork — please tag `type:enhancement` if you can)
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?

### Testing instructions
1. Create a LAD Table, edit it, drag a telemetry object from the tree — you should see the dashed drop overlay light up, then the row appear after drop.
2. Create an empty LAD Table — empty-state message should show; overlay still appears on a valid drag.
3. Same idea for LAD Table Set, but dropping LAD Tables instead of telemetry.
4. Open a Flexible Layout with a couple of containers in edit mode and drag a frame/object between them — drop strips should still work, and the visible drop region should expose an accessible name (e.g. via accessibility tree / axe).
5. Confirm locked LAD objects don't show the overlay.