### PR TITLE
fix(types): update TypeDefinition and CompositionProvider JSDoc definitions (#8144)

### DIFF
--- a/API.md
+++ b/API.md
@@ -184,7 +184,7 @@ In order to use Open MCT's provided types in your own application, create a
       "checkJs": true,
       "moduleResolution": "node",
       "paths": {
-        "openmct": ["node_modules/openmct/dist/openmct.d.ts"]
+        "openmct": ["node_modules/openmct/dist/types/index.d.ts"]
       }
   }
 }

--- a/src/api/composition/CompositionAPI.js
+++ b/src/api/composition/CompositionAPI.js
@@ -24,7 +24,12 @@ import CompositionCollection from './CompositionCollection.js';
 import DefaultCompositionProvider from './DefaultCompositionProvider.js';
 
 /**
- * @typedef {import('./CompositionProvider').default} CompositionProvider
+ * @typedef {Object} CompositionProvider
+ * @property {function(DomainObject): boolean} appliesTo Check if this provider applies to the given domain object.
+ * @property {function(DomainObject): Promise<import('../../../openmct').Identifier[]>} load Load child identifiers for the given domain object.
+ * @property {function(DomainObject, import('../../../openmct').Identifier): void} [add] Add a child identifier to the domain object composition.
+ * @property {function(DomainObject, import('../../../openmct').Identifier[]): void} [reorder] Reorder child identifiers in composition.
+ * @property {function(DomainObject, import('../../../openmct').Identifier): void} [remove] Remove a child identifier from composition.
  */
 
 /**

--- a/src/api/types/TypeRegistry.js
+++ b/src/api/types/TypeRegistry.js
@@ -29,9 +29,10 @@ const UNKNOWN_TYPE = new Type({
 
 /**
  * @typedef TypeDefinition
- * @property {string} label the name for this type of object
- * @property {string} description a longer-form description of this type
- * @property {function(domainObject:DomainObject): void} [initialize] a function which initializes
+ * @property {string} [name] human-readable name for this type
+ * @property {string} [label] legacy support for type name (preferred: name)
+ * @property {string} [description] a longer-form description of this type
+ * @property {function(import('../objects/ObjectAPI').DomainObject): void} [initialize] a function which initializes
  *           the model for new domain objects of this type
  * @property {boolean} [creatable=false] true if users should be allowed to
  *           create this type (default: false)


### PR DESCRIPTION
## Summary
Fixes #8144.

This PR addresses type definition mismatches and outdated documentation paths:
* **`API.md`**: Updated the TypeScript configuration example to point to `dist/types/index.d.ts`.
* **`CompositionAPI.js`**: Updated the `@typedef` for `CompositionProvider` to a duck-typed object interface, allowing objects implementing `appliesTo` and `load` to pass type checks without requiring concrete class inheritance.
* **`TypeRegistry.js`**: Updated `TypeDefinition` JSDoc to include the preferred `name` property alongside optional `label` and `description` fields.

## Verification
- Built generated types cleanly via `npm run build` (`npx tsc`).
- Checked formatting and code quality via `npm run lint`.