### PR TITLE
fix(webpack): move compiled js files into js directory (#6120)

### DIFF
--- a/.webpack/webpack.common.mjs
+++ b/.webpack/webpack.common.mjs
@@ -58,7 +58,7 @@ const config = {
   },
   output: {
     globalObject: 'this',
-    filename: '[name].js',
+    filename: 'js/[name].js',
     path: path.resolve(projectRootDir, 'dist'),
     library: {
       name: 'openmct',


### PR DESCRIPTION
Closes #6120

### Describe your changes:
Moves compiled JavaScript files into the `js` directory to resolve #6120.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
