### PR TITLE
[Plan] Guard sourceMap lookups against missing keys

### DIFF
--- a/src/plugins/plan/util.js
+++ b/src/plugins/plan/util.js
@@ -44,7 +44,13 @@ export function getValidatedData(domainObject) {
     sourceMap.groupId !== undefined
   ) {
     let mappedJson = {};
-    json[sourceMap.activities].forEach((activity) => {
+    const activities = json[sourceMap.activities];
+    if (!Array.isArray(activities)) {
+      // The mapping points at data that isn't there (stale/typo'd key):
+      // show an empty plan instead of crashing the view (#8428).
+      return mappedJson;
+    }
+    activities.forEach((activity) => {
       if (activity[sourceMap.groupId]) {
         const groupIdKey = activity[sourceMap.groupId];
         let groupActivity = {
@@ -113,7 +119,9 @@ export function getValidatedGroups(domainObject, planData) {
   const json = getObjectJson(domainObject);
   if (sourceMap?.orderedGroups) {
     const groups = json[sourceMap.orderedGroups];
-    if (groups.length && typeof groups[0] === 'object') {
+    if (!Array.isArray(groups)) {
+      // Mapping points at missing data: fall through to plan-data keys (#8428).
+    } else if (groups.length && typeof groups[0] === 'object') {
       //if groups is a list of objects, then get the name property from each group object.
       const groupsWithNames = groups.filter(
         (groupObj) => groupObj.name !== undefined && groupObj.name !== ''

--- a/src/plugins/plan/utilSpec.js
+++ b/src/plugins/plan/utilSpec.js
@@ -1,0 +1,76 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *****************************************************************************/
+
+import { getValidatedData, getValidatedGroups } from './util.js';
+
+describe('plan util sourceMap guards (#8428)', () => {
+  it('getValidatedData returns an empty plan when activities key is missing', () => {
+    const domainObject = {
+      sourceMap: {
+        activities: 'missing-key',
+        groupId: 'group'
+      },
+      selectFile: {
+        body: {
+          items: [{ group: 'a' }]
+        }
+      }
+    };
+
+    let result;
+    expect(() => {
+      result = getValidatedData(domainObject);
+    }).not.toThrow();
+    expect(result).toEqual({});
+  });
+
+  it('getValidatedData still maps valid data', () => {
+    const domainObject = {
+      sourceMap: {
+        activities: 'items',
+        groupId: 'group'
+      },
+      selectFile: {
+        body: {
+          items: [{ group: 'a' }, { group: 'b' }]
+        }
+      }
+    };
+
+    expect(getValidatedData(domainObject)).toEqual({
+      a: [{ group: 'a' }],
+      b: [{ group: 'b' }]
+    });
+  });
+
+  it('getValidatedGroups falls back to plan-data keys when orderedGroups key is missing', () => {
+    const domainObject = {
+      sourceMap: {
+        orderedGroups: 'missing-groups'
+      },
+      selectFile: {
+        body: {}
+      }
+    };
+
+    let result;
+    expect(() => {
+      result = getValidatedGroups(domainObject, { a: [], b: [] });
+    }).not.toThrow();
+    expect(result).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
Closes #8428.

### Describe your changes:

`getValidatedData` and `getValidatedGroups` (`src/plugins/plan/util.js`) crashed with an uncaught `TypeError` when the `sourceMap` names data keys that don't exist (stale/typo'd mapping, or an upstream schema change after the mapping was saved). All three callers (Plan, Timelist, Timeline views) call these unguarded, so one bad mapping killed the whole view.

Both lookups now check `Array.isArray` first: a mapping that points at missing data yields an empty plan / falls back to plan-data keys — the same graceful degradation `getObjectJson` already applies to unparseable file bodies. Valid mappings behave exactly as before.

### Describe your steps to test:

1. Open a Plan view whose `sourceMap.activities` names a key absent from the file data — the view renders empty instead of crashing.
2. Same for `sourceMap.orderedGroups` — group names fall back to plan-data keys.
3. New `src/plugins/plan/utilSpec.js` covers both guards plus the unchanged happy path (runs with `npm test`; could not run karma locally, leaving the suite run to CI).
