### PR TITLE
[LAD Table] Add a view for single telemetry objects

### DIFF
--- a/src/plugins/LADTable/LADTableConfiguration.js
+++ b/src/plugins/LADTable/LADTableConfiguration.js
@@ -32,6 +32,8 @@ export default class LADTableConfiguration extends EventEmitter {
     // it cannot access any private methods (like #mutate()).
     this.openmct = markRaw(openmct);
 
+    this.notPersistable = !openmct.objects.isPersistable(domainObject.identifier);
+
     this.objectMutated = this.objectMutated.bind(this);
     this.unlistenFromMutation = openmct.objects.observe(
       domainObject,
@@ -50,6 +52,14 @@ export default class LADTableConfiguration extends EventEmitter {
   }
 
   updateConfiguration(configuration) {
+    if (this.notPersistable) {
+      // Read only objects, such as telemetry from a dictionary, cannot store view
+      // configuration, so the change lives for as long as the view does.
+      this.emit('change', configuration);
+
+      return;
+    }
+
     this.openmct.objects.mutate(this.domainObject, 'configuration', configuration);
   }
 

--- a/src/plugins/LADTable/LADTableViewProvider.js
+++ b/src/plugins/LADTable/LADTableViewProvider.js
@@ -31,12 +31,19 @@ export default class LADTableViewProvider {
   }
 
   canView(domainObject) {
-    const supportsComposition = this.openmct.composition.supportsComposition(domainObject);
     const providesTelemetry = this.openmct.telemetry.isTelemetryObject(domainObject);
     const isLadTable = domainObject.type === 'LadTable';
     const isConditionSet = domainObject.type === 'conditionSet';
 
-    return !isConditionSet && (isLadTable || (providesTelemetry && supportsComposition));
+    return !isConditionSet && (isLadTable || providesTelemetry);
+  }
+
+  priority(domainObject) {
+    // A telemetry object with no composition is shown as a single row, which is an
+    // alternative to its plot and table views rather than a replacement for them.
+    const supportsComposition = this.openmct.composition.supportsComposition(domainObject);
+
+    return supportsComposition ? this.openmct.priority.DEFAULT : this.openmct.priority.LOW;
   }
 
   canEdit(domainObject) {

--- a/src/plugins/LADTable/components/LadRow.vue
+++ b/src/plugins/LADTable/components/LadRow.vue
@@ -99,6 +99,12 @@ export default {
       type: Object,
       required: true
     },
+    canRemove: {
+      type: Boolean,
+      default() {
+        return true;
+      }
+    },
     limitDefinition: {
       type: Object,
       default() {
@@ -296,7 +302,11 @@ export default {
     showContextMenu(event) {
       this.updateViewContext();
 
-      const actions = CONTEXT_MENU_ACTIONS.map((key) => this.openmct.actions.getAction(key));
+      // Removal takes a row out of the table that contains it; when the row is the
+      // table's own object, that would instead remove it from wherever it lives.
+      const actions = CONTEXT_MENU_ACTIONS.filter(
+        (key) => this.canRemove || key !== REMOVE_ACTION_KEY
+      ).map((key) => this.openmct.actions.getAction(key));
       const menuItems = this.openmct.menus.actionsToMenuItems(
         actions,
         this.objectPath,

--- a/src/plugins/LADTable/components/LadTable.vue
+++ b/src/plugins/LADTable/components/LadTable.vue
@@ -46,7 +46,8 @@
           :domain-object="ladRow.domainObject"
           :limit-definition="ladRow.limitDefinition"
           :limit-column-names="limitColumnNames"
-          :path-to-table="objectPath"
+          :path-to-table="pathToTable"
+          :can-remove="!isSingleTelemetryObject"
           :has-units="hasUnits"
           :is-stale="staleObjects.includes(ladRow.key)"
           :configuration="configuration"
@@ -84,10 +85,16 @@ export default {
     return {
       items: [],
       viewContext: {},
+      isSingleTelemetryObject: false,
       configuration: this.ladTableConfiguration.getConfiguration()
     };
   },
   computed: {
+    pathToTable() {
+      // When this view's object is itself the single row, it is already the head of
+      // objectPath; dropping it keeps LadRow from repeating it in the row's own path.
+      return this.isSingleTelemetryObject ? this.objectPath.slice(1) : this.objectPath;
+    },
     hasUnits() {
       let itemsWithUnits = this.items.filter((item) => {
         let metadata = this.openmct.telemetry.getMetadata(item.domainObject);
@@ -151,10 +158,16 @@ export default {
   async mounted() {
     this.ladTableConfiguration.on('change', this.handleConfigurationChange);
     this.composition = this.openmct.composition.get(this.domainObject);
-    this.composition.on('add', this.addItem);
-    this.composition.on('remove', this.removeItem);
-    this.composition.on('reorder', this.reorder);
-    this.composition.load();
+    if (this.composition) {
+      this.composition.on('add', this.addItem);
+      this.composition.on('remove', this.removeItem);
+      this.composition.on('reorder', this.reorder);
+      this.composition.load();
+    } else {
+      // A telemetry object with no composition provides the only row in its own table.
+      this.isSingleTelemetryObject = true;
+      this.addItem(this.domainObject);
+    }
     await nextTick();
     this.viewActionsCollection = this.openmct.actions.getActionsCollection(
       this.objectPath,
@@ -170,9 +183,11 @@ export default {
   unmounted() {
     this.ladTableConfiguration.off('change', this.handleConfigurationChange);
 
-    this.composition.off('add', this.addItem);
-    this.composition.off('remove', this.removeItem);
-    this.composition.off('reorder', this.reorder);
+    if (this.composition) {
+      this.composition.off('add', this.addItem);
+      this.composition.off('remove', this.removeItem);
+      this.composition.off('reorder', this.reorder);
+    }
   },
   methods: {
     async addItem(domainObject) {

--- a/src/plugins/LADTable/pluginSpec.js
+++ b/src/plugins/LADTable/pluginSpec.js
@@ -20,6 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 import {
+  createMouseEvent,
   createOpenMct,
   getLatestTelemetry,
   getMockObjects,
@@ -30,6 +31,7 @@ import {
 } from 'utils/testing';
 import { nextTick } from 'vue';
 
+import LADTableConfiguration from './LADTableConfiguration.js';
 import LadPlugin from './plugin.js';
 
 const TABLE_BODY_ROWS = '.js-lad-table__body__row';
@@ -105,13 +107,82 @@ describe('The LAD Table', () => {
     return resetApplicationState(openmct);
   });
 
-  it('should provide a table view only for lad table objects', () => {
+  it('should provide a table view for lad table objects', () => {
     let applicableViews = openmct.objectViews.get(mockObj.ladTable, []);
 
     let ladTableView = applicableViews.find((viewProvider) => viewProvider.key === ladTableKey);
 
     expect(applicableViews.length).toEqual(1);
     expect(ladTableView).toBeDefined();
+  });
+
+  it('should provide a table view for telemetry producing objects', () => {
+    const applicableViews = openmct.objectViews.get(mockObj.telemetry, [mockObj.telemetry]);
+
+    const ladTableView = applicableViews.find((viewProvider) => viewProvider.key === ladTableKey);
+
+    expect(ladTableView).toBeDefined();
+  });
+
+  it('should not supersede the other views of a telemetry producing object', () => {
+    const applicableViews = openmct.objectViews.get(mockObj.telemetry, [mockObj.telemetry]);
+
+    const ladTableIndex = applicableViews.findIndex(
+      (viewProvider) => viewProvider.key === ladTableKey
+    );
+
+    expect(ladTableIndex).toBeGreaterThan(0);
+  });
+
+  it('should not provide a table view for condition sets', () => {
+    const conditionSetObj = getMockObjects({
+      objectKeyStrings: ['telemetry'],
+      overwrite: {
+        telemetry: {
+          name: 'Condition Set Object',
+          type: 'conditionSet',
+          identifier: {
+            namespace: '',
+            key: 'condition-set-object'
+          },
+          configuration: {
+            conditionCollection: []
+          }
+        }
+      }
+    }).telemetry;
+
+    const applicableViews = openmct.objectViews.get(conditionSetObj, [conditionSetObj]);
+
+    const ladTableView = applicableViews.find((viewProvider) => viewProvider.key === ladTableKey);
+
+    expect(ladTableView).toBeUndefined();
+  });
+
+  it('should apply configuration changes to read only objects without persisting them', () => {
+    const readOnlyObj = getMockObjects({
+      objectKeyStrings: ['telemetry'],
+      overwrite: {
+        telemetry: {
+          name: 'Read Only Telemetry Object',
+          identifier: {
+            namespace: 'read-only',
+            key: 'read-only-telemetry-object'
+          }
+        }
+      }
+    }).telemetry;
+    const ladTableConfiguration = new LADTableConfiguration(readOnlyObj, openmct);
+    const changed = jasmine.createSpy('changed');
+    ladTableConfiguration.on('change', changed);
+
+    const configuration = ladTableConfiguration.getConfiguration();
+    configuration.isFixedLayout = !configuration.isFixedLayout;
+
+    expect(() => {
+      ladTableConfiguration.updateConfiguration(configuration);
+    }).not.toThrow();
+    expect(changed).toHaveBeenCalledWith(configuration);
   });
 
   describe('composition', () => {
@@ -288,6 +359,84 @@ describe('The LAD Table', () => {
       const actualRangeValue = parent.querySelector(TABLE_BODY_FIRST_ROW_THIRD_DATA).innerText;
       expect(actualRangeValue).toBe(rangeValue);
       expect(actualDomainValue).toBe(domainValue);
+    });
+  });
+
+  describe('telemetry object view', () => {
+    beforeEach(async () => {
+      let telemetryRequestResolve;
+      const telemetryRequestPromise = new Promise((resolve) => {
+        telemetryRequestResolve = resolve;
+      });
+
+      spyOnBuiltins(['requestAnimationFrame']);
+      window.requestAnimationFrame.and.callFake((callBack) => {
+        callBack();
+      });
+
+      historicalProvider.request = () => {
+        telemetryRequestResolve(mockTelemetry);
+
+        return telemetryRequestPromise;
+      };
+
+      openmct.time.bounds({
+        start: bounds.start,
+        end: bounds.end
+      });
+
+      const applicableViews = openmct.objectViews.get(mockObj.telemetry, [mockObj.telemetry]);
+      const ladTableViewProvider = applicableViews.find(
+        (viewProvider) => viewProvider.key === ladTableKey
+      );
+      const ladTableView = ladTableViewProvider.view(mockObj.telemetry, [mockObj.telemetry]);
+      ladTableView.show(child, false, { renderWhenVisible });
+
+      await telemetryRequestPromise;
+      await nextTick();
+      await nextTick();
+    });
+
+    it('should show a single row for the telemetry object itself', () => {
+      const rowCount = parent.querySelectorAll(TABLE_BODY_ROWS).length;
+
+      expect(rowCount).toBe(1);
+    });
+
+    it('should show the name provided for the telemetry producing object', () => {
+      const rowName = parent.querySelector(TABLE_BODY_FIRST_ROW_FIRST_DATA).innerText.trim();
+
+      expect(rowName).toBe(mockObj.telemetry.name);
+    });
+
+    it('should show the most recent datum from the telemetry producing object', async () => {
+      const latestDatum = getLatestTelemetry(mockTelemetry, { timeFormat });
+      const expectedDate = utcTimeFormat(latestDatum[timeFormat]);
+      await nextTick();
+
+      const latestDate = parent.querySelector(TABLE_BODY_FIRST_ROW_SECOND_DATA).innerText;
+
+      expect(latestDate).toBe(expectedDate);
+    });
+
+    describe('row context menu', () => {
+      beforeEach(() => {
+        spyOn(openmct.menus, 'actionsToMenuItems').and.returnValue([]);
+
+        parent.querySelector(TABLE_BODY_FIRST_ROW).dispatchEvent(createMouseEvent('contextmenu'));
+      });
+
+      it('should not repeat the telemetry object in the row object path', () => {
+        const objectPath = openmct.menus.actionsToMenuItems.calls.mostRecent().args[1];
+
+        expect(objectPath).toEqual([mockObj.telemetry]);
+      });
+
+      it('should not offer to remove the telemetry object from its parent', () => {
+        const actions = openmct.menus.actionsToMenuItems.calls.mostRecent().args[0];
+
+        expect(actions.some((action) => action?.key === 'remove')).toBe(false);
+      });
     });
   });
 });


### PR DESCRIPTION
Closes #8243

### Describe your changes:

Telemetry objects that come from a dictionary — a single measurement, a state, a position — could be opened as a **Plot** or a **Telemetry Table**, but not as a **LAD Table**. This adds LAD Table to their view menu, so you can look at the latest available value for one telemetry point on its own, without first creating a LAD Table and dropping the point into it.

**Why the view was missing:** `LADTableViewProvider.canView` required an object to both provide telemetry *and* support composition. A dictionary telemetry object has no composition, so it was filtered out.

**What changed**

- The LAD Table view is now offered for any telemetry object. Condition sets stay excluded, as before.
- A LAD Table with no composition shows the object it is viewing as its own single row — the same thing `TelemetryTable` already does for a single telemetry object.
- The LAD view takes `LOW` priority for those objects, so **Plot is still the default view** of a telemetry object. Objects that do have composition (LAD Tables, Derived Telemetry, Summary Widgets) keep the priority they had before.
- Because the row is now the view's own object, two consequences are handled: the row no longer repeats that object in its object path, and its context menu no longer offers **Remove** — which would have removed the object from its parent folder rather than from a table.
- View configuration (expand / autosize columns) is now kept in memory for read-only objects instead of throwing when it tries to persist. Dictionary objects are typically read-only, so this path is reachable for the first time here.

**A note for the reviewer:** the issue asks for "a latest available data view" without specifying its shape. This reads that as *the existing LAD Table view should apply to a single telemetry object*. The other reasonable reading — a purpose-built view, or one row per value in the object's metadata — would be a different change, so please redirect if that's what you had in mind.

### Testing instructions

1. Create a Sine Wave Generator (or use any telemetry point supplied by a dictionary).
2. Open it. It still opens as a **Plot** — unchanged.
3. Open the View Switcher menu. **LAD Table** is now listed alongside Plot and Telemetry Table.
4. Choose **LAD Table**. One row appears with the latest value, units, type and limit columns, updating in real time and colouring on limit violations.
5. Right-click the row. **View Full Datum** and **View Historical Data** appear; **Remove** does not.
6. Use the **Autosize Columns** / **Expand Columns** button in the view's status bar — the layout toggles without error.
7. Open a Condition Set and check its View Switcher — **LAD Table** is still absent.

Unit tests covering all of the above were added to `src/plugins/LADTable/pluginSpec.js`.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? — worth a mention: any deployment with the LAD Table plugin installed will now see a LAD Table option on every telemetry object. No API is broken, and default views are unchanged.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? — `type:enhancement`, matching the issue; I can't set labels on this repo.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?
