### PR TITLE
[CI] Use .nvmrc for E2E workflows

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/hydrogen'
+          node-version-file: '.nvmrc'
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3

--- a/.github/workflows/e2e-perf.yml
+++ b/.github/workflows/e2e-perf.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/hydrogen'
+          node-version-file: '.nvmrc'
 
       - name: Cache NPM dependencies
         uses: actions/cache@v3


### PR DESCRIPTION
Closes #8422

### Describe your changes:

Both end-to-end workflows now pass `.nvmrc` to `actions/setup-node@v4` instead of pinning the retired Hydrogen/Node 18 line. This keeps the full and performance E2E jobs aligned with the Node version supported by the repository and removes the engine mismatch that prevents dependency installation.

Validation performed:

- parsed both modified workflow files as YAML;
- verified both jobs use `node-version-file: '.nvmrc'` and no longer pin Hydrogen;
- ran an isolated `npm ci --dry-run` with the `.nvmrc` Node version (24.14.1);
- ran `git diff --check`.

AI assistance disclosure: Codex was used to help prepare and validate this change.

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? No; this is a CI-only Node-version alignment.

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes? The two affected workflow configurations are updated and were validated directly.
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? `type:bug` will be applied after creation if permissions allow.
* [ ] Have you associated a milestone with this PR? The issue has no milestone, so this is intentionally left blank.
* [x] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
