### PR TITLE
[Notebook] Escape regex chars in search highlight

### DIFF
--- a/src/utils/textHighlight/TextHighlight.vue
+++ b/src/utils/textHighlight/TextHighlight.vue
@@ -48,11 +48,11 @@ export default {
     highlightedText() {
       const highlight = this.highlight;
 
-      const normalCharsRegex = /^[^A-Za-z0-9]+$/g;
+      // The highlight is free-typed search text: escape regex syntax so
+      // arbitrary input (e.g. `(a`, `[unclosed`) can never throw (#8432).
+      const escapedHighlight = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-      const newHighLight = normalCharsRegex.test(highlight) ? `\\${highlight}` : highlight;
-
-      const highlightRegex = new RegExp(`(?<!<[^>]*)(${newHighLight})`, 'gi');
+      const highlightRegex = new RegExp(`(?<!<[^>]*)(${escapedHighlight})`, 'gi');
 
       const replacement = `<span class="${this.highlightClass}">${highlight}</span>`;
 

--- a/src/utils/textHighlight/TextHighlightSpec.js
+++ b/src/utils/textHighlight/TextHighlightSpec.js
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ * Open MCT, Copyright (c) 2014-2024, United States Government
+ * as represented by the Administrator of the National Aeronautics and Space
+ * Administration. All rights reserved.
+ *
+ * Open MCT is licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *****************************************************************************/
+
+import TextHighlight from './TextHighlight.vue';
+
+describe('TextHighlight', () => {
+  function render(text, highlight) {
+    const ctx = { text, highlight, highlightClass: 'highlight' };
+    return TextHighlight.computed.highlightedText.call(ctx);
+  }
+
+  it('highlights plain text', () => {
+    expect(render('hello world', 'world')).toBe(
+      'hello <span class="highlight">world</span>'
+    );
+  });
+
+  it('does not throw on search text with regex characters (#8432)', () => {
+    let result;
+    expect(() => {
+      result = render('note (a) here', '(a');
+    }).not.toThrow();
+    expect(result).toContain('<span class="highlight">(a</span>');
+  });
+
+  it('does not throw on unclosed character classes (#8432)', () => {
+    let result;
+    expect(() => {
+      result = render('a [unclosed entry', '[unclosed');
+    }).not.toThrow();
+    expect(result).toContain('<span class="highlight">[unclosed</span>');
+  });
+});


### PR DESCRIPTION
Closes #8432.

### Describe your changes:

`TextHighlight.vue` built its match regex from the free-typed notebook search string with only a single-backslash prefix for all-symbol inputs, so mixed inputs like `(a` or `[unclosed` threw `SyntaxError` (unterminated group / character class) out of the `highlightedText` computed — taking down the results render. The highlight text is now escaped with a standard character-class escape before compiling, so arbitrary search input matches literally and can never throw. Plain-text matching is unchanged (verified identical spans for plain, symbolic, and previously-crashing inputs).

### Describe your steps to test:

1. In a notebook, search for `(a` with an entry containing `(a)` — results render with the match highlighted instead of crashing.
2. New `src/utils/textHighlight/TextHighlightSpec.js` covers plain highlighting plus both crash inputs (runs with `npm test`; could not run karma locally — no workspace install in this environment — leaving the suite run to CI).
