### PR TITLE
[Create] Fix locator crash when object location is missing

### DIFF
--- a/e2e/tests/functional/plugins/displayLayout/displayLayout.e2e.spec.js
+++ b/e2e/tests/functional/plugins/displayLayout/displayLayout.e2e.spec.js
@@ -649,6 +649,49 @@ async function addAndRemoveDrawingObjectAndAssert(page, layoutObject, DISPLAY_LA
   await expect(page.getByLabel(layoutObject, { exact: true })).toHaveCount(0);
 }
 
+test.describe('Display Layout Create while missing location', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('./', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('Create locator remains usable when the layout has no location', async ({ page }) => {
+    test.info().annotations.push({
+      type: 'issue',
+      description: 'https://github.com/nasa/openmct/issues/8324'
+    });
+
+    const layout = await createDomainObjectWithDefaults(page, {
+      type: 'Display Layout',
+      name: 'Layout Missing Location'
+    });
+
+    // Reproduce objects that are composed under My Items but have a null location
+    // (as in the issue's exported Example Display Layout.json).
+    await page.evaluate(async (layoutKey) => {
+      const domainObject = await window.openmct.objects.get(layoutKey);
+      window.openmct.objects.mutate(domainObject, 'location', null);
+      await window.openmct.objects.save(domainObject);
+    }, layout.uuid);
+
+    await page.goto(`./#/browse/mine/${layout.uuid}`, { waitUntil: 'domcontentloaded' });
+
+    const pageErrors = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await page.getByRole('menuitem', { name: 'Condition Widget' }).click();
+
+    const createTree = page.getByRole('tree', { name: 'Create Modal Tree' });
+    await expect(createTree.getByText('My Items')).toBeVisible();
+    await expect(createTree.getByText('No items')).toBeHidden();
+    await expect(createTree.getByText('Layout Missing Location')).toBeVisible();
+    expect(pageErrors.filter((message) => message.includes('objectPath'))).toEqual([]);
+
+    await page.getByLabel('Save').click();
+    await expect(page.getByRole('dialog', { name: 'Modal Overlay' })).toBeHidden();
+  });
+});
+
 /**
  * Remove the first matching layout object from the layout
  * @param {import('@playwright/test').Page} page

--- a/src/ui/layout/MctTree.vue
+++ b/src/ui/layout/MctTree.vue
@@ -273,9 +273,7 @@ export default {
       await this.syncTreeOpenItems();
     } else {
       if (this.initialSelection.identifier) {
-        const objectPath = await this.openmct.objects.getOriginalPath(
-          this.initialSelection.identifier
-        );
+        const objectPath = await this.getPathForInitialSelection();
         const navigationPath = this.buildNavigationPath(objectPath);
 
         this.openAndScrollTo(navigationPath);
@@ -442,6 +440,27 @@ export default {
         }
       }
     },
+    // getOriginalPath walks `location` only. Some objects are still in the tree
+    // via composition with a missing/null location (see #8324) — use router.path
+    // when it points at the same object so the locator can still open.
+    async getPathForInitialSelection() {
+      let objectPath = await this.openmct.objects.getOriginalPath(this.initialSelection.identifier);
+
+      if (!this.openmct.objects.isReachable(objectPath)) {
+        const routerPath = this.openmct.router.path;
+        if (
+          routerPath?.length &&
+          this.openmct.objects.areIdsEqual(
+            routerPath[0].identifier,
+            this.initialSelection.identifier
+          )
+        ) {
+          objectPath = routerPath;
+        }
+      }
+
+      return objectPath;
+    },
     openAndScrollTo(navigationPath) {
       if (navigationPath.includes('/ROOT')) {
         navigationPath = navigationPath.split('/ROOT').join('');
@@ -472,7 +491,12 @@ export default {
         .reduce(async (parentLoaded, childPath) => {
           await parentLoaded;
 
-          return this.openTreeItem(this.getTreeItemByPath(childPath));
+          const treeItem = this.getTreeItemByPath(childPath);
+          if (!treeItem) {
+            return;
+          }
+
+          return this.openTreeItem(treeItem);
         }, Promise.resolve())
         .then(() => {
           if (this.isSelectorTree) {
@@ -487,7 +511,12 @@ export default {
               item = this.getTreeItemByPath(navigationPath);
             }
 
-            this.treeItemSelection(item);
+            if (item) {
+              this.treeItemSelection(item);
+            } else if (this.treeItems.length > 0) {
+              // Keep the locator usable if the preferred path cannot be resolved
+              this.treeItemSelection(this.treeItems[0]);
+            }
           }
 
           this.scrollToCheck(navigationPath);

--- a/src/ui/layout/TreeItem.vue
+++ b/src/ui/layout/TreeItem.vue
@@ -87,7 +87,10 @@ export default {
     },
     selectedItem: {
       type: Object,
-      required: true
+      required: false,
+      default() {
+        return {};
+      }
     },
     activeSearch: {
       type: Boolean,
@@ -153,7 +156,7 @@ export default {
       return parentKeyString !== this.node.object.location;
     },
     isSelectedItem() {
-      return this.selectedItem.objectPath === this.node.objectPath;
+      return this.selectedItem?.objectPath === this.node.objectPath;
     },
     isTargetedItem() {
       return this.targetedPath === this.navigationPath;


### PR DESCRIPTION
Closes #8324

### Describe your changes:
Create was blowing up when the current object had a null/missing `location` (the Example Display Layout from the issue is in that state).

What was going wrong:
1. Create opens the locator with the current object as the initial selection
2. The tree resolves that via `getOriginalPath`, which only walks `location`
3. With no location, the path is just `[layout]` → `/browse/<uuid>`
4. That path isn't in the tree (the object still lives under My Items via composition), so we called `treeItemSelection(undefined)`
5. `TreeItem` then crashed reading `selectedItem.objectPath`, and the locator fell back to "No items"

Fixes:
- If `getOriginalPath` isn't reachable, fall back to `router.path` when it points at the same object
- Don't select `undefined` in `openAndScrollTo` (fall back to the first tree item)
- Guard `selectedItem` access in `TreeItem`

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?

### Testing instructions
1. Import the JSON from #8324 into My Items, or create a Display Layout and set its `location` to `null` (still under My Items).
2. Navigate to that layout via `#/browse/mine/<uuid>`.
3. Click Create → Condition Widget (also try Folder / Clock).
4. The Save In tree should show My Items + the layout (not "No items"), and there should be no `objectPath` console error.
5. Saving the new object should succeed.

Also covered by the new e2e in `displayLayout.e2e.spec.js`.