### PR TITLE
[AppLayout] Tolerate corrupt shell-head storage

### DIFF
--- a/src/ui/layout/AppLayout.vue
+++ b/src/ui/layout/AppLayout.vue
@@ -214,7 +214,14 @@ export default {
     let element;
 
     const storedHeadProps = localStorage.getItem(SHELL_HEAD_LOCAL_STORAGE_KEY);
-    const storedHeadPropsObject = JSON.parse(storedHeadProps);
+    let storedHeadPropsObject = null;
+    try {
+      storedHeadPropsObject = JSON.parse(storedHeadProps);
+    } catch {
+      // Corrupt stored value (shared-origin writer, devtools edit, truncated
+      // write): fall back to defaults. The fresh value is persisted below,
+      // so this self-heals instead of bricking the shell on every boot (#8430).
+    }
     const storedHeadExpanded = storedHeadPropsObject?.expanded;
     const storedIndicatorsMultiline = storedHeadPropsObject?.multiline;
 


### PR DESCRIPTION
Closes #8430.

### Describe your changes:

`AppLayout.vue` `setup()` called `JSON.parse` on the stored `openmct-shell-head` value with no guard, so one corrupt value (shared-origin writer, devtools edit, truncated write) threw during the shell mount — and kept throwing on every reload until the key was manually cleared.

The parse is now wrapped in `try/catch`: an unparseable value falls back to the defaults, and the existing persist-on-mount right below overwrites the bad value with fresh JSON, so a corrupt entry self-heals on the next boot. Valid stored values behave exactly as before.

### Describe your steps to test:

1. Set `localStorage['openmct-shell-head'] = '{corrupt'` and reload — the shell mounts with default head state instead of a blank page, and the key is rewritten with valid JSON.
2. `npm test` (could not run karma locally — no workspace install in this environment — leaving the suite run to CI).
