### PR TITLE
[Couch] Use chttpd for CORS config

### DIFF
--- a/src/plugins/persistence/couch/setup-couchdb.sh
+++ b/src/plugins/persistence/couch/setup-couchdb.sh
@@ -51,11 +51,11 @@ create_admin_user() {
 }
 
 is_cors_enabled() {
-    resource_exists "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/httpd/enable_cors
+    resource_exists "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/chttpd/enable_cors
 }
 
 enable_cors() {
-    curl -su "${CURL_USERPASS_ARG}" -o /dev/null -X PUT "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/httpd/enable_cors -d '"true"'
+    curl -su "${CURL_USERPASS_ARG}" -o /dev/null -X PUT "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/chttpd/enable_cors -d '"true"'
     curl -su "${CURL_USERPASS_ARG}" -o /dev/null -X PUT "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/cors/origins -d '"*"'
     curl -su "${CURL_USERPASS_ARG}" -o /dev/null -X PUT "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/cors/credentials -d '"true"'
     curl -su "${CURL_USERPASS_ARG}" -o /dev/null -X PUT "$COUCH_BASE_LOCAL"/_node/"$COUCH_NODE_NAME"/_config/cors/methods -d '"GET, PUT, POST, HEAD, DELETE"'


### PR DESCRIPTION
Closes #8375

### Describe your changes:
Updates both CORS detection and enablement in setup-couchdb.sh to use the chttpd/enable_cors configuration path. This matches CouchDB 3.2 and later and the existing Open MCT CouchDB README.

### Testing:
- bash -n src/plugins/persistence/couch/setup-couchdb.sh
- Ran the complete setup script against a fake curl endpoint that returned CORS disabled, then verified both the HEAD check and PUT used /_config/chttpd/enable_cors.
- Verified the run made no request to /_config/httpd/enable_cors.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Confirmed this is not a notable or breaking change requiring a release-note callout.

### Author Checklist

* [x] Changes address original issue?
* [ ] Tests included and/or updated with changes? No test file was added; the shell script was validated with the smoke test above.
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a type: label? External contributors cannot apply labels; type:bug is requested.
* [ ] Have you associated a milestone with this PR? Left blank for maintainers.
* [x] Testing instructions included in associated issue or PR.