### PR TITLE
condition sets default styling

### DIFF
--- a/e2e/tests/functional/plugins/styling/conditionSetStyling.e2e.spec.js
+++ b/e2e/tests/functional/plugins/styling/conditionSetStyling.e2e.spec.js
@@ -26,36 +26,37 @@ This test suite is dedicated to tests which verify the basic operations surround
 import {
   createDomainObjectWithDefaults,
   linkParameterToObject,
-  setRealTimeMode
+  setEndOffset,
+  setRealTimeMode,
+  setStartOffset
 } from '../../../../appActions.js';
 import { MISSION_TIME } from '../../../../constants.js';
 import { expect, test } from '../../../../pluginFixtures.js';
 
 test.describe('Conditionally Styling, using a Condition Set', () => {
-  let stateGenerator;
   let conditionSet;
   let displayLayout;
-  const STATE_CHANGE_INTERVAL = '1';
+  let textElement;
+  let styledElement;
+
+  const onBG = 'background-color: rgb(0, 255, 0);';
+  const offBG = 'background-color: rgb(255, 0, 0);';
+  const defaultBG = 'background-color: rgb(0, 0, 255);';
 
   test.beforeEach(async ({ page }) => {
     // Install the clock and set the time to the mission time such that the state generator will be controllable
     await page.clock.install({ time: MISSION_TIME });
-    await page.clock.resume();
+
     await page.goto('./', { waitUntil: 'domcontentloaded' });
-    // Create Condition Set, State Generator, and Display Layout
+
+    textElement = page.getByLabel('Alpha-numeric telemetry value').locator('div:first-child');
+    styledElement = page.getByLabel('Box', { exact: true });
+
+    // Create Condition Set and Display Layout
     conditionSet = await createDomainObjectWithDefaults(page, {
       type: 'Condition Set',
       name: 'Test Condition Set'
     });
-    stateGenerator = await createDomainObjectWithDefaults(page, {
-      type: 'State Generator',
-      name: 'One Second State Generator'
-    });
-    // edit the state generator to have a 1 second update rate
-    await page.getByTitle('More actions').click();
-    await page.getByRole('menuitem', { name: 'Edit Properties...' }).click();
-    await page.getByLabel('State Duration (seconds)', { exact: true }).fill(STATE_CHANGE_INTERVAL);
-    await page.getByLabel('Save').click();
 
     displayLayout = await createDomainObjectWithDefaults(page, {
       type: 'Display Layout',
@@ -66,10 +67,19 @@ test.describe('Conditionally Styling, using a Condition Set', () => {
   test('Conditional styling, using a Condition Set, will style correctly based on the output @clock', async ({
     page
   }) => {
-    test.info().annotations.push({
-      type: 'issue',
-      description: 'https://github.com/nasa/openmct/issues/7840'
+    const STATE_CHANGE_INTERVAL = '1';
+    const stateGenerator = await createDomainObjectWithDefaults(page, {
+      type: 'State Generator',
+      name: 'One Second State Generator'
     });
+
+    await page.clock.resume();
+
+    // edit the state generator to have a 1 second update rate
+    await page.getByTitle('More actions').click();
+    await page.getByRole('menuitem', { name: 'Edit Properties...' }).click();
+    await page.getByLabel('State Duration (seconds)', { exact: true }).fill(STATE_CHANGE_INTERVAL);
+    await page.getByLabel('Save').click();
 
     // set up the condition set to use the state generator
     await page.goto(conditionSet.url, { waitUntil: 'domcontentloaded' });
@@ -85,23 +95,35 @@ test.describe('Conditionally Styling, using a Condition Set', () => {
       })
       .dragTo(page.locator('#conditionCollection'));
 
-    // Add the state generator to the first criterion such that there is a condition named 'OFF' when the state generator is off
+    // Add a condition named 'OFF' when the state generator is off
     await page.getByLabel('Add Condition').click();
+    await page.getByLabel('Condition Name Input').first().fill('OFF');
     await page.getByLabel('Criterion Telemetry Selection').selectOption({ value: 'all' });
     await page.getByLabel('Criterion Metadata Selection').selectOption({ label: 'State' });
     await page.getByLabel('Criterion Comparison Selection').selectOption({ label: 'is' });
-    await page.getByLabel('Condition Name Input').first().fill('OFF');
+    await page.getByLabel('Criterion Else Selection').selectOption({ label: 'OFF' });
+
+    // Add a condition named 'ON' when the state generator is on
+    await page.getByLabel('Add Condition').click();
+    await page.getByLabel('Condition Name Input').first().fill('ON');
+    await page.getByLabel('Condition Output Type').first().selectOption({ value: 'true' });
+    await page.getByLabel('Criterion Telemetry Selection').first().selectOption({ value: 'all' });
+    await page.getByLabel('Criterion Metadata Selection').first().selectOption({ label: 'State' });
+    await page.getByLabel('Criterion Comparison Selection').first().selectOption({ label: 'is' });
+    await page.getByLabel('Criterion Else Selection').first().selectOption({ label: 'ON' });
+
+    // Save the condition set
     await page.getByLabel('Save').click();
     await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
 
     await linkParameterToObject(page, stateGenerator.name, displayLayout.name);
 
-    //Add a box to the display layout
+    // Add a box to the display layout
     await page.goto(displayLayout.url, { waitUntil: 'domcontentloaded' });
     await page.getByLabel('Edit Object').click();
 
-    //Add a box to the display layout and move it to the right
-    //TEMP: Click the layout such that the state generator is deselected
+    // Add a box to the display layout and move it to the right
+    // TEMP: Click the layout such that the state generator is deselected
     await page.getByLabel('Test Display Layout Layout Grid').locator('div').nth(1).click();
     await page.getByLabel('Add Drawing Object').click();
     await page.getByText('Box').click();
@@ -109,39 +131,162 @@ test.describe('Conditionally Styling, using a Condition Set', () => {
     await page.getByLabel('X:').fill('10');
     await page.getByLabel('X:').press('Enter');
 
-    // set up conditional styling such that the box is red when the state generator condition is 'OFF'
+    // set up conditional styling
     await page.getByRole('tab', { name: 'Styles' }).click();
     await page.getByRole('button', { name: 'Use Conditional Styling...' }).click();
     await page.getByLabel('Modal Overlay').getByLabel('Expand My Items folder').click();
     await page.getByLabel('Modal Overlay').getByLabel(`Preview ${conditionSet.name}`).click();
     await page.getByText('Ok').click();
-    await page.getByLabel('Set background color').first().click();
+
+    // style box green when the state generator condition is 'ON'
+    page
+      .locator('.c-inspect-styles__condition')
+      .filter({ hasText: 'ON Match' })
+      .getByLabel('Set background color')
+      .click();
+    await page.getByLabel('#00ff00').click();
+
+    // style box red when the state generator condition is 'OFF'
+    page
+      .locator('.c-inspect-styles__condition')
+      .filter({ hasText: 'OFF Match' })
+      .getByLabel('Set background color')
+      .click();
     await page.getByLabel('#ff0000').click();
+
+    // save the display layout
     await page.getByLabel('Save', { exact: true }).click();
     await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
 
     await setRealTimeMode(page);
 
-    //Pause at a time when the state generator is 'OFF' which is 20 minutes in the future
+    // Pause at a time when the state generator is 'OFF' which is 20 minutes in the future
     await page.clock.pauseAt(new Date(MISSION_TIME + 1200000));
-
-    const redBG = 'background-color: rgb(255, 0, 0);';
-    const defaultBG = 'background-color: rgb(102, 102, 102);';
-    const textElement = page.getByLabel('Alpha-numeric telemetry value').locator('div:first-child');
-    const styledElement = page.getByLabel('Box', { exact: true });
 
     await page.clock.resume();
 
     // Check if the style is red when text is 'OFF'
     await expect(textElement).toHaveText('OFF');
-    await waitForStyleChange(styledElement, redBG);
+    await waitForStyleChange(styledElement, offBG);
 
     // Fast forward to the next state change
     await page.clock.fastForward(STATE_CHANGE_INTERVAL * 1000);
 
     // Check if the style is not red when text is 'ON'
     await expect(textElement).toHaveText('ON');
+    await waitForStyleChange(styledElement, onBG);
+  });
+
+  test('Conditional styling, using a Condition Set, will be the default style if no conditions match, including if no telemetry has been received @clock', async ({
+    page
+  }) => {
+    const LOADING_DELAY = 5000;
+    const sineWaveGenerator = await createDomainObjectWithDefaults(page, {
+      type: 'Sine Wave Generator',
+      name: 'Sine Wave Generator'
+    });
+
+    await setRealTimeMode(page);
+    await setStartOffset(page, {
+      submitChanges: true,
+      startHours: '00',
+      startMins: '00',
+      startSecs: '02'
+    });
+    await setEndOffset(page, {
+      submitChanges: true,
+      endHours: '00',
+      endMins: '00',
+      endSecs: '01'
+    });
+
+    // edit the sine wave generator to have a 5 second loading delay
+    await page.getByTitle('More actions').click();
+    await page.getByRole('menuitem', { name: 'Edit Properties...' }).click();
+    await page.getByLabel('Loading Delay (ms)', { exact: true }).fill(`${LOADING_DELAY}`);
+    await page.getByLabel('Save').click();
+
+    // set up the condition set to use the state generator
+    await page.goto(conditionSet.url, { waitUntil: 'domcontentloaded' });
+
+    // Add the Sine Wave Generator to the Condition Set by dragging from the main tree
+    await page.getByLabel('Show selected item in tree').click();
+    await page
+      .getByRole('tree', {
+        name: 'Main Tree'
+      })
+      .getByRole('treeitem', {
+        name: sineWaveGenerator.name
+      })
+      .dragTo(page.locator('#conditionCollection'));
+
+    // Add a condition named 'ON' when the since wave generator has data
+    await page.getByLabel('Add Condition').click();
+    await page.getByLabel('Condition Name Input').first().fill('ON');
+    await page.getByLabel('Criterion Telemetry Selection').selectOption({ value: 'all' });
+    await page.getByLabel('Criterion Metadata Selection').selectOption({ label: 'Sine' });
+    await page.getByLabel('Criterion Comparison Selection').selectOption({ label: 'is defined' });
+
+    // Save the condition set
+    await page.getByLabel('Save').click();
+    await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
+
+    await linkParameterToObject(page, sineWaveGenerator.name, displayLayout.name);
+
+    // Add a box to the display layout
+    await page.goto(displayLayout.url, { waitUntil: 'domcontentloaded' });
+    await page.getByLabel('Edit Object').click();
+
+    // Add a box to the display layout and move it to the right
+    // TEMP: Click the layout such that the sine wave generator is deselected
+    await page.getByLabel('Test Display Layout Layout Grid').locator('div').nth(1).click();
+    await page.getByLabel('Add Drawing Object').click();
+    await page.getByText('Box').click();
+    await page.getByLabel('X:').click();
+    await page.getByLabel('X:').fill('10');
+    await page.getByLabel('X:').press('Enter');
+
+    // set up conditional styling
+    await page.getByRole('tab', { name: 'Styles' }).click();
+    await page.getByRole('button', { name: 'Use Conditional Styling...' }).click();
+    await page.getByLabel('Modal Overlay').getByLabel('Expand My Items folder').click();
+    await page.getByLabel('Modal Overlay').getByLabel(`Preview ${conditionSet.name}`).click();
+    await page.getByText('Ok').click();
+
+    // style box green when the sine wave generator condition is 'ON'
+    page
+      .locator('.c-inspect-styles__condition')
+      .filter({ hasText: 'ON Match' })
+      .getByLabel('Set background color')
+      .click();
+    await page.getByLabel('#00ff00').click();
+
+    // style box blue when the state generator condition is 'Default'
+    page
+      .locator('.c-inspect-styles__condition')
+      .filter({ hasText: 'Default Match' })
+      .getByLabel('Set background color')
+      .click();
+    await page.getByLabel('#0000ff').click();
+
+    // save the display layout
+    await page.getByLabel('Save', { exact: true }).click();
+    await page.getByRole('listitem', { name: 'Save and Finish Editing' }).click();
+
+    // Check before telemetry is received the style is 'Default'
+    // and the condition output is '---'
+    await expect(textElement).toHaveText('---');
     await waitForStyleChange(styledElement, defaultBG);
+
+    await page.clock.resume();
+
+    // Fast forward to the next state change
+    await page.clock.fastForward(LOADING_DELAY);
+
+    // Check after telemetry is received the style is 'ON'
+    // and the condition output is not '---'
+    await expect(textElement).not.toHaveText('---');
+    await waitForStyleChange(styledElement, onBG);
   });
 });
 

--- a/src/plugins/condition/StyleRuleManager.js
+++ b/src/plugins/condition/StyleRuleManager.js
@@ -35,13 +35,15 @@ export default class StyleRuleManager extends EventEmitter {
     }
 
     if (styleConfiguration) {
-      // We don't set the selectedConditionId here because we want condition set computation to happen before we apply any selected style
+      // set selectedConditionId to undefined initially
+      // so that the default style is applied prior to condition calculations
       const styleConfigurationWithNoSelection = Object.assign(styleConfiguration, {
-        selectedConditionId: ''
+        selectedConditionId: undefined
       });
       this.initialize(styleConfigurationWithNoSelection);
       if (styleConfiguration.conditionSetIdentifier) {
         this.openmct.time.on('boundsChanged', this.refreshData);
+        this.applySelectedConditionStyle();
         this.subscribeToConditionSet();
       } else {
         this.applyStaticStyle();
@@ -61,7 +63,7 @@ export default class StyleRuleManager extends EventEmitter {
         this.applySelectedConditionStyle();
       }
     } else if (this.conditionSetIdentifier) {
-      //reset the selected style and let the condition set output determine what it should be
+      // reset the selected style to the default style
       this.selectedConditionId = this.defaultConditionId;
       this.applySelectedConditionStyle();
       this.updateDomainObjectStyle();
@@ -70,10 +72,10 @@ export default class StyleRuleManager extends EventEmitter {
   }
 
   initialize(styleConfiguration) {
-    this.conditionSetIdentifier = styleConfiguration.conditionSetIdentifier;
-    this.selectedConditionId = styleConfiguration.selectedConditionId;
-    this.staticStyle = styleConfiguration.staticStyle;
     this.defaultConditionId = styleConfiguration.defaultConditionId;
+    this.conditionSetIdentifier = styleConfiguration.conditionSetIdentifier;
+    this.selectedConditionId = styleConfiguration.selectedConditionId ?? this.defaultConditionId;
+    this.staticStyle = styleConfiguration.staticStyle;
     this.updateConditionStylesMap(styleConfiguration.styles || []);
   }
 
@@ -186,7 +188,7 @@ export default class StyleRuleManager extends EventEmitter {
   }
 
   applySelectedConditionStyle() {
-    const conditionId = this.selectedConditionId || this.defaultConditionId;
+    const conditionId = this.selectedConditionId ?? this.defaultConditionId;
     if (!conditionId) {
       this.applyStaticStyle();
     } else if (this.conditionalStyleMap[conditionId]) {

--- a/src/plugins/condition/StyleRuleManager.js
+++ b/src/plugins/condition/StyleRuleManager.js
@@ -62,8 +62,8 @@ export default class StyleRuleManager extends EventEmitter {
       }
     } else if (this.conditionSetIdentifier) {
       //reset the selected style and let the condition set output determine what it should be
-      this.selectedConditionId = undefined;
-      this.currentStyle = undefined;
+      this.selectedConditionId = this.defaultConditionId;
+      this.applySelectedConditionStyle();
       this.updateDomainObjectStyle();
       this.subscribeToConditionSet();
     }

--- a/src/plugins/condition/components/ConditionCollection.vue
+++ b/src/plugins/condition/components/ConditionCollection.vue
@@ -47,8 +47,8 @@
           criteria.</template
         >
         <template v-else
-          >The first condition to match is the one that is applied. Drag conditions to
-          reorder.</template
+          >The first condition to match is the one that is applied. Conditions, including default,
+          evaluate on receipt of telemetry. Drag conditions to reorder.</template
         >
       </div>
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #8397
Closes #5925

### Describe your changes:
- [x] Leave condition sets as they are. They will continue to be event-driven on receipt of telemetry
- [x] Modify conditional styling logic to always apply default styling on load
- [x] Add some verbiage to the condition set editor to make it clear that rules only execute on receipt of telemetry.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [x] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [x] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
