### PR TITLE
[Time] Isolate event listener failures

### DIFF
--- a/src/api/time/TimeAPISpec.js
+++ b/src/api/time/TimeAPISpec.js
@@ -245,12 +245,19 @@ describe('The Time API', function () {
       .createSpy('failingListener')
       .and.throwError(new Error('listener failed'));
     spyOn(console, 'error');
+    spyOn(api, 'removeListener').and.callThrough();
 
     api.once('boundsChanged', failingListener);
     api.setBounds(bounds);
     api.setBounds({ start: 1, end: 2 });
 
     expect(failingListener).toHaveBeenCalledTimes(1);
+    expect(api.removeListener).toHaveBeenCalledWith(
+      'boundsChanged',
+      jasmine.any(Function),
+      undefined,
+      true
+    );
   });
 
   it('If bounds are set and TOI lies inside them, do not change TOI', function () {

--- a/src/api/time/TimeAPISpec.js
+++ b/src/api/time/TimeAPISpec.js
@@ -211,6 +211,48 @@ describe('The Time API', function () {
     expect(eventListener).toHaveBeenCalledWith(bounds, false);
   });
 
+  it('continues notifying bounds listeners when one listener throws', function () {
+    const error = new Error('listener failed');
+    const failingListener = jasmine.createSpy('failingListener').and.throwError(error);
+    const followingListener = jasmine.createSpy('followingListener');
+    spyOn(console, 'error');
+
+    api.on('boundsChanged', failingListener);
+    api.on('boundsChanged', followingListener);
+
+    expect(() => api.setBounds(bounds)).not.toThrow();
+    expect(failingListener).toHaveBeenCalledWith(bounds, false);
+    expect(followingListener).toHaveBeenCalledWith(bounds, false);
+    expect(console.error).toHaveBeenCalledWith(
+      'Error in Time API listener for "boundsChanged"',
+      error
+    );
+  });
+
+  it('removes a wrapped listener using its original function and context', function () {
+    const context = {};
+    const listener = jasmine.createSpy('listener');
+
+    api.on('boundsChanged', listener, context);
+    api.off('boundsChanged', listener, context);
+    api.setBounds(bounds);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('removes a failing one-time listener after its first invocation', function () {
+    const failingListener = jasmine
+      .createSpy('failingListener')
+      .and.throwError(new Error('listener failed'));
+    spyOn(console, 'error');
+
+    api.once('boundsChanged', failingListener);
+    api.setBounds(bounds);
+    api.setBounds({ start: 1, end: 2 });
+
+    expect(failingListener).toHaveBeenCalledTimes(1);
+  });
+
   it('If bounds are set and TOI lies inside them, do not change TOI', function () {
     api.timeOfInterest(6);
     api.bounds({

--- a/src/api/time/TimeContext.js
+++ b/src/api/time/TimeContext.js
@@ -69,8 +69,12 @@ import { FIXED_MODE_KEY, MODES, REALTIME_MODE_KEY, TIME_CONTEXT_EVENTS } from '.
  * @extends EventEmitter
  */
 class TimeContext extends EventEmitter {
+  #listenerWrappers;
+
   constructor() {
     super();
+
+    this.#listenerWrappers = new Map();
 
     /**
      * The time systems available to the TimeAPI.
@@ -109,6 +113,128 @@ class TimeContext extends EventEmitter {
     this.warnCounts = {};
 
     this.tick = this.tick.bind(this);
+  }
+
+  /**
+   * Register an event listener without allowing a listener failure to prevent
+   * the remaining Time API listeners from running.
+   * @param {string | symbol} event The event name
+   * @param {Function} listener The event listener
+   * @param {object} [context] The listener context
+   * @returns {TimeContext} this time context
+   */
+  on(event, listener, context) {
+    return this.#addListener(event, listener, context, false);
+  }
+
+  /**
+   * Alias for {@link TimeContext#on}.
+   * @param {string | symbol} event The event name
+   * @param {Function} listener The event listener
+   * @param {object} [context] The listener context
+   * @returns {TimeContext} this time context
+   */
+  addListener(event, listener, context) {
+    return this.on(event, listener, context);
+  }
+
+  /**
+   * Register an event listener that is removed after its first invocation.
+   * @param {string | symbol} event The event name
+   * @param {Function} listener The event listener
+   * @param {object} [context] The listener context
+   * @returns {TimeContext} this time context
+   */
+  once(event, listener, context) {
+    return this.#addListener(event, listener, context, true);
+  }
+
+  /**
+   * Remove a previously registered event listener.
+   * @param {string | symbol} event The event name
+   * @param {Function} listener The event listener
+   * @param {object} [context] The listener context
+   * @param {boolean} [once] Only remove one-time listeners
+   * @returns {TimeContext} this time context
+   */
+  removeListener(event, listener, context, once) {
+    const registeredListeners = this.#listenerWrappers.get(event) ?? [];
+    const matchingListeners = registeredListeners.filter((registeredListener) => {
+      const listenerMatches =
+        registeredListener.listener === listener || registeredListener.wrapper === listener;
+      const contextMatches = context === undefined || registeredListener.context === context;
+      const onceMatches = !once || registeredListener.once;
+
+      return listenerMatches && contextMatches && onceMatches;
+    });
+
+    matchingListeners.forEach((registeredListener) => {
+      super.removeListener(event, registeredListener.wrapper, context, once);
+    });
+
+    if (matchingListeners.length > 0) {
+      const remainingListeners = registeredListeners.filter(
+        (registeredListener) => !matchingListeners.includes(registeredListener)
+      );
+
+      if (remainingListeners.length > 0) {
+        this.#listenerWrappers.set(event, remainingListeners);
+      } else {
+        this.#listenerWrappers.delete(event);
+      }
+
+      return this;
+    }
+
+    super.removeListener(event, listener, context, once);
+
+    return this;
+  }
+
+  /**
+   * Alias for {@link TimeContext#removeListener}.
+   * @param {string | symbol} event The event name
+   * @param {Function} listener The event listener
+   * @param {object} [context] The listener context
+   * @param {boolean} [once] Only remove one-time listeners
+   * @returns {TimeContext} this time context
+   */
+  off(event, listener, context, once) {
+    return this.removeListener(event, listener, context, once);
+  }
+
+  /**
+   * Remove all listeners, or all listeners for one event.
+   * @param {string | symbol} [event] The event name
+   * @returns {TimeContext} this time context
+   */
+  removeAllListeners(event) {
+    if (event === undefined) {
+      this.#listenerWrappers.clear();
+    } else {
+      this.#listenerWrappers.delete(event);
+    }
+
+    super.removeAllListeners(event);
+
+    return this;
+  }
+
+  /**
+   * Return the original listeners registered for an event.
+   * @param {string | symbol} event The event name
+   * @returns {Function[]} the registered listeners
+   */
+  listeners(event) {
+    const registeredListeners = this.#listenerWrappers.get(event) ?? [];
+
+    return super.listeners(event).map((listener) => {
+      const registeredListener = registeredListeners.find(
+        (candidate) => candidate.wrapper === listener
+      );
+
+      return registeredListener?.listener ?? listener;
+    });
   }
 
   /**
@@ -647,6 +773,39 @@ class TimeContext extends EventEmitter {
      * offsets.
      */
     this.emit(TIME_CONTEXT_EVENTS.clockOffsetsChanged, this.#copy(offsets));
+  }
+
+  #addListener(event, listener, context, once) {
+    if (typeof listener !== 'function') {
+      throw new TypeError('The listener must be a function');
+    }
+
+    const listenerContext = context || this;
+    const registeredListeners = this.#listenerWrappers.get(event) ?? [];
+
+    function wrapper(...args) {
+      try {
+        listener.apply(listenerContext, args);
+      } catch (error) {
+        console.error(`Error in Time API listener for "${String(event)}"`, error);
+      }
+    }
+
+    registeredListeners.push({
+      listener,
+      wrapper,
+      context,
+      once
+    });
+    this.#listenerWrappers.set(event, registeredListeners);
+
+    if (once) {
+      super.once(event, wrapper, context);
+    } else {
+      super.on(event, wrapper, context);
+    }
+
+    return this;
   }
 
   /**

--- a/src/api/time/TimeContext.js
+++ b/src/api/time/TimeContext.js
@@ -782,12 +782,17 @@ class TimeContext extends EventEmitter {
 
     const listenerContext = context || this;
     const registeredListeners = this.#listenerWrappers.get(event) ?? [];
+    const timeContext = this;
 
     function wrapper(...args) {
       try {
         listener.apply(listenerContext, args);
       } catch (error) {
         console.error(`Error in Time API listener for "${String(event)}"`, error);
+      } finally {
+        if (once) {
+          timeContext.removeListener(event, wrapper, context, true);
+        }
       }
     }
 


### PR DESCRIPTION
Closes #7924

### Describe your changes:

Protect Time API event delivery from individual listener failures by wrapping
registered callbacks and logging thrown errors. This preserves the original
listener function and context for `off`/`removeListener`, keeps `once`
behavior, and returns original callbacks from `listeners()`.

Added regression tests covering listener isolation, removal by original
function/context, and failing one-time listeners.

Validation:

- Prettier check on changed files
- ESLint on changed files with zero warnings
- TypeScript compiler
- Webpack development build
- Full Karma suite: 978 passed, 67 skipped

### All Submissions:

* [x] Followed the contributing guidelines.
* [x] Checked that no open pull request duplicates this change.
* [x] Checked release-note impact; no special callout is required.

### Author Checklist

* [x] Changes address the original issue.
* [x] Tests included with the changes.
* [ ] Manual UI smoke test is not applicable to this event-delivery path; it is covered by browser unit tests.
* [ ] PR type label: `type:bug`.
* [ ] Milestone left blank for maintainers.
* [x] Testing instructions and results are included above.
