### PR TITLE
[Notebook] Preserve snapshot drag semantics

### DIFF
--- a/e2e/tests/functional/plugins/notebook/notebookSnapshots.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebookSnapshots.e2e.spec.js
@@ -24,6 +24,7 @@
 This test suite is dedicated to tests which verify the basic operations surrounding Notebooks.
 */
 
+import { createDomainObjectWithDefaults } from '../../../../appActions.js';
 import { expect, test } from '../../../../pluginFixtures.js';
 
 test.describe('Snapshot Menu tests', () => {
@@ -80,6 +81,43 @@ test.describe('Snapshot Container tests', () => {
     await page.getByRole('menuitem', { name: 'Quick View' }).click();
     await expect(page.getByLabel('Modal Overlay')).toBeVisible();
     await expect(page.getByLabel('Preview Container')).toBeVisible();
+  });
+  test('Dragging a snapshot thumbnail into a Notebook keeps snapshot semantics', async ({
+    page
+  }) => {
+    await createDomainObjectWithDefaults(page, {
+      type: 'Notebook'
+    });
+
+    await page.locator('.c-notebook__drag-area').click();
+    await page.getByLabel('Notebook Entry Input').last().fill('Snapshot target');
+    await page.locator('.c-ne__save-button > button').click();
+
+    const snapshotContainer = page.locator('.c-snapshots-h .c-snapshots');
+    const snapshotThumbnail = snapshotContainer.getByRole('img', {
+      name: 'My Items thumbnail'
+    });
+    const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+
+    await snapshotThumbnail.dispatchEvent('dragstart', { dataTransfer });
+    const snapshotId = await dataTransfer.evaluate((transfer) =>
+      transfer.getData('openmct/snapshot/id')
+    );
+    expect(snapshotId).not.toEqual('');
+
+    await dataTransfer.evaluate((transfer) => {
+      transfer.setData('URL', 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=');
+    });
+
+    const targetEntry = page.locator('.c-notebook__entry').last();
+    await targetEntry.dispatchEvent('drop', { dataTransfer });
+
+    await expect(snapshotThumbnail).toHaveCount(0);
+
+    const notebookEmbed = targetEntry.getByLabel('My Items Notebook Embed');
+    await expect(notebookEmbed).toBeVisible();
+    await notebookEmbed.getByLabel('More actions').click();
+    await expect(page.getByRole('menuitem', { name: 'Quick View' })).toBeVisible();
   });
   test('A snapshot can be Viewed, Annotated, display deleted, and saved from Container with 3 dot action menu', async ({
     page

--- a/src/plugins/notebook/components/NotebookComponent.vue
+++ b/src/plugins/notebook/components/NotebookComponent.vue
@@ -639,7 +639,7 @@ export default {
       const localImageDropped = dataTransferFiles.some((file) => file.type.includes('image'));
       const snapshotId = dropEvent.dataTransfer.getData('openmct/snapshot/id');
       const domainObjectData = dropEvent.dataTransfer.getData('openmct/domain-object-path');
-      const imageUrl = dropEvent.dataTransfer.getData('URL');
+      const imageUrl = snapshotId.length ? '' : dropEvent.dataTransfer.getData('URL');
       if (localImageDropped) {
         // local image(s) dropped from disk (file)
         const embeds = [];

--- a/src/plugins/notebook/components/NotebookEntry.vue
+++ b/src/plugins/notebook/components/NotebookEntry.vue
@@ -514,7 +514,7 @@ export default {
       const localImageDropped = dataTransferFiles.some((file) => file.type.includes('image'));
       const snapshotId = dropEvent.dataTransfer.getData('openmct/snapshot/id');
       const domainObjectData = dropEvent.dataTransfer.getData('openmct/domain-object-path');
-      const imageUrl = dropEvent.dataTransfer.getData('URL');
+      const imageUrl = snapshotId.length ? '' : dropEvent.dataTransfer.getData('URL');
       if (localImageDropped) {
         // local image(s) dropped from disk (file)
         await Promise.all(


### PR DESCRIPTION
Closes #8308

### Describe your changes

Dragging a Notebook Snapshot by its thumbnail can produce two payloads at once: the Open MCT openmct/snapshot/id payload and a browser-native image URL. Both Notebook drop handlers checked the image URL before the Snapshot ID, so the drop was treated as a plain image. That lost the Snapshot context and left the original Snapshot in the holder.

This change makes the Snapshot transfer payload take precedence whenever a Snapshot ID is present in both NotebookComponent.vue and NotebookEntry.vue. Local image-file drops retain their existing behavior.

The regression test dispatches the real Snapshot dragstart, adds the native image URL payload, drops onto an existing Notebook entry, and verifies that the Snapshot is removed from the holder, the Notebook receives the full Snapshot embed, and Snapshot-only actions such as Quick View remain available.

### Testing

Validated on Node 24.14.1 with the repository toolchain:

- ESLint passed for all changed files.
- Prettier check passed for all changed files.
- git diff --check passed.
- Focused Playwright Chrome regression passed.

### All Submissions

- [x] Followed CONTRIBUTING.md.
- [x] Checked for an existing open PR for #8308 before submission.
- [x] No release-note callout expected; this is a focused bug fix with no API surface change.

### Author Checklist

- [x] Changes address the original issue.
- [x] Tests included and updated.
- [x] Focused browser validation completed.
- [ ] type:bug label to be applied by maintainers if needed.
- [ ] Milestone left blank for maintainers.
- [x] Testing instructions and results included above.

### Reviewer Checklist

- [ ] Changes appear to address issue.
- [ ] Reviewer has tested changes using the instructions above.
- [ ] Changes appear not to be breaking changes.
- [ ] Appropriate automated tests included.
- [ ] Code style and inline documentation are appropriate.

<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes <!--- Insert Issue Number(s) this PR addresses. Start by typing # will open a dropdown of recent issues. Note: this does not work on PRs which target release branches -->

### Describe your changes:
<!--- Describe your changes and add any comments about your approach either here or inline if code comments aren't added -->

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [ ] Changes address original issue?
* [ ] Tests included and/or updated with changes?
* [ ] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
