### PR TITLE
Refuse telemetry table regex filters that can freeze the tab

### DIFF
--- a/src/api/telemetry/BatchingWebSocket.js
+++ b/src/api/telemetry/BatchingWebSocket.js
@@ -19,6 +19,7 @@
  * this source code distribution or the Licensing information page available
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
+import { createSafeRegExp } from '../../utils/safeRegExp.js';
 import installWorker from './WebSocketWorker.js';
 
 /**
@@ -131,7 +132,25 @@ class BatchingWebSocket extends EventTarget {
     this.#throttleRate = throttleRate;
     this.#sendThrottleRateToWorker(this.#throttleRate);
   }
+  /**
+   * @param {string} throttleMessagePattern a regular expression. Messages
+   * matching it are sent on without waiting for the next batch.
+   *
+   * The pattern is checked here rather than in the worker, because the worker
+   * is built from the source of a single function and so cannot import
+   * anything. It is tested against every message that arrives, so a pattern
+   * that will not compile or that could backtrack catastrophically is refused:
+   * it would stall the batching of telemetry rather than throttle it.
+   */
   setThrottleMessagePattern(throttleMessagePattern) {
+    if (createSafeRegExp(throttleMessagePattern, 'm') === undefined) {
+      console.warn(
+        `Ignoring throttle message pattern "${throttleMessagePattern}". It is not a valid regular expression, or it could backtrack catastrophically.`
+      );
+
+      return;
+    }
+
     this.#worker.postMessage({
       type: 'setThrottleMessagePattern',
       throttleMessagePattern

--- a/src/api/telemetry/BatchingWebSocketSpec.js
+++ b/src/api/telemetry/BatchingWebSocketSpec.js
@@ -1,0 +1,76 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+import BatchingWebSocket from './BatchingWebSocket.js';
+
+describe('The BatchingWebSocket', () => {
+  let batchingWebSocket;
+  let mockWorker;
+  let destroyOpenMct;
+
+  beforeEach(() => {
+    // A real worker is built by stringifying installWorker, which under an
+    // instrumented build carries references that do not exist in worker scope.
+    mockWorker = {
+      addEventListener: jasmine.createSpy('addEventListener'),
+      postMessage: jasmine.createSpy('postMessage')
+    };
+    spyOn(window, 'Worker').and.returnValue(mockWorker);
+    spyOn(console, 'warn');
+
+    batchingWebSocket = new BatchingWebSocket({
+      on: (event, callback) => {
+        destroyOpenMct = callback;
+      }
+    });
+  });
+
+  afterEach(() => {
+    destroyOpenMct();
+  });
+
+  describe('when given a throttle message pattern', () => {
+    it('sends a well formed pattern to the worker', () => {
+      batchingWebSocket.setThrottleMessagePattern('^important');
+
+      expect(mockWorker.postMessage).toHaveBeenCalledOnceWith({
+        type: 'setThrottleMessagePattern',
+        throttleMessagePattern: '^important'
+      });
+    });
+
+    it('refuses a pattern that will not compile', () => {
+      batchingWebSocket.setThrottleMessagePattern('(');
+
+      expect(mockWorker.postMessage).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it('refuses a pattern that can backtrack catastrophically', () => {
+      // The worker tests this pattern against every message that arrives, so
+      // one like this would stall telemetry rather than prioritize any of it.
+      batchingWebSocket.setThrottleMessagePattern('(a+)+$');
+
+      expect(mockWorker.postMessage).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/telemetry/WebSocketWorker.js
+++ b/src/api/telemetry/WebSocketWorker.js
@@ -313,7 +313,13 @@ export default function installWorker() {
     }
 
     setThrottleMessagePattern(priorityMessagePattern) {
-      this.#throttleMessagePattern = new RegExp(priorityMessagePattern, 'm');
+      try {
+        this.#throttleMessagePattern = new RegExp(priorityMessagePattern, 'm');
+      } catch (error) {
+        // BatchingWebSocket screens patterns before they are sent here. This is
+        // only so that one that somehow is not screened leaves the pattern
+        // already in use alone, rather than taking the message loop down.
+      }
     }
   }
 

--- a/src/plugins/telemetryTable/collections/TableRowCollection.js
+++ b/src/plugins/telemetryTable/collections/TableRowCollection.js
@@ -22,6 +22,7 @@
 import { EventEmitter } from 'eventemitter3';
 import _ from 'lodash';
 
+import { createSafeRegExp } from '../../../utils/safeRegExp.js';
 import { ORDER } from '../constants.js';
 
 /**
@@ -326,11 +327,30 @@ export default class TableRowCollection extends EventEmitter {
     }
   }
 
+  /**
+   * Filters a column by a regular expression typed by the user.
+   *
+   * The pattern is tested against every row of the column, on the main thread,
+   * so a pattern that will not compile or that could backtrack catastrophically
+   * is refused rather than applied. Any filter already on the column stays in
+   * place, which is how a half typed pattern is treated too.
+   *
+   * @param {string} columnKey
+   * @param {string} filter a regular expression source, without delimiters
+   * @returns {boolean} whether the filter was applied
+   */
   setColumnRegexFilter(columnKey, filter) {
-    filter = filter.trim();
-    this.columnFilters[columnKey] = new RegExp(filter);
+    const columnFilter = createSafeRegExp(filter.trim());
+
+    if (columnFilter === undefined) {
+      return false;
+    }
+
+    this.columnFilters[columnKey] = columnFilter;
 
     this.emit('resetRowsFromAllData');
+
+    return true;
   }
 
   getColumnMapForObject(objectKeyString) {

--- a/src/plugins/telemetryTable/collections/TableRowCollectionSpec.js
+++ b/src/plugins/telemetryTable/collections/TableRowCollectionSpec.js
@@ -1,0 +1,99 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+import TableRowCollection from './TableRowCollection.js';
+
+const COLUMN_KEY = 'some.telemetry.value';
+
+/**
+ * A stand-in for TelemetryTableRow. Filtering only reaches `columns` and
+ * `getFormattedValue()`, so there is no need for a real row here.
+ */
+function createRow(formattedValue) {
+  return {
+    objectKeyString: 'mock-telemetry-object',
+    columns: { [COLUMN_KEY]: {} },
+    getFormattedValue: () => formattedValue
+  };
+}
+
+describe('The TableRowCollection', () => {
+  let tableRowCollection;
+  let resetRows;
+
+  beforeEach(() => {
+    tableRowCollection = new TableRowCollection();
+    resetRows = jasmine.createSpy('resetRowsFromAllData');
+    tableRowCollection.on('resetRowsFromAllData', resetRows);
+  });
+
+  describe('when given a regex column filter', () => {
+    it('applies a well formed pattern and filters rows with it', () => {
+      expect(tableRowCollection.setColumnRegexFilter(COLUMN_KEY, '^-?[0-9]+$')).toBe(true);
+      expect(tableRowCollection.columnFilters[COLUMN_KEY]).toEqual(/^-?[0-9]+$/);
+      expect(resetRows).toHaveBeenCalled();
+
+      const matching = tableRowCollection.filterRows([createRow('-12'), createRow('12.5')]);
+
+      expect(matching.length).toBe(1);
+    });
+
+    it('rejects a pattern that will not compile, rather than throwing', () => {
+      // TableComponent only checks that the input opens and closes with a
+      // slash, so a half typed pattern such as `/(/` arrives here intact.
+      let applied;
+
+      expect(() => {
+        applied = tableRowCollection.setColumnRegexFilter(COLUMN_KEY, '(');
+      }).not.toThrow();
+
+      expect(applied).toBe(false);
+      expect(tableRowCollection.columnFilters[COLUMN_KEY]).toBeUndefined();
+      expect(resetRows).not.toHaveBeenCalled();
+    });
+
+    it('leaves the previous filter in place when a pattern is rejected', () => {
+      tableRowCollection.setColumnRegexFilter(COLUMN_KEY, '^-?[0-9]+$');
+      tableRowCollection.setColumnRegexFilter(COLUMN_KEY, '(');
+
+      expect(tableRowCollection.columnFilters[COLUMN_KEY]).toEqual(/^-?[0-9]+$/);
+    });
+
+    it('rejects a pattern that can backtrack catastrophically', () => {
+      expect(tableRowCollection.setColumnRegexFilter(COLUMN_KEY, '(a+)+$')).toBe(false);
+      expect(tableRowCollection.columnFilters[COLUMN_KEY]).toBeUndefined();
+      expect(resetRows).not.toHaveBeenCalled();
+    });
+
+    it('never runs a rejected pattern against a row', () => {
+      // Filtering happens on the main thread, once per row. `(a+)+$` takes over
+      // ten seconds against a thirty character run of "a", so the pattern must
+      // not reach a value at all.
+      tableRowCollection.setColumnRegexFilter(COLUMN_KEY, '(a+)+$');
+
+      const row = createRow(`${'a'.repeat(3)}b`);
+      spyOn(row, 'getFormattedValue').and.callThrough();
+
+      expect(tableRowCollection.filterRows([row]).length).toBe(1);
+      expect(row.getFormattedValue).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/telemetryTable/components/TableComponent.vue
+++ b/src/plugins/telemetryTable/components/TableComponent.vue
@@ -191,7 +191,9 @@
                 <Search
                   :value="filters[key]"
                   class="c-table__search"
+                  :class="{ 'is-invalid': rejectedRegexFilters[key] }"
                   :aria-label="`${key} filter input`"
+                  :title="regexFilterTitle(key)"
                   @input="filterChanged(key, $event)"
                   @clear="clearFilter(key)"
                 >
@@ -305,6 +307,8 @@ import TelemetryTableRow from './TableRow.vue';
 const VISIBLE_ROW_COUNT = 100;
 const ROW_HEIGHT = 17;
 const AUTO_SCROLL_TRIGGER_HEIGHT = ROW_HEIGHT * 3;
+const REJECTED_REGEX_MESSAGE =
+  'This regular expression cannot be used. It is either malformed, or it is one that could take minutes to evaluate against a single value.';
 
 export default {
   components: {
@@ -394,6 +398,7 @@ export default {
       markedRows: [],
       isShowingMarkedRowsOnly: false,
       enableRegexSearch: {},
+      rejectedRegexFilters: {},
       hideHeaders: configuration.hideHeaders,
       totalNumberOfRows: 0,
       rowContext: {},
@@ -775,12 +780,21 @@ export default {
     },
     filterTelemetry(columnKey) {
       if (this.enableRegexSearch[columnKey]) {
-        if (this.isCompleteRegex(this.filters[columnKey])) {
-          this.table.tableRows.setColumnRegexFilter(
-            columnKey,
-            this.filters[columnKey].slice(1, -1)
-          );
-        } else {
+        if (!this.isCompleteRegex(this.filters[columnKey])) {
+          return;
+        }
+
+        const applied = this.table.tableRows.setColumnRegexFilter(
+          columnKey,
+          this.filters[columnKey].slice(1, -1)
+        );
+
+        // A pattern is rejected if it will not compile, or if running it could
+        // hang the tab. Mark the input so that the filter is not just quietly
+        // ignored, and leave whatever was filtering the column before.
+        this.rejectedRegexFilters[columnKey] = !applied;
+
+        if (!applied) {
           return;
         }
       } else {
@@ -795,6 +809,7 @@ export default {
     },
     clearFilter(columnKey) {
       this.filters[columnKey] = '';
+      this.rejectedRegexFilters[columnKey] = false;
       this.table.tableRows.setColumnFilter(columnKey, '');
       this.setHeight();
     },
@@ -1166,6 +1181,7 @@ export default {
     },
     toggleRegex(key) {
       this.filters[key] = '';
+      this.rejectedRegexFilters[key] = false;
 
       if (this.enableRegexSearch[key] === undefined) {
         this.enableRegexSearch[key] = true;
@@ -1175,6 +1191,9 @@ export default {
     },
     isCompleteRegex(string) {
       return string.length > 2 && string[0] === '/' && string[string.length - 1] === '/';
+    },
+    regexFilterTitle(key) {
+      return this.rejectedRegexFilters[key] ? REJECTED_REGEX_MESSAGE : undefined;
     },
     getViewContext() {
       return {

--- a/src/ui/components/search.scss
+++ b/src/ui/components/search.scss
@@ -56,6 +56,18 @@
 
   }
 
+  &.is-invalid {
+    // Set by the consumer when the value cannot be used, such as a regex
+    // filter that will not compile. Deliberately quiet: a pattern spends most
+    // of the time it is being typed in an incomplete state.
+    box-shadow: inset 0 0 0 1px $colorFormInvalid;
+
+    input[type='text'],
+    input[type='search'] {
+      color: $colorFormInvalid;
+    }
+  }
+
   &.is-active {
     body.mobile & { // In mobile, persist the expanded search bar instead of collapsing upon clicking away
       background-color: rgba($colorHeadFg, 0.2) !important; 

--- a/src/utils/safeRegExp.js
+++ b/src/utils/safeRegExp.js
@@ -1,0 +1,208 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+
+/**
+ * Matches `{n}`, `{n,}` or `{n,m}` at the start of the string it is given. A
+ * `{` that does not fit that shape is an ordinary character, not a quantifier.
+ */
+const BRACED_QUANTIFIER = /^\{(\d+)(?:,(\d*))?\}/;
+
+/**
+ * Finds the end of a character class, so that grouping and repetition
+ * characters inside one — `[(]`, `[+]`, `[^)]` — are not mistaken for the real
+ * thing.
+ *
+ * @param {string} pattern
+ * @param {number} openIndex index of the opening `[`
+ * @returns {number} index of the first character after the class
+ */
+function endOfCharacterClass(pattern, openIndex) {
+  let index = openIndex + 1;
+
+  while (index < pattern.length) {
+    if (pattern[index] === '\\') {
+      index += 2;
+    } else if (pattern[index] === ']') {
+      return index + 1;
+    } else {
+      index += 1;
+    }
+  }
+
+  return pattern.length;
+}
+
+/**
+ * @param {string} pattern
+ * @param {number} index
+ * @returns {number} index after a lazy modifier, if there is one
+ */
+function skipLazyModifier(pattern, index) {
+  return pattern[index] === '?' ? index + 1 : index;
+}
+
+/**
+ * Reads whatever quantifier sits at `index`.
+ *
+ * `?`, `{1}` and `{0,1}` are not counted as repetition. An atom that can match
+ * at most once cannot multiply the number of ways the pattern as a whole can
+ * match, so it cannot contribute to a backtracking blowup.
+ *
+ * @param {string} pattern
+ * @param {number} index
+ * @returns {{isRepetition: boolean, nextIndex: number}}
+ */
+function readQuantifier(pattern, index) {
+  const character = pattern[index];
+
+  if (character === '*' || character === '+') {
+    return { isRepetition: true, nextIndex: skipLazyModifier(pattern, index + 1) };
+  }
+
+  if (character === '?') {
+    return { isRepetition: false, nextIndex: skipLazyModifier(pattern, index + 1) };
+  }
+
+  if (character === '{') {
+    const match = BRACED_QUANTIFIER.exec(pattern.slice(index));
+
+    if (match !== null) {
+      const [quantifier, minimum, maximum] = match;
+      let largestCount;
+
+      if (maximum === undefined) {
+        largestCount = Number(minimum);
+      } else if (maximum === '') {
+        largestCount = Number.POSITIVE_INFINITY;
+      } else {
+        largestCount = Number(maximum);
+      }
+
+      return {
+        isRepetition: largestCount > 1,
+        nextIndex: skipLazyModifier(pattern, index + quantifier.length)
+      };
+    }
+  }
+
+  return { isRepetition: false, nextIndex: index };
+}
+
+/**
+ * Reports whether `pattern` repeats a group that itself contains a repetition —
+ * `(a+)+`, `(a*)*`, `([a-z]+\s*)+` and so on. Those patterns give the engine
+ * exponentially many ways to divide the same input between the inner and outer
+ * repetition, so a value that very nearly matches sends it through all of them.
+ *
+ * `pattern` is expected to have compiled already, so its groups and character
+ * classes are balanced.
+ *
+ * @param {string} pattern
+ * @returns {boolean}
+ */
+function repeatsARepetition(pattern) {
+  const groups = [{ containsRepetition: false }];
+  let index = 0;
+
+  while (index < pattern.length) {
+    const character = pattern[index];
+    let closedGroup;
+    let indexAfterAtom;
+
+    if (character === '(') {
+      groups.push({ containsRepetition: false });
+      index += 1;
+      continue;
+    } else if (character === '|' || character === '^' || character === '$') {
+      // Nothing can be repeated, so there is nothing to account for.
+      index += 1;
+      continue;
+    } else if (character === ')') {
+      closedGroup = groups.length > 1 ? groups.pop() : undefined;
+      indexAfterAtom = index + 1;
+    } else if (character === '\\') {
+      indexAfterAtom = index + 2;
+    } else if (character === '[') {
+      indexAfterAtom = endOfCharacterClass(pattern, index);
+    } else {
+      indexAfterAtom = index + 1;
+    }
+
+    const { isRepetition, nextIndex } = readQuantifier(pattern, indexAfterAtom);
+    const enclosingGroup = groups[groups.length - 1];
+
+    if (closedGroup !== undefined) {
+      if (isRepetition && closedGroup.containsRepetition) {
+        return true;
+      }
+
+      if (isRepetition || closedGroup.containsRepetition) {
+        enclosingGroup.containsRepetition = true;
+      }
+    } else if (isRepetition) {
+      enclosingGroup.containsRepetition = true;
+    }
+
+    index = nextIndex;
+  }
+
+  return false;
+}
+
+/**
+ * Compiles a regular expression from a pattern that came from outside Open MCT
+ * — a telemetry table column filter, for instance — refusing any pattern that
+ * could hang the thread that runs it.
+ *
+ * JavaScript offers no way to abandon a regular expression once it is running,
+ * and no way to run one under a time limit, so the pattern has to be judged
+ * before it is used. This applies the rule the `safe-regex` family of libraries
+ * applies, without the dependency: reject a repetition applied to a group that
+ * already contains a repetition.
+ *
+ * The rule is deliberately conservative, and it is not exhaustive. `(\d+,)+` is
+ * rejected even though its `,` makes each iteration unambiguous and therefore
+ * quick, and an ambiguous alternation such as `(a|a)*` is accepted even though
+ * it takes over a minute against a thirty character value. Filtering user
+ * patterns off the main thread is the only complete answer; this closes the
+ * shapes that can be written by accident.
+ *
+ * @param {string} pattern a regular expression source, without delimiters
+ * @param {string} [flags] regular expression flags
+ * @returns {RegExp | undefined} the compiled expression, or undefined if the
+ * pattern will not compile or was rejected
+ */
+export function createSafeRegExp(pattern, flags) {
+  let regExp;
+
+  try {
+    regExp = new RegExp(pattern, flags);
+  } catch (error) {
+    return undefined;
+  }
+
+  if (repeatsARepetition(pattern)) {
+    return undefined;
+  }
+
+  return regExp;
+}

--- a/src/utils/safeRegExpSpec.js
+++ b/src/utils/safeRegExpSpec.js
@@ -1,0 +1,109 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * Open MCT includes source code licensed under additional open source
+ * licenses. See the Open Source Licenses file (LICENSES.md) included with
+ * this source code distribution or the Licensing information page available
+ * at runtime from the About dialog for additional information.
+ *****************************************************************************/
+import { createSafeRegExp } from './safeRegExp.js';
+
+const PATTERNS_THAT_DO_NOT_COMPILE = ['(', '[', '*', '\\', '(?<', 'a{2,1}'];
+
+const NESTED_REPETITION_PATTERNS = [
+  '(a+)+$',
+  '^(a+)+$',
+  '(a*)*',
+  '(a+)*',
+  '(a*)+',
+  '(\\d+)+',
+  '(x+x+)+y',
+  '([a-z]+\\s*)+',
+  '((a+)?)+',
+  '(a{1,3})+',
+  '(?:a+)+',
+  '(?:(a+))+',
+  '(a+|b)+'
+];
+
+const ACCEPTABLE_PATTERNS = [
+  'a+b+',
+  '(a)+',
+  '(foo|bar)+',
+  '[a-z]+',
+  '\\d{2,}',
+  '(a{1})+',
+  '(a?)+',
+  '(a+)?',
+  '(a+)(b)+',
+  '^\\s*\\S+\\s*$',
+  '(a{)+',
+  '\\(a+\\)+',
+  '[(]a+[)]+',
+  '(a\\+)+',
+  '(a[+])+',
+  '([^)]+)',
+  '^[0-9]{4}-[0-9]{2}-[0-9]{2}'
+];
+
+describe('createSafeRegExp', () => {
+  it('returns a usable RegExp for an ordinary pattern', () => {
+    const regExp = createSafeRegExp('^-?[0-9]+(\\.[0-9]+)?$');
+
+    expect(regExp).toEqual(/^-?[0-9]+(\.[0-9]+)?$/);
+    expect(regExp.test('-12.5')).toBe(true);
+    expect(regExp.test('12.5.5')).toBe(false);
+  });
+
+  it('passes flags through to the RegExp', () => {
+    expect(createSafeRegExp('^a$', 'm')).toEqual(/^a$/m);
+  });
+
+  it('returns undefined for a pattern that will not compile', () => {
+    PATTERNS_THAT_DO_NOT_COMPILE.forEach((pattern) => {
+      expect(createSafeRegExp(pattern)).withContext(`pattern: ${pattern}`).toBeUndefined();
+    });
+  });
+
+  it('returns undefined for a pattern that repeats a group containing a repetition', () => {
+    NESTED_REPETITION_PATTERNS.forEach((pattern) => {
+      // Every one of these compiles without complaint. What they cost to run
+      // against a value that very nearly matches is the problem.
+      expect(() => new RegExp(pattern))
+        .withContext(`pattern: ${pattern}`)
+        .not.toThrow();
+
+      expect(createSafeRegExp(pattern)).withContext(`pattern: ${pattern}`).toBeUndefined();
+    });
+  });
+
+  it('accepts patterns whose repetition is not nested', () => {
+    ACCEPTABLE_PATTERNS.forEach((pattern) => {
+      expect(createSafeRegExp(pattern))
+        .withContext(`pattern: ${pattern}`)
+        .toEqual(new RegExp(pattern));
+    });
+  });
+
+  it('rejects a pattern without ever running it', () => {
+    // A guard that decided by timing how long the pattern takes would already
+    // have paid the cost it is meant to avoid.
+    const startedAt = performance.now();
+
+    expect(createSafeRegExp('(a+)+$')).toBeUndefined();
+    expect(performance.now() - startedAt).toBeLessThan(50);
+  });
+});


### PR DESCRIPTION
Closes #8325

### Describe your changes:

A regular expression typed into a telemetry table column filter was handed straight to `new RegExp` and then run against every row, on the main thread. Two things went wrong with that:

- A pattern that is still half typed, such as `/(/`, threw an uncaught `SyntaxError`. The filter box only checks that the text opens and closes with a slash, so incomplete patterns reach the collection intact.
- A pattern with nested repetition — the `/(a+)+$/` from the issue — compiled without complaint and then took about twelve seconds to evaluate against a single thirty character value on my machine, longer against a table full of them. The tab is unusable for that whole time.

Both are now refused before they can be applied.

**How a pattern is judged.** A new `createSafeRegExp` helper compiles the pattern inside a `try`/`catch`, then rejects any repetition applied to a group that already contains a repetition: `(a+)+`, `(a*)*`, `([a-z]+\s*)+`. That is the same rule the `safe-regex` family of libraries applies. I implemented it rather than adding `safe-regex2` because Open MCT currently ships no runtime dependencies, and taking one on seemed like a maintainer's decision rather than mine. Glad to swap in the library instead if you would prefer that.

**What it does not catch.** The rule is conservative in one direction and incomplete in the other, and it is worth being plain about both. It rejects `(\d+,)+`, which is unambiguous and would in practice have been fine. And it accepts an ambiguous alternation such as `(a|a)*`, which has a star height of one but still took 75 seconds against a thirty character value when I measured it — `safe-regex2` would miss that one too. Evaluating user supplied patterns off the main thread is the only complete answer; this closes the shapes that get typed by accident. The limitation is written down beside the check rather than left implied.

**The second call site.** The issue also flags `WebSocketWorker.setThrottleMessagePattern`. That pattern is screened in `BatchingWebSocket`, on the main thread, rather than inside the worker: the worker is built by stringifying `installWorker` into a Blob and so cannot import anything. `BatchingWebSocket` is the only path into the worker, so screening there covers it. The worker itself gained a `try`/`catch` so that a pattern arriving unscreened cannot take its message loop down.

**What a user sees.** A refused pattern leaves the column's previous filter in place — already how a half typed pattern behaved — and marks the filter box, with a tooltip saying why. The marking is deliberately quiet, since a pattern spends most of the time it is being typed in an incomplete state.

### How to check it

1. Open any telemetry table, click a column filter, and turn on `/R/`.
2. Type `/(/`. The box is outlined in red and nothing appears in the console. Before this change that threw `SyntaxError: Invalid regular expression: /(/: Unterminated group`.
3. Type `/(a+)+$/`. Same, and the tab stays responsive.
4. Type an ordinary pattern such as `/^-?[0-9]+$/`. It filters as it always did.

### Tests

- `src/utils/safeRegExpSpec.js` — the judgement itself, including a list of patterns that must keep working, so the rule cannot quietly get greedier.
- `src/plugins/telemetryTable/collections/TableRowCollectionSpec.js` — new file. Both failing behaviours from the issue, plus a check that a refused pattern never reaches a row value at all.
- `src/api/telemetry/BatchingWebSocketSpec.js` — new file. The throttle pattern is screened before it is posted to the worker.

Locally the full suite finishes with six failures, all six also present on `master` before this change (the four Object API search timeouts, the image exporter, and the URLIndicator clock). `npm run lint` is clean.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [x] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

Flagging that last one for your judgement rather than assuming. `BatchingWebSocket.setThrottleMessagePattern` is reachable by integrators, and a throttle pattern with nested repetition is now ignored with a console warning instead of being used. No such pattern is likely in practice, but the behaviour did change, so it may be worth a line in the notes.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

I do not have permission to set labels or milestones on this repository. `type:bug` would match the issue.

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
