### PR TITLE
feat: configure purgecss to remove unused CSS (#7021)

### DIFF
--- a/.webpack/webpack.common.mjs
+++ b/.webpack/webpack.common.mjs
@@ -58,7 +58,7 @@ const config = {
   },
   output: {
     globalObject: 'this',
-    filename: '[name].js',
+    filename: 'js/[name].js',
     path: path.resolve(projectRootDir, 'dist'),
     library: {
       name: 'openmct',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@babel/eslint-parser": "7.23.3",
         "@braintree/sanitize-url": "7.1.1",
+        "@fullhuman/postcss-purgecss": "^8.0.0",
         "@types/d3-axis": "3.0.6",
         "@types/d3-scale": "4.0.8",
         "@types/d3-selection": "3.0.10",
@@ -1895,6 +1896,19 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fullhuman/postcss-purgecss": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-8.0.0.tgz",
+      "integrity": "sha512-fSRaBGf6+DYdfQMxedWfnIW8FSYE1LBpgy16jpK1L2vNb1HgeBRRZ+UX4UokNmW7YEAwPdvwkKdYtlkYpH+Aqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "purgecss": "^8.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -9056,6 +9070,46 @@
       "version": "1.4.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/purgecss": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-8.0.0.tgz",
+      "integrity": "sha512-QFJyps9y5oHeXnNA3Ql1EaAqWBivNwQn19Pw1lt9RxfB+4e+bIyqCyuombk79D6Fxe+lPXggVfI1WtRGEBwgbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "fast-glob": "^3.3.2",
+        "postcss": "^8.4.47",
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "bin": {
+        "purgecss": "bin/purgecss.js"
+      }
+    },
+    "node_modules/purgecss/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/purgecss/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/qjobs": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "7.23.3",
     "@braintree/sanitize-url": "7.1.1",
+    "@fullhuman/postcss-purgecss": "^8.0.0",
     "@types/d3-axis": "3.0.6",
     "@types/d3-scale": "4.0.8",
     "@types/d3-selection": "3.0.10",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,14 @@
+const purgecss = require('@fullhuman/postcss-purgecss')({
+  content: [
+    './src/**/*.html',
+    './src/**/*.vue',
+    './src/**/*.js'
+  ],
+  defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
+});
+
+module.exports = {
+  plugins: [
+    ...(process.env.NODE_ENV === 'production' ? [purgecss] : [])
+  ]
+};


### PR DESCRIPTION
Closes #7021

### Describe your changes:
Configured PostCSS with `@fullhuman/postcss-purgecss` plugin in `postcss.config.js` to automatically clean up and remove unused CSS styles during production builds.

### Author Checklist

* [x] Changes address original issue?
* [x] Has this been smoke tested?