### PR TITLE
Fix/6538 notebook embed menu dismiss

### DIFF
--- a/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
+++ b/e2e/tests/functional/plugins/notebook/notebook.e2e.spec.js
@@ -352,6 +352,31 @@ test.describe('Notebook entry tests', () => {
     expect(embedName).toBe(overlayPlot.name);
   });
   test.fixme('new entries persist through navigation events without save', async ({ page }) => {});
+  test('An embed actions menu is dismissed by a click anywhere outside of it', async ({ page }) => {
+    await nbUtils.dragAndDropEmbed(page, notebookObject);
+    await nbUtils.enterTextEntry(page, 'Second Entry');
+
+    const menu = page.locator('.c-menu');
+    const embedActionsButton = page.getByLabel('Notebook Entry').first().getByLabel('More actions');
+
+    // Clicking the entry which holds the embed should dismiss the menu
+    await embedActionsButton.click();
+    await expect(menu).toBeVisible();
+    await page.getByLabel('Notebook Entry').first().click();
+    await expect(menu).toBeHidden();
+
+    // So should clicking a different entry
+    await embedActionsButton.click();
+    await expect(menu).toBeVisible();
+    await page.getByLabel('Notebook Entry').last().click();
+    await expect(menu).toBeHidden();
+
+    // Menu items must still be invoked when clicked
+    await embedActionsButton.click();
+    await expect(menu).toBeVisible();
+    await menu.getByRole('menuitem', { name: 'Remove This Embed' }).click();
+    await expect(page.getByText('This action will permanently remove this embed')).toBeVisible();
+  });
   test('previous and new entries can be deleted', async ({ page }) => {
     // Navigate to the notebook object
     await page.goto(notebookObject.url);

--- a/src/api/menu/MenuAPISpec.js
+++ b/src/api/menu/MenuAPISpec.js
@@ -136,6 +136,22 @@ describe('The Menu API', () => {
         expect(menuElement).toBeNull();
       });
 
+      it('dismisses the menu when a click outside of it stops propagation', (done) => {
+        menuOptions.onDestroy = done;
+
+        const clickBlocker = document.createElement('div');
+        clickBlocker.addEventListener('click', (event) => event.stopPropagation());
+        document.body.appendChild(clickBlocker);
+
+        menuAPI.showMenu(x, y, actionsArray, menuOptions);
+
+        clickBlocker.click();
+
+        expect(document.querySelector('.c-menu')).toBeNull();
+
+        clickBlocker.remove();
+      });
+
       it('invokes the destroy method when menu is dismissed', (done) => {
         menuOptions.onDestroy = done;
 

--- a/src/api/menu/menu.js
+++ b/src/api/menu/menu.js
@@ -60,6 +60,7 @@ class Menu extends EventEmitter {
     }
 
     this.dismiss = this.dismiss.bind(this);
+    this.dismissIfClickedOutside = this.dismissIfClickedOutside.bind(this);
     this.show = this.show.bind(this);
     this.showMenu = this.showMenu.bind(this);
     this.showSuperMenu = this.showSuperMenu.bind(this);
@@ -74,7 +75,20 @@ class Menu extends EventEmitter {
       this.destroy = null;
     }
     document.removeEventListener('click', this.dismiss);
+    document.removeEventListener('click', this.dismissIfClickedOutside, true);
     this.emit('destroy');
+  }
+
+  /**
+   * Dismiss the menu when a click lands outside of it.
+   * @param {MouseEvent} event
+   */
+  dismissIfClickedOutside(event) {
+    if (this.el?.contains(event.target)) {
+      return;
+    }
+
+    this.dismiss();
   }
 
   /**
@@ -130,6 +144,9 @@ class Menu extends EventEmitter {
   show() {
     document.body.appendChild(this.el);
     document.addEventListener('click', this.dismiss);
+    // Listen during the capture phase as well, so that clicks on elements which stop
+    // propagation of their own click events still dismiss the menu.
+    document.addEventListener('click', this.dismissIfClickedOutside, true);
   }
 }
 


### PR DESCRIPTION
<!--- Note: Please open the PR in draft form until you are ready for active review. -->
Closes #6538 

### Describe your changes:
The embed’s "More actions" menu in a notebook couldn’t close when you clicked outside of it, for example on the date, on the input field, or below the input field, because the entry stops the click from reaching the document.

So I added a listener on the document that runs in the capture phase, before that can happen, and it only dismisses the menu when the click landed outside of it.

Before:

https://github.com/user-attachments/assets/a856d218-35a5-4fd3-998a-81278076e2ba

After (you can close the “More actions” menu as soon as you click outside it):

https://github.com/user-attachments/assets/59a9893d-0fe4-4f30-861f-422b2281d2f5


### All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/nasa/openmct/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/openmct/pulls) for the same update/change?
* [ ] Is this a [notable change](../docs/src/process/release.md) that will require a special callout in the release notes? For example, will this break compatibility with existing APIs or projects that consume these plugins?

### Author Checklist

* [x] Changes address original issue?
* [x] Tests included and/or updated with changes?
* [x] Has this been smoke tested?
* [ ] Have you associated this PR with a `type:` label? Note: this is not necessarily the same as the original issue.
* [ ] Have you associated a milestone with this PR? Note: leave blank if unsure.
* [ ] Testing instructions included in associated issue OR is this a dependency/testcase change?

### Reviewer Checklist

* [ ] Changes appear to address issue?
* [ ] Reviewer has tested changes by following the provided instructions?
* [ ] Changes appear not to be breaking changes?
* [ ] Appropriate automated tests included?
* [ ] Code style and in-line documentation are appropriate?
