### PR TITLE
CouchDB setup script now reports failures instead of hiding them

### DIFF
--- a/.github/workflows/e2e-couchdb.yml
+++ b/.github/workflows/e2e-couchdb.yml
@@ -33,6 +33,9 @@ jobs:
 
       - run: npm exec --workspace e2e -- playwright install --with-deps
 
+      - name: Test CouchDB Setup Script
+        run: bash src/plugins/persistence/couch/setup-couchdb.test.sh
+
       - name: Start CouchDB Docker Container and Init with Setup Scripts
         run: |
           export $(cat src/plugins/persistence/couch/.env.ci | xargs)

--- a/src/plugins/persistence/couch/setup-couchdb.sh
+++ b/src/plugins/persistence/couch/setup-couchdb.sh
@@ -36,12 +36,23 @@ create_db() {
     echo "$response"
 }
 
+# Echo TRUE if the admin user exists, FALSE if CouchDB says it does not, and
+# ERROR if CouchDB could not be reached or gave any other answer. Reporting
+# FALSE for every failure would make an unreachable server or bad credentials
+# look like a missing user.
 admin_user_exists() {
-    response=$(curl -su "${CURL_USERPASS_ARG}" -o /dev/null -I -w "%{http_code}" "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/admins/"$COUCH_ADMIN_USER");
-    if [ "200" == "${response}" ]; then
+    local curl_status=0
+    response=$(curl -su "${CURL_USERPASS_ARG}" -o /dev/null -I -w "%{http_code}" "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/admins/"$COUCH_ADMIN_USER") || curl_status=$?
+    if [ 0 -ne "${curl_status}" ]; then
+        echo "Could not reach CouchDB at $COUCH_BASE_LOCAL (curl exited ${curl_status})" 1>&2
+        echo "ERROR"
+    elif [ "200" == "${response}" ]; then
         echo "TRUE"
+    elif [ "404" == "${response}" ]; then
+        echo "FALSE"
     else
-        echo "FALSE";
+        echo "Unexpected response ${response} when checking for admin user $COUCH_ADMIN_USER" 1>&2
+        echo "ERROR"
     fi
 }
 
@@ -224,8 +235,14 @@ add_index_and_views() {
 
 # Main script execution
 
-# Check if the admin user exists; if not, create it.
-if [ "$(admin_user_exists)" == "FALSE" ]; then
+# Check if the admin user exists; if not, create it. An indeterminate answer
+# means CouchDB is unreachable or misconfigured, so stop instead of guessing.
+admin_user_status=$(admin_user_exists)
+if [ "ERROR" == "${admin_user_status}" ]; then
+    echo "Unable to determine whether the admin user exists at $COUCH_BASE_LOCAL, aborting." 1>&2
+    echo "Check that CouchDB is running and that COUCH_ADMIN_USER, COUCH_ADMIN_PASSWORD and COUCH_NODE_NAME are correct." 1>&2
+    exit 1
+elif [ "FALSE" == "${admin_user_status}" ]; then
     echo "Admin user does not exist, creating..."
     create_admin_user
 else

--- a/src/plugins/persistence/couch/setup-couchdb.test.sh
+++ b/src/plugins/persistence/couch/setup-couchdb.test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Tests for setup-couchdb.sh.
+#
+# These need nothing beyond bash: a stub `curl` is placed ahead of the real one
+# on PATH and setup-couchdb.sh is run as a subprocess, so both
+# admin_user_exists() and the code that acts on its answer are exercised.
+#
+# Run with: bash src/plugins/persistence/couch/setup-couchdb.test.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="${SCRIPT_DIR}/setup-couchdb.sh"
+
+STUB_DIR="$(mktemp -d)"
+STDOUT_FILE="${STUB_DIR}/stdout"
+STDERR_FILE="${STUB_DIR}/stderr"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+
+FAILURES=0
+FAILURES_BEFORE_TEST=0
+CURRENT_TEST=""
+EXIT_CODE=0
+STDOUT=""
+STDERR=""
+
+# A stand-in for curl. Every request is answered as though CouchDB is healthy,
+# except the admin config lookup, whose transport result and HTTP status the
+# tests drive through MOCK_ADMIN_CURL_RC and MOCK_ADMIN_HTTP_CODE.
+cat > "${STUB_DIR}/curl" <<'STUB'
+#!/bin/bash
+is_admin_request=false
+is_status_request=false
+for argument in "$@"; do
+    case "${argument}" in
+        *"/_config/admins/"*) is_admin_request=true ;;
+        "%{http_code}") is_status_request=true ;;
+    esac
+done
+
+if [ "${is_admin_request}" = true ] && [ "${MOCK_ADMIN_CURL_RC:-0}" -ne 0 ]; then
+    echo "curl: (${MOCK_ADMIN_CURL_RC}) stubbed transport failure" 1>&2
+    exit "${MOCK_ADMIN_CURL_RC}"
+fi
+
+if [ "${is_status_request}" = true ]; then
+    if [ "${is_admin_request}" = true ]; then
+        echo "${MOCK_ADMIN_HTTP_CODE:-200}"
+    else
+        echo "200"
+    fi
+elif [[ "$*" == *"/_index"* ]]; then
+    echo '{"result":"created"}'
+else
+    echo '{"ok":true}'
+fi
+STUB
+chmod +x "${STUB_DIR}/curl"
+
+run_setup_script() {
+    MOCK_ADMIN_HTTP_CODE="$1" \
+    MOCK_ADMIN_CURL_RC="$2" \
+    PATH="${STUB_DIR}:${PATH}" \
+    OPENMCT_DATABASE_NAME="openmct" \
+    COUCH_ADMIN_USER="admin" \
+    COUCH_ADMIN_PASSWORD="password" \
+    COUCH_BASE_LOCAL="http://localhost:5984" \
+    COUCH_NODE_NAME="nonode@nohost" \
+        bash "${SETUP_SCRIPT}" > "${STDOUT_FILE}" 2> "${STDERR_FILE}"
+    EXIT_CODE=$?
+    STDOUT="$(cat "${STDOUT_FILE}")"
+    STDERR="$(cat "${STDERR_FILE}")"
+}
+
+fail() {
+    echo "    FAIL: $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+expect_exit_code() {
+    if [ "${EXIT_CODE}" -ne "$1" ]; then
+        fail "expected exit code $1, got ${EXIT_CODE}"
+    fi
+}
+
+expect_failed_exit_code() {
+    if [ "${EXIT_CODE}" -eq 0 ]; then
+        fail "expected a non-zero exit code, got 0"
+    fi
+}
+
+expect_stdout_contains() {
+    if [[ "${STDOUT}" != *"$1"* ]]; then
+        fail "expected stdout to contain '$1'"
+    fi
+}
+
+expect_stdout_missing() {
+    if [[ "${STDOUT}" == *"$1"* ]]; then
+        fail "expected stdout not to contain '$1'"
+    fi
+}
+
+expect_stderr_contains() {
+    if [[ "${STDERR}" != *"$1"* ]]; then
+        fail "expected stderr to contain '$1'"
+    fi
+}
+
+begin_test() {
+    CURRENT_TEST="$1"
+    FAILURES_BEFORE_TEST=${FAILURES}
+}
+
+end_test() {
+    if [ "${FAILURES}" -gt "${FAILURES_BEFORE_TEST}" ]; then
+        echo "FAIL ${CURRENT_TEST}"
+        echo "    --- stdout ---"
+        sed 's/^/    /' "${STDOUT_FILE}"
+        echo "    --- stderr ---"
+        sed 's/^/    /' "${STDERR_FILE}"
+    else
+        echo "ok   ${CURRENT_TEST}"
+    fi
+}
+
+echo "Running ${SETUP_SCRIPT} tests"
+
+begin_test "reports the admin user as present when CouchDB answers 200"
+run_setup_script 200 0
+expect_exit_code 0
+expect_stdout_contains "Admin user exists"
+expect_stdout_missing "Admin user does not exist"
+end_test
+
+begin_test "creates the admin user when CouchDB answers 404"
+run_setup_script 404 0
+expect_exit_code 0
+expect_stdout_contains "Admin user does not exist, creating..."
+end_test
+
+begin_test "aborts when CouchDB cannot be reached"
+run_setup_script 000 7
+expect_failed_exit_code
+expect_stdout_missing "Admin user does not exist"
+expect_stderr_contains "Unable to determine whether the admin user exists"
+expect_stderr_contains "http://localhost:5984"
+end_test
+
+begin_test "aborts when CouchDB rejects the credentials"
+run_setup_script 401 0
+expect_failed_exit_code
+expect_stdout_missing "Admin user does not exist"
+expect_stderr_contains "Unable to determine whether the admin user exists"
+expect_stderr_contains "401"
+end_test
+
+begin_test "aborts when CouchDB reports a server error"
+run_setup_script 500 0
+expect_failed_exit_code
+expect_stdout_missing "Admin user does not exist"
+expect_stderr_contains "Unable to determine whether the admin user exists"
+expect_stderr_contains "500"
+end_test
+
+if [ "${FAILURES}" -gt 0 ]; then
+    echo "${FAILURES} assertion(s) failed"
+    exit 1
+fi
+
+echo "All assertions passed"

--- a/src/plugins/persistence/couch/setup-couchdb.test.sh
+++ b/src/plugins/persistence/couch/setup-couchdb.test.sh
@@ -16,6 +16,7 @@ SETUP_SCRIPT="${SCRIPT_DIR}/setup-couchdb.sh"
 STUB_DIR="$(mktemp -d)"
 STDOUT_FILE="${STUB_DIR}/stdout"
 STDERR_FILE="${STUB_DIR}/stderr"
+REQUEST_LOG_FILE="${STUB_DIR}/requests"
 trap 'rm -rf "${STUB_DIR}"' EXIT
 
 FAILURES=0
@@ -30,6 +31,7 @@ STDERR=""
 # tests drive through MOCK_ADMIN_CURL_RC and MOCK_ADMIN_HTTP_CODE.
 cat > "${STUB_DIR}/curl" <<'STUB'
 #!/bin/bash
+echo "$*" >> "${MOCK_REQUEST_LOG:-/dev/null}"
 is_admin_request=false
 is_status_request=false
 for argument in "$@"; do
@@ -58,16 +60,26 @@ fi
 STUB
 chmod +x "${STUB_DIR}/curl"
 
+# Usage: run_setup_script <admin-http-code> <admin-curl-rc> [direct]
+# By default the script is started with `bash`, which skips the shebang and its
+# -e flag — exactly how CI starts it. Pass "direct" to execute the script
+# itself, so the `#!/bin/bash -e` line applies as it does for ./setup-couchdb.sh.
 run_setup_script() {
+    local launcher=(bash "${SETUP_SCRIPT}")
+    if [ "${3:-bash}" = "direct" ]; then
+        launcher=("${SETUP_SCRIPT}")
+    fi
+    : > "${REQUEST_LOG_FILE}"
     MOCK_ADMIN_HTTP_CODE="$1" \
     MOCK_ADMIN_CURL_RC="$2" \
+    MOCK_REQUEST_LOG="${REQUEST_LOG_FILE}" \
     PATH="${STUB_DIR}:${PATH}" \
     OPENMCT_DATABASE_NAME="openmct" \
     COUCH_ADMIN_USER="admin" \
     COUCH_ADMIN_PASSWORD="password" \
     COUCH_BASE_LOCAL="http://localhost:5984" \
     COUCH_NODE_NAME="nonode@nohost" \
-        bash "${SETUP_SCRIPT}" > "${STDOUT_FILE}" 2> "${STDERR_FILE}"
+        "${launcher[@]}" > "${STDOUT_FILE}" 2> "${STDERR_FILE}"
     EXIT_CODE=$?
     STDOUT="$(cat "${STDOUT_FILE}")"
     STDERR="$(cat "${STDERR_FILE}")"
@@ -108,6 +120,28 @@ expect_stderr_contains() {
     fi
 }
 
+# The stub logs every curl invocation's arguments, one line per request; these
+# match that log with grep -E, so tests can assert what was asked of CouchDB.
+expect_request_matching() {
+    if ! grep -qE -- "$1" "${REQUEST_LOG_FILE}"; then
+        fail "expected a curl request matching '$1'"
+    fi
+}
+
+expect_no_request_matching() {
+    if grep -qE -- "$1" "${REQUEST_LOG_FILE}"; then
+        fail "expected no curl request matching '$1'"
+    fi
+}
+
+expect_request_count() {
+    local actual
+    actual="$(wc -l < "${REQUEST_LOG_FILE}" | tr -d '[:space:]')"
+    if [ "${actual}" -ne "$1" ]; then
+        fail "expected $1 curl request(s), got ${actual}"
+    fi
+}
+
 begin_test() {
     CURRENT_TEST="$1"
     FAILURES_BEFORE_TEST=${FAILURES}
@@ -127,41 +161,57 @@ end_test() {
 
 echo "Running ${SETUP_SCRIPT} tests"
 
-begin_test "reports the admin user as present when CouchDB answers 200"
+begin_test "reports the admin user as present when CouchDB answers 200, and leaves it alone"
 run_setup_script 200 0
 expect_exit_code 0
 expect_stdout_contains "Admin user exists"
 expect_stdout_missing "Admin user does not exist"
+expect_no_request_matching "X PUT .*/_config/admins/"
 end_test
 
 begin_test "creates the admin user when CouchDB answers 404"
 run_setup_script 404 0
 expect_exit_code 0
 expect_stdout_contains "Admin user does not exist, creating..."
+expect_request_matching "X PUT .*/_config/admins/admin"
 end_test
 
-begin_test "aborts when CouchDB cannot be reached"
+begin_test "aborts before doing any setup work when CouchDB cannot be reached"
 run_setup_script 000 7
 expect_failed_exit_code
 expect_stdout_missing "Admin user does not exist"
+expect_stdout_missing "Successfully created"
+expect_stdout_missing "Creating"
+expect_request_count 1
 expect_stderr_contains "Unable to determine whether the admin user exists"
 expect_stderr_contains "http://localhost:5984"
 end_test
 
-begin_test "aborts when CouchDB rejects the credentials"
+begin_test "aborts before doing any setup work when CouchDB rejects the credentials"
 run_setup_script 401 0
 expect_failed_exit_code
 expect_stdout_missing "Admin user does not exist"
+expect_stdout_missing "Successfully created"
+expect_request_count 1
 expect_stderr_contains "Unable to determine whether the admin user exists"
 expect_stderr_contains "401"
 end_test
 
-begin_test "aborts when CouchDB reports a server error"
+begin_test "aborts before doing any setup work when CouchDB reports a server error"
 run_setup_script 500 0
 expect_failed_exit_code
 expect_stdout_missing "Admin user does not exist"
+expect_stdout_missing "Successfully created"
+expect_request_count 1
 expect_stderr_contains "Unable to determine whether the admin user exists"
 expect_stderr_contains "500"
+end_test
+
+begin_test "aborts just as loudly when executed directly, with the shebang's -e active"
+run_setup_script 000 7 direct
+expect_failed_exit_code
+expect_stdout_missing "Admin user does not exist"
+expect_stderr_contains "Unable to determine whether the admin user exists"
 end_test
 
 if [ "${FAILURES}" -gt 0 ]; then


### PR DESCRIPTION
Closes #8373

### Describe your changes:

The CouchDB setup script begins by asking CouchDB whether the admin user already exists. Until now, that check treated **every** unsuccessful answer as "the admin user is missing". A database that wasn't running yet, a wrong password, or a wrong node name all looked exactly the same as a genuinely missing user. The script would then announce *"Admin user does not exist, creating..."* and keep going against a server it couldn't actually talk to. This is what the issue reports, and the reporter also sketched the fix.

While reproducing it, a second problem turned up that makes the first one worse. The script starts with `#!/bin/bash -e`, but that only takes effect when the file is run directly. Our own CI starts it with `bash setup-couchdb.sh`, which ignores the shebang line — so "stop on the first error" was never actually switched on there. With CouchDB stopped, the old script printed *"Successfully created"* for every index and view and exited **0**. A completely failed setup looked like a completely successful one.

So this change makes the script stop on its own rather than relying on `-e`. The admin check now reports three outcomes instead of two:

* **200** — the admin user exists → carry on (unchanged)
* **404** — the admin user really is missing → create it (unchanged)
* **anything else, or `curl` couldn't connect** — say what actually happened and stop with a non-zero exit code

The two normal outcomes behave exactly as they do today, so a healthy setup run is byte-for-byte identical. Only the failure cases changed, and they're now loud instead of silent.

One thing worth a reviewer's judgement: this does change behaviour for anyone scripting around `setup-couchdb.sh`, because it can now exit non-zero where it previously carried on. That seems like the point of the issue, but flagging it rather than burying it.

I deliberately left `resource_exists()` alone even though it has the same shape, since the issue names the admin check specifically — and now that the admin check stops the script, connectivity and credentials are already proven by the time anything else runs.

### What changed

* **`setup-couchdb.sh`** — the admin check now tells "not found" apart from "couldn't ask", and prints what it saw: the address it couldn't reach, or the unexpected status code it got back. On an unclear answer the script stops and points at the likely cause (server not running, or wrong `COUCH_ADMIN_USER` / `COUCH_ADMIN_PASSWORD` / `COUCH_NODE_NAME`).
* **`setup-couchdb.test.sh`** — new, and adds no dependency. It puts a stand-in `curl` on `PATH` and runs the real script as a subprocess, so both the check and the code reacting to it are covered. Six cases: admin present, admin missing, connection refused, credentials rejected, server error, and direct execution (so the shebang's `-e` is active, the way it isn't when CI starts the script with `bash`). The stub also records every request it receives, so the tests assert deeds as well as messages: the admin-creation `PUT` really goes out on 404, doesn't go out on 200, and an aborting run stops before doing any setup work at all.
* **`.github/workflows/e2e-couchdb.yml`** — runs that test before starting the container, so it can't quietly rot.

### How to test

The automated test needs nothing but bash, and runs in about a second:

```
bash src/plugins/persistence/couch/setup-couchdb.test.sh
```

It should print six `ok` lines. Running that same command against `master` shows the bug — four of the six cases fail there.

To see it by hand, with the CouchDB container **stopped**:

```
export $(cat src/plugins/persistence/couch/.env.ci | xargs)
bash src/plugins/persistence/couch/setup-couchdb.sh; echo "exit: $?"
```

On `master` this prints *"Admin user does not exist, creating..."*, then *"Successfully created"* for every index, and exits **0**. On this branch it explains that it could not reach CouchDB and exits **1**.

Then start the container and run the same command again, to confirm the normal path is untouched:

```
docker compose -f src/plugins/persistence/couch/couchdb-compose.yaml up --detach
bash src/plugins/persistence/couch/setup-couchdb.sh; echo "exit: $?"
```

It should print *"Admin user exists"* and finish exactly as it does today.

**What I verified, and what I couldn't:** I ran the script end to end against a real HTTP server on a real socket (real `curl`, real connection) for all four cases, both as `bash setup-couchdb.sh` and executed directly; the full unit suite and `npm run lint` are clean, and `shellcheck` reports nothing new. I did not have Docker on hand, so the one step I could not do myself is the run against an actual CouchDB container — the `e2e-couchdb` job covers that.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

