### PR TITLE
fix: respect telemetry request interceptor priority

### DIFF
--- a/src/api/telemetry/TelemetryRequestInterceptor.js
+++ b/src/api/telemetry/TelemetryRequestInterceptor.js
@@ -20,6 +20,7 @@
  * at runtime from the About dialog for additional information.
  *****************************************************************************/
 
+const DEFAULT_INTERCEPTOR_PRIORITY = 0;
 export default class TelemetryRequestInterceptorRegistry {
   /**
    * A TelemetryRequestInterceptorRegistry maintains the definitions for different interceptors that may be invoked on telemetry
@@ -44,7 +45,6 @@ export default class TelemetryRequestInterceptorRegistry {
    * @method addInterceptor
    */
   addInterceptor(interceptorDef) {
-    //TODO: sort by priority
     this.interceptors.push(interceptorDef);
   }
 
@@ -54,10 +54,19 @@ export default class TelemetryRequestInterceptorRegistry {
    * @returns [module:openmct.RequestInterceptorDef] the registered interceptors for this identifier/request
    */
   getInterceptors(identifier, request) {
-    return this.interceptors.filter((interceptor) => {
-      return (
-        typeof interceptor.appliesTo === 'function' && interceptor.appliesTo(identifier, request)
-      );
-    });
+    function byPriority(interceptorA, interceptorB) {
+      const priorityA = interceptorA.priority ?? DEFAULT_INTERCEPTOR_PRIORITY;
+      const priorityB = interceptorB.priority ?? DEFAULT_INTERCEPTOR_PRIORITY;
+
+      return priorityB - priorityA;
+    }
+
+    return this.interceptors
+      .filter((interceptor) => {
+        return (
+          typeof interceptor.appliesTo === 'function' && interceptor.appliesTo(identifier, request)
+        );
+      })
+      .sort(byPriority);
   }
 }

--- a/src/api/telemetry/TelemetryRequestInterceptor.js
+++ b/src/api/telemetry/TelemetryRequestInterceptor.js
@@ -54,11 +54,14 @@ export default class TelemetryRequestInterceptorRegistry {
    * @returns [module:openmct.RequestInterceptorDef] the registered interceptors for this identifier/request
    */
   getInterceptors(identifier, request) {
-    function byPriority(interceptorA, interceptorB) {
-      const priorityA = interceptorA.priority ?? DEFAULT_INTERCEPTOR_PRIORITY;
-      const priorityB = interceptorB.priority ?? DEFAULT_INTERCEPTOR_PRIORITY;
+    function getPriority(interceptor) {
+      const priority = interceptor.priority ?? DEFAULT_INTERCEPTOR_PRIORITY;
 
-      return priorityB - priorityA;
+      return typeof priority === 'function' ? priority(identifier, request) : priority;
+    }
+
+    function byPriority(interceptorA, interceptorB) {
+      return getPriority(interceptorB) - getPriority(interceptorA);
     }
 
     return this.interceptors

--- a/src/api/telemetry/TelemetryRequestInterceptorSpec.js
+++ b/src/api/telemetry/TelemetryRequestInterceptorSpec.js
@@ -14,7 +14,7 @@ describe('TelemetryRequestInterceptorRegistry', () => {
     request = {};
   });
 
-  it('returns applicable interceptors in descending priority order', () => {
+  it('returns applicable interceptors in descending numeric priority order', () => {
     const lowPriorityInterceptor = {
       appliesTo: () => true,
       priority: -1000
@@ -27,6 +27,34 @@ describe('TelemetryRequestInterceptorRegistry', () => {
     const highPriorityInterceptor = {
       appliesTo: () => true,
       priority: 1000
+    };
+
+    registry.addInterceptor(lowPriorityInterceptor);
+    registry.addInterceptor(defaultPriorityInterceptor);
+    registry.addInterceptor(highPriorityInterceptor);
+
+    const interceptors = registry.getInterceptors(identifier, request);
+
+    expect(interceptors).toEqual([
+      highPriorityInterceptor,
+      defaultPriorityInterceptor,
+      lowPriorityInterceptor
+    ]);
+  });
+
+  it('evaluates function-valued priorities before sorting', () => {
+    const lowPriorityInterceptor = {
+      appliesTo: () => true,
+      priority: () => -1000
+    };
+
+    const defaultPriorityInterceptor = {
+      appliesTo: () => true
+    };
+
+    const highPriorityInterceptor = {
+      appliesTo: () => true,
+      priority: () => 1000
     };
 
     registry.addInterceptor(lowPriorityInterceptor);

--- a/src/api/telemetry/TelemetryRequestInterceptorSpec.js
+++ b/src/api/telemetry/TelemetryRequestInterceptorSpec.js
@@ -1,0 +1,44 @@
+import TelemetryRequestInterceptorRegistry from './TelemetryRequestInterceptor.js';
+
+describe('TelemetryRequestInterceptorRegistry', () => {
+  let registry;
+  let identifier;
+  let request;
+
+  beforeEach(() => {
+    registry = new TelemetryRequestInterceptorRegistry();
+    identifier = {
+      namespace: 'test',
+      key: 'object'
+    };
+    request = {};
+  });
+
+  it('returns applicable interceptors in descending priority order', () => {
+    const lowPriorityInterceptor = {
+      appliesTo: () => true,
+      priority: -1000
+    };
+
+    const defaultPriorityInterceptor = {
+      appliesTo: () => true
+    };
+
+    const highPriorityInterceptor = {
+      appliesTo: () => true,
+      priority: 1000
+    };
+
+    registry.addInterceptor(lowPriorityInterceptor);
+    registry.addInterceptor(defaultPriorityInterceptor);
+    registry.addInterceptor(highPriorityInterceptor);
+
+    const interceptors = registry.getInterceptors(identifier, request);
+
+    expect(interceptors).toEqual([
+      highPriorityInterceptor,
+      defaultPriorityInterceptor,
+      lowPriorityInterceptor
+    ]);
+  });
+});


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #8418

### Describe your changes:
Sort telemetry request interceptors by descending priority instead of registration order.

Interceptors without an explicit priority default to `0`, matching the behavior of the existing object interceptor registry.

This PR also adds a regression test covering high, default, and low priority interceptors, and removes the now-resolved priority sorting TODO.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?