### PR TITLE
[ListView] Tolerate corrupt sort-order storage

### DIFF
--- a/src/plugins/folderView/components/ListView.vue
+++ b/src/plugins/folderView/components/ListView.vue
@@ -100,10 +100,20 @@ export default {
     let persistedSortOrder = window.localStorage.getItem('openmct-listview-sort-order');
 
     if (persistedSortOrder) {
-      let parsed = JSON.parse(persistedSortOrder);
-
-      sortBy = parsed.sortBy;
-      ascending = parsed.ascending;
+      try {
+        const parsed = JSON.parse(persistedSortOrder);
+        // Only accept well-shaped values; anything else (corrupt text,
+        // null, wrong types) falls back to the defaults (#8434).
+        if (parsed && typeof parsed.sortBy === 'string') {
+          sortBy = parsed.sortBy;
+        }
+        if (parsed && typeof parsed.ascending === 'boolean') {
+          ascending = parsed.ascending;
+        }
+      } catch {
+        // Corrupt stored value: keep the defaults instead of
+        // breaking the view on init.
+      }
     }
 
     return {


### PR DESCRIPTION
Closes #8434.

### Describe your changes:

`ListView.vue` `data()` parsed the stored `openmct-listview-sort-order` value with no guard, so a corrupt entry (`SyntaxError`) — or valid JSON with the wrong shape like `null` (`TypeError` on `parsed.sortBy`) — threw during init and no folder list view would render until the key was manually cleared.

The parse is now guarded: unparseable or wrong-shaped values fall back to the default sort (`model.name`, ascending), and only a string `sortBy` / boolean `ascending` are accepted. Well-formed stored values behave exactly as before (verified all six input shapes in node: corrupt/null/string/wrong-types → defaults, valid custom sort → honored).

### Describe your steps to test:

1. Set `localStorage['openmct-listview-sort-order'] = '{{{corrupt'` and open any folder as a list view — it renders with the default sort instead of a blank view.
2. `npm test` (could not run karma locally — no workspace install in this environment — leaving the suite run to CI).
