### PR TITLE
[Plot] Update Y axis label when it changes

### DIFF
--- a/src/plugins/plot/axis/YAxis.vue
+++ b/src/plugins/plot/axis/YAxis.vue
@@ -172,6 +172,7 @@ export default {
         }
 
         this.config = config;
+        this.listenTo(this.yAxis, 'change:label', this.updateYAxisLabel, this);
         this.listenTo(this.config.series, 'add', this.addSeries, this);
         this.listenTo(this.config.series, 'remove', this.removeSeries, this);
         this.listenTo(this.config.series, 'reorder', this.addOrRemoveSeries, this);
@@ -244,6 +245,11 @@ export default {
       if (this.yAxisLabel === 'none') {
         this.yAxisLabel = this.yAxis.get('label');
       }
+    },
+    //  the label may be edited from the inspector, or derived from series
+    //  metadata, so mirror the model instead of reading it only once
+    updateYAxisLabel(label) {
+      this.yAxisLabel = label;
     },
     toggleYAxisLabel() {
       let yAxisObject = this.yKeyOptions.filter((o) => o.name === this.yAxisLabel)[0];

--- a/src/plugins/plot/overlayPlot/pluginSpec.js
+++ b/src/plugins/plot/overlayPlot/pluginSpec.js
@@ -346,6 +346,23 @@ describe('the plugin', function () {
       expect(yAxisElement.length).toBe(2);
     });
 
+    it('Updates the Y-axis label when it is changed on the axis model', async () => {
+      function getRenderedLabels() {
+        return Array.from(
+          element.querySelectorAll('.gl-plot-axis-area.gl-plot-y .gl-plot-y-label')
+        ).map((labelElement) => labelElement.textContent.trim());
+      }
+
+      expect(getRenderedLabels()).toContain('Test Object 2 Label');
+
+      const editedYAxis = config.additionalYAxes.find((yAxis) => yAxis.id === 3);
+      editedYAxis.set('label', 'Edited Y Axis Label');
+      await nextTick();
+
+      expect(getRenderedLabels()).toContain('Edited Y Axis Label');
+      expect(getRenderedLabels()).not.toContain('Test Object 2 Label');
+    });
+
     describe('the inspector view', () => {
       let inspectorComponent;
       let viewComponentObject;


### PR DESCRIPTION
Closes #6313

### Describe your changes:

`YAxis.vue` read the axis label from the axis model only once, when the
component was mounted (`setUpYAxisOptions()` assigns `yAxisLabel` only while it
still holds its initial `'none'` value). The component registered listeners for
series `add` / `remove` / `reorder`, but nothing listened to the y-axis model
itself, so a label edited from the inspector was persisted and stored on the
model while the rendered label stayed stale until the view was recreated — which
is why reloading or navigating away and back "fixed" it.

This adds a `change:label` listener on the axis model and mirrors the new value
into `yAxisLabel`, following the same `listenTo` pattern the component already
uses for series changes.

As a side effect this also covers the case where `YAxisModel.updateFromSeries()`
derives a label from series metadata (name, then units) — that assignment
previously had the same delayed-render behaviour.

Scope note: `MctPlot.vue` assigns `this.config.yAxisLabel` once during init in
the same way, but that value is not read anywhere, so I left it alone rather
than widen this change.

### Testing

Added a unit test to `overlayPlot/pluginSpec.js` that asserts the rendered
y-axis label tracks the model. Verified it fails without the fix and passes
with it:

```
# without the fix
Expected [ 'Some attribute', 'Test Object 2 Label' ] to contain 'Edited Y Axis Label'.
TOTAL: 1 FAILED, 5 SUCCESS

# with the fix
TOTAL: 6 SUCCESS
```

Full unit suite run before and after the change: same 6 pre-existing failures in
both runs (Object API Search, Image Exporter, URLIndicator — all unrelated to
plots and failing on a clean `master` in my environment), with the success count
going from 969 to 970, i.e. no regressions.

Manual reproduction steps are in issue #6313 and are unchanged.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?
